### PR TITLE
Polish-gaze-panel

### DIFF
--- a/apps/demo-render-no-rig/src/App.tsx
+++ b/apps/demo-render-no-rig/src/App.tsx
@@ -13,6 +13,8 @@ import {
 import { AnimationEditor } from "./components/AnimationEditor";
 import { GraphEditor } from "./components/GraphEditor";
 import { CollapsiblePanel } from "./components/CollapsiblePanel";
+import { GazeControlPanel } from "./components/GazeControlPanel";
+import { getGazeControlledPaths } from "./data/gazeMappings";
 import { useFaceLoader } from "./hooks/useFaceLoader";
 import { useAnimatableList } from "./hooks/useAnimatableList";
 import { useNodeRegistry } from "./hooks/useNodeRegistry";
@@ -88,6 +90,11 @@ export default function App() {
     }
     return buildExpressionGraph(face.id);
   }, [face]);
+
+  const gazeInputPaths = useMemo(
+    () => getGazeControlledPaths(face?.id),
+    [face?.id],
+  );
 
   useEffect(() => {
     if (!face?.rig) {
@@ -247,6 +254,7 @@ export default function App() {
             : []
         }
         initialOutputMap={rigOutputMap}
+        hiddenInputPaths={gazeInputPaths}
       >
         <main className="app-main">
           <div className="viewer-column">
@@ -258,6 +266,7 @@ export default function App() {
               namespace={namespace}
               showSafeArea={showSafeArea}
             />
+            <GazeControlPanel face={face} />
             <div className="panel status-panel">
               <div className="panel-header">
                 <h2>Status</h2>

--- a/apps/demo-render-no-rig/src/components/GazeControlPanel.tsx
+++ b/apps/demo-render-no-rig/src/components/GazeControlPanel.tsx
@@ -1,0 +1,420 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
+import { useVizijStore } from "@vizij/render";
+import type {
+  LowLevelRigDefinition,
+  LowLevelRigTrackDefinition,
+} from "@vizij/config";
+import type { RawValue } from "@vizij/utils";
+
+import type { FaceConfig } from "../data/faces";
+import {
+  buildGazePath,
+  getGazeMapping,
+  SUPPORTED_GAZE_FACE_IDS,
+  type Axis,
+  type AxisMappingConfig,
+} from "../data/gazeMappings";
+import { useOrchestratorBridge } from "./OrchestratorPanel";
+
+const AXES = { x: 0, y: 1, z: 2 } as const;
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function resolveTrackKind(trackName: string) {
+  const lower = trackName.toLowerCase();
+  if (lower === "pos" || lower === "position") return "pos";
+  if (lower === "rot" || lower === "rotation") return "rot";
+  if (lower === "scale") return "scale";
+  if (lower === "morph") return "morph";
+  return lower;
+}
+
+function buildAnimatableName(
+  rig: LowLevelRigDefinition,
+  channelName: string,
+  trackName: string,
+  track: LowLevelRigTrackDefinition,
+): string | null {
+  const channel = rig.channels[channelName];
+  if (!channel) return null;
+  const shapeKey = channel.shapeKey;
+  const kind = resolveTrackKind(trackName);
+
+  switch (kind) {
+    case "morph":
+      return `${shapeKey} Key ${track.key ?? "1"}`;
+    case "pos":
+      return `${shapeKey} translation`;
+    case "rot":
+      return `${shapeKey} rotation`;
+    case "scale":
+      return `${shapeKey} scale`;
+    default:
+      return `${shapeKey} ${trackName}`;
+  }
+}
+
+function getAxisComponent(value: RawValue | undefined, axis: Axis) {
+  if (value == null) return 0;
+  if (Array.isArray(value)) {
+    const index = AXES[axis];
+    const numeric = value[index];
+    return typeof numeric === "number" ? numeric : 0;
+  }
+  if (typeof value === "object") {
+    const record = value as Partial<Record<Axis, unknown>>;
+    const numeric = record[axis];
+    if (typeof numeric === "number") {
+      return numeric;
+    }
+  }
+  return 0;
+}
+
+function toNumber(value: unknown, fallback = 0) {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+type AxisEntry = {
+  path: string;
+  kind: string;
+  min: number;
+  max: number;
+  base: number;
+  from: number;
+  to: number;
+  primary: boolean;
+  defaultOffset: number;
+  baseT: number;
+};
+
+type AxisEntryMap = {
+  x: AxisEntry[];
+  y: AxisEntry[];
+};
+
+export function GazeControlPanel({ face }: { face?: FaceConfig }) {
+  const animatables = useVizijStore((state) => state.animatables);
+  const { ready, status, inputRows, inputValues, updateInputValue } =
+    useOrchestratorBridge();
+
+  const mapping = face?.rig ? getGazeMapping(face.id) : undefined;
+
+  const animByName = useMemo(() => {
+    const map = new Map<string, { default?: RawValue }>();
+    Object.values(animatables).forEach((anim) => {
+      if (anim && typeof anim.name === "string" && anim.name.length) {
+        map.set(anim.name, { default: anim.default });
+      }
+    });
+    return map;
+  }, [animatables]);
+
+  const inputRowMap = useMemo(() => {
+    const map = new Map<string, (typeof inputRows)[number]>();
+    inputRows.forEach((row) => {
+      if (row.path) {
+        map.set(row.path, row);
+      }
+    });
+    return map;
+  }, [inputRows]);
+
+  const axisEntries = useMemo<AxisEntryMap | null>(() => {
+    if (!face?.rig || !mapping) {
+      return null;
+    }
+
+    const buildEntries = (entries: AxisMappingConfig[]) => {
+      const list: AxisEntry[] = [];
+      entries.forEach((entry) => {
+        const channel = face.rig!.channels[entry.channel];
+        if (!channel) return;
+        const track = channel.tracks[entry.track];
+        if (!track) return;
+        const path = buildGazePath(face.id, entry);
+        if (!inputRowMap.has(path)) return;
+        const row = inputRowMap.get(path)!;
+        const animName = buildAnimatableName(
+          face.rig!,
+          entry.channel,
+          entry.track,
+          track,
+        );
+        if (!animName) return;
+        const animDefaults = animByName.get(animName);
+        const base = getAxisComponent(animDefaults?.default, entry.axis);
+        const min = toNumber(row.meta?.min, Number.NEGATIVE_INFINITY);
+        const max = toNumber(row.meta?.max, Number.POSITIVE_INFINITY);
+        const defaultOffset = toNumber(row.defaultValue, 0);
+        const denom = entry.to - entry.from;
+        const baseT =
+          Math.abs(denom) > 1e-6
+            ? clamp((base - entry.from) / denom, 0, 1)
+            : 0.5;
+        list.push({
+          path,
+          kind: row.kind,
+          min,
+          max,
+          base,
+          from: entry.from,
+          to: entry.to,
+          primary: Boolean(entry.primary),
+          defaultOffset,
+          baseT,
+        });
+      });
+      return list;
+    };
+
+    const xEntries = buildEntries(mapping.x);
+    const yEntries = buildEntries(mapping.y);
+
+    if (!xEntries.length || !yEntries.length) {
+      return null;
+    }
+
+    return { x: xEntries, y: yEntries };
+  }, [animByName, face, inputRowMap, mapping]);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [dragging, setDragging] = useState(false);
+
+  useEffect(() => {
+    setDragging(false);
+  }, [face?.id]);
+
+  const getAxisPosition = useCallback(
+    (entries: AxisEntry[]) => {
+      const primary = entries.find((entry) => entry.primary) ?? entries[0];
+      if (!primary) return 0.5;
+      const raw =
+        primary.path in inputValues
+          ? inputValues[primary.path]
+          : primary.defaultOffset;
+      const offset = toNumber(raw, 0);
+      const absolute = primary.base + offset;
+      const denom = primary.to - primary.from;
+      if (Math.abs(denom) < 1e-6) {
+        return primary.baseT;
+      }
+      return clamp((absolute - primary.from) / denom, 0, 1);
+    },
+    [inputValues],
+  );
+
+  const applyAxisValue = useCallback(
+    (entries: AxisEntry[], t: number) => {
+      const clamped = clamp(t, 0, 1);
+      entries.forEach((entry) => {
+        const absolute = entry.from + (entry.to - entry.from) * clamped;
+        const offset = clamp(absolute - entry.base, entry.min, entry.max);
+        if (Number.isFinite(offset)) {
+          updateInputValue(entry.path, entry.kind as any, offset);
+        }
+      });
+    },
+    [updateInputValue],
+  );
+
+  const updateFromPointer = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (!axisEntries || !containerRef.current) return;
+      const rect = containerRef.current.getBoundingClientRect();
+      const relativeX = clamp(event.clientX - rect.left, 0, rect.width);
+      const relativeY = clamp(event.clientY - rect.top, 0, rect.height);
+      const width = rect.width || 1;
+      const height = rect.height || 1;
+      const normX = relativeX / width;
+      const normY = 1 - relativeY / height;
+      applyAxisValue(axisEntries.x, normX);
+      applyAxisValue(axisEntries.y, normY);
+    },
+    [axisEntries, applyAxisValue],
+  );
+
+  const handlePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (!axisEntries || !containerRef.current) return;
+      event.preventDefault();
+      containerRef.current.setPointerCapture(event.pointerId);
+      setDragging(true);
+      updateFromPointer(event);
+    },
+    [axisEntries, updateFromPointer],
+  );
+
+  const handlePointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (!dragging || !axisEntries) return;
+      event.preventDefault();
+      updateFromPointer(event);
+    },
+    [axisEntries, dragging, updateFromPointer],
+  );
+
+  const handlePointerUp = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (containerRef.current?.hasPointerCapture(event.pointerId)) {
+        containerRef.current.releasePointerCapture(event.pointerId);
+      }
+      setDragging(false);
+    },
+    [],
+  );
+
+  const supportedFacesLabel = useMemo(() => {
+    if (!SUPPORTED_GAZE_FACE_IDS.length) {
+      return "";
+    }
+    return SUPPORTED_GAZE_FACE_IDS.map(
+      (id) => id.charAt(0).toUpperCase() + id.slice(1),
+    ).join(", ");
+  }, []);
+
+  const isInteractive = Boolean(face?.rig && mapping && axisEntries);
+
+  const statusLabel =
+    !face?.rig || !mapping
+      ? "unsupported"
+      : !ready
+        ? "loading"
+        : !axisEntries
+          ? "disabled"
+          : "ready";
+
+  const knobX = axisEntries ? getAxisPosition(axisEntries.x) : 0.5;
+  const knobY = axisEntries ? getAxisPosition(axisEntries.y) : 0.5;
+
+  const primaryX =
+    axisEntries?.x.find((entry) => entry.primary) ?? axisEntries?.x[0];
+  const primaryY =
+    axisEntries?.y.find((entry) => entry.primary) ?? axisEntries?.y[0];
+
+  const horizontalOffset =
+    primaryX != null
+      ? toNumber(
+          primaryX.path in inputValues
+            ? inputValues[primaryX.path]
+            : primaryX.defaultOffset,
+          0,
+        )
+      : null;
+
+  const verticalOffset =
+    primaryY != null
+      ? toNumber(
+          primaryY.path in inputValues
+            ? inputValues[primaryY.path]
+            : primaryY.defaultOffset,
+          0,
+        )
+      : null;
+
+  const handleReset = useCallback(() => {
+    if (!axisEntries) {
+      return;
+    }
+    const primaryXEntry =
+      axisEntries.x.find((entry) => entry.primary) ?? axisEntries.x[0];
+    const primaryYEntry =
+      axisEntries.y.find((entry) => entry.primary) ?? axisEntries.y[0];
+    applyAxisValue(axisEntries.x, primaryXEntry?.baseT ?? 0.5);
+    applyAxisValue(axisEntries.y, primaryYEntry?.baseT ?? 0.5);
+  }, [axisEntries, applyAxisValue]);
+
+  const areaClassName = [
+    "gaze-area",
+    dragging ? "is-dragging" : "",
+    !isInteractive ? "is-disabled" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const unsupportedMessage = supportedFacesLabel.length
+    ? `Gaze controls are only available for low-level rigs (${supportedFacesLabel}).`
+    : "Gaze controls are only available for supported faces.";
+
+  const disabledMessage =
+    status && ready
+      ? status
+      : "Connect the orchestrator bridge to enable gaze control for this face.";
+
+  if (!face) {
+    return null;
+  }
+
+  return (
+    <div className="panel gaze-panel">
+      <div className="panel-header">
+        <div className="panel-heading">
+          <h2>Gaze Control</h2>
+          <p>Drag the handle to steer the low-rig gaze.</p>
+        </div>
+        <div className="gaze-panel-actions">
+          <span className="tag">{statusLabel}</span>
+          <button
+            type="button"
+            className="btn btn-muted"
+            onClick={handleReset}
+            disabled={!axisEntries}
+          >
+            Reset
+          </button>
+        </div>
+      </div>
+      <div className="panel-body gaze-body">
+        {!mapping ? (
+          <p className="panel-status">{unsupportedMessage}</p>
+        ) : (
+          <>
+            <div
+              className={areaClassName}
+              ref={containerRef}
+              onPointerDown={handlePointerDown}
+              onPointerMove={handlePointerMove}
+              onPointerUp={handlePointerUp}
+              tabIndex={0}
+              aria-label="Gaze control"
+            >
+              <div className="gaze-grid" aria-hidden="true">
+                <div />
+              </div>
+              <div
+                className="gaze-knob"
+                style={{
+                  left: `${knobX * 100}%`,
+                  top: `${(1 - knobY) * 100}%`,
+                }}
+                aria-hidden="true"
+              />
+            </div>
+            <div className="gaze-readout">
+              <span>
+                Horizontal offset:{" "}
+                {horizontalOffset != null ? horizontalOffset.toFixed(3) : "–"}
+              </span>
+              <span>
+                Vertical offset:{" "}
+                {verticalOffset != null ? verticalOffset.toFixed(3) : "–"}
+              </span>
+            </div>
+            {!axisEntries ? (
+              <p className="gaze-note">{disabledMessage}</p>
+            ) : null}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/demo-render-no-rig/src/components/OrchestratorPanel.tsx
+++ b/apps/demo-render-no-rig/src/components/OrchestratorPanel.tsx
@@ -439,6 +439,7 @@ interface OrchestratorBridgeContextValue {
   }>;
   setGraphEnabled: (graphId: string, enabled: boolean) => void;
   logCurrentInputs: () => void;
+  hiddenInputPaths: Set<string>;
 }
 
 const OrchestratorBridgeContext =
@@ -466,6 +467,7 @@ interface OrchestratorPanelProps {
   graphState: GraphEditorState;
   extraGraphs?: AdditionalGraphState[];
   initialOutputMap?: Record<string, string> | null;
+  hiddenInputPaths?: string[];
 }
 
 function applyOutputMappings(
@@ -512,6 +514,7 @@ export function OrchestratorBridgeProvider({
   graphState,
   extraGraphs,
   initialOutputMap,
+  hiddenInputPaths = [],
   children,
 }: OrchestratorBridgeProviderProps) {
   const {
@@ -1169,6 +1172,11 @@ export function OrchestratorBridgeProvider({
     console.log(payload);
   }, [inputRows, inputValues]);
 
+  const hiddenInputPathSet = useMemo(
+    () => new Set(hiddenInputPaths.filter((entry) => entry && entry.length)),
+    [hiddenInputPaths],
+  );
+
   const contextValue = useMemo<OrchestratorBridgeContextValue>(
     () => ({
       ready,
@@ -1192,9 +1200,11 @@ export function OrchestratorBridgeProvider({
       graphToggles,
       setGraphEnabled,
       logCurrentInputs,
+      hiddenInputPaths: hiddenInputPathSet,
     }),
     [
       animatables,
+      hiddenInputPathSet,
       buttonsDisabled,
       connected,
       currentMappingsSummary,
@@ -1389,9 +1399,16 @@ export function OrchestratorPanel() {
 }
 
 export function OrchestratorInputsPanel() {
-  const { inputRows, inputValues, updateInputValue } = useOrchestratorBridge();
+  const { inputRows, inputValues, updateInputValue, hiddenInputPaths } =
+    useOrchestratorBridge();
 
-  const hasInputs = inputRows.some((row) => row.path);
+  const visibleRows = useMemo(
+    () =>
+      inputRows.filter((row) => row.path && !hiddenInputPaths.has(row.path)),
+    [hiddenInputPaths, inputRows],
+  );
+
+  const hasInputs = visibleRows.length > 0;
 
   if (!hasInputs) {
     return (
@@ -1403,7 +1420,7 @@ export function OrchestratorInputsPanel() {
 
   return (
     <div className="orchestrator-inputs">
-      {inputRows.map((row) => {
+      {visibleRows.map((row) => {
         if (!row.path) return null;
         const value =
           row.path in inputValues ? inputValues[row.path] : row.defaultValue;

--- a/apps/demo-render-no-rig/src/data/gazeMappings.ts
+++ b/apps/demo-render-no-rig/src/data/gazeMappings.ts
@@ -1,0 +1,147 @@
+export type Axis = "x" | "y" | "z";
+
+export type AxisMappingConfig = {
+  channel: string;
+  track: string;
+  axis: Axis;
+  from: number;
+  to: number;
+  primary?: boolean;
+};
+
+export type FaceGazeMapping = {
+  x: AxisMappingConfig[];
+  y: AxisMappingConfig[];
+};
+
+export const GAZE_MAPPINGS: Record<string, FaceGazeMapping> = {
+  hugo: {
+    x: [
+      {
+        channel: "left_eye",
+        track: "pos",
+        axis: "x",
+        from: 1.33,
+        to: 1.63,
+        primary: true,
+      },
+      {
+        channel: "right_eye",
+        track: "pos",
+        axis: "x",
+        from: -1.48,
+        to: -1.13,
+      },
+    ],
+    y: [
+      {
+        channel: "left_eye",
+        track: "pos",
+        axis: "y",
+        from: 0.2,
+        to: 0.4,
+        primary: true,
+      },
+      {
+        channel: "right_eye",
+        track: "pos",
+        axis: "y",
+        from: 0.2,
+        to: 0.4,
+      },
+    ],
+  },
+  quori: {
+    x: [
+      {
+        channel: "left_eye",
+        track: "pos",
+        axis: "x",
+        from: 0.12,
+        to: 0.16,
+        primary: true,
+      },
+      {
+        channel: "right_eye",
+        track: "pos",
+        axis: "x",
+        from: -0.14,
+        to: -0.09,
+      },
+    ],
+    y: [
+      {
+        channel: "left_eye",
+        track: "pos",
+        axis: "y",
+        from: -0.06,
+        to: -0.02,
+        primary: true,
+      },
+      {
+        channel: "left_eye_top_eyelid",
+        track: "pos",
+        axis: "y",
+        from: -0.02,
+        to: 0,
+      },
+      {
+        channel: "left_eye_bottom_eyelid",
+        track: "pos",
+        axis: "y",
+        from: -0.1,
+        to: -0.08,
+      },
+      {
+        channel: "right_eye",
+        track: "pos",
+        axis: "y",
+        from: -0.06,
+        to: -0.02,
+      },
+      {
+        channel: "right_eye_top_eyelid",
+        track: "pos",
+        axis: "y",
+        from: -0.01,
+        to: 0.01,
+      },
+      {
+        channel: "right_eye_bottom_eyelid",
+        track: "pos",
+        axis: "y",
+        from: -0.09,
+        to: -0.07,
+      },
+    ],
+  },
+};
+
+export const SUPPORTED_GAZE_FACE_IDS = Object.keys(GAZE_MAPPINGS);
+
+export function getGazeMapping(faceId?: string | null) {
+  if (!faceId) {
+    return undefined;
+  }
+  return GAZE_MAPPINGS[faceId];
+}
+
+export function buildGazePath(faceId: string, entry: AxisMappingConfig) {
+  return `rig/${faceId}/${entry.channel}/${entry.track}/${entry.axis}`;
+}
+
+export function getGazeControlledPaths(faceId?: string | null) {
+  const mapping = getGazeMapping(faceId);
+  if (!mapping) {
+    return [];
+  }
+  const paths = new Set<string>();
+  const addEntries = (entries: AxisMappingConfig[]) => {
+    entries.forEach((entry) => {
+      paths.add(buildGazePath(faceId!, entry));
+    });
+  };
+  addEntries(mapping.x);
+  addEntries(mapping.y);
+  return Array.from(paths);
+}

--- a/apps/demo-render-no-rig/src/styles.css
+++ b/apps/demo-render-no-rig/src/styles.css
@@ -1013,3 +1013,109 @@ textarea {
   resize: vertical;
   min-height: 5rem;
 }
+
+.gaze-panel .panel-body {
+  gap: 0.75rem;
+}
+
+.gaze-panel .panel-heading p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(245, 245, 245, 0.65);
+}
+
+.gaze-panel-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.gaze-body {
+  gap: 0.75rem;
+}
+
+.gaze-area {
+  position: relative;
+  width: 100%;
+  padding-top: 100%;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: radial-gradient(
+    circle at center,
+    rgba(80, 196, 182, 0.18),
+    rgba(14, 20, 28, 0.65)
+  );
+  cursor: crosshair;
+  overflow: hidden;
+}
+
+.gaze-area.is-disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.gaze-area.is-dragging {
+  border-color: rgba(80, 196, 182, 0.5);
+  box-shadow:
+    inset 0 0 0 1px rgba(80, 196, 182, 0.25),
+    0 0 18px rgba(80, 196, 182, 0.2);
+}
+
+.gaze-area:focus-visible {
+  outline: 2px solid rgba(88, 166, 255, 0.75);
+  outline-offset: 2px;
+}
+
+.gaze-grid {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(245, 245, 245, 0.12) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(245, 245, 245, 0.12) 1px, transparent 1px);
+  background-size: 20% 20%;
+  pointer-events: none;
+}
+
+.gaze-grid::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 20%;
+  height: 20%;
+  border: 1px dashed rgba(255, 255, 255, 0.3);
+  border-radius: 8px;
+}
+
+.gaze-knob {
+  position: absolute;
+  width: 18%;
+  aspect-ratio: 1;
+  border-radius: 12px;
+  border: 1px solid rgba(80, 196, 182, 0.9);
+  background: rgba(80, 196, 182, 0.6);
+  transform: translate(-50%, -50%);
+  pointer-events: auto;
+  cursor: grab;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+}
+
+.gaze-knob:active {
+  cursor: grabbing;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+}
+
+.gaze-readout {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  color: rgba(245, 245, 245, 0.75);
+}
+
+.gaze-note {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(245, 245, 245, 0.65);
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "build:apps": "pnpm --filter vizij-node-graph-editor run build && pnpm --filter demo-render-no-rig run build && pnpm --filter demo-animation-studio run build && pnpm --filter demo-animation run build && pnpm --filter demo-graph run build",
     "prettier:check": "pnpm -r run --if-present prettier:check",
     "prettier": "pnpm -r run --if-present prettier:write",
+    "format": "pnpm run prettier",
+    "format:check": "pnpm run prettier:check",
     "lint": "pnpm -r run --if-present lint",
     "test": "pnpm -r run --if-present test",
     "typecheck": "pnpm -r run --if-present typecheck",
@@ -33,11 +35,12 @@
   "devDependencies": {
     "@eslint/js": "^9.19.0",
     "eslint": "^9.19.0",
+    "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.18",
-    "eslint-plugin-import": "^2.31.0",
     "globals": "^15.14.0",
     "prettier": "^3.4.2",
+    "typescript": "^5.9.3",
     "typescript-eslint": "^8.22.0",
     "vitest": "^3.2.4"
   }

--- a/packages/@vizij/node-graph-react/src/__tests__/urdf-fk-ik.test.tsx
+++ b/packages/@vizij/node-graph-react/src/__tests__/urdf-fk-ik.test.tsx
@@ -174,9 +174,12 @@ describe("URDF FK/IK integration", () => {
     const dom = new JSDOM("<!doctype html><html><body></body></html>");
     (globalThis as any).window = dom.window;
     (globalThis as any).document = dom.window.document;
-    (globalThis as any).navigator = {
-      userAgent: "node.js",
-    };
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: {
+        userAgent: "node.js",
+      },
+    });
 
     const here = dirname(fileURLToPath(import.meta.url));
     const wasmPath = resolvePath(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 9.37.0(jiti@2.6.1)
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.7.3))(eslint@9.37.0(jiti@2.6.1))
+        version: 2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1))
       eslint-plugin-react-hooks:
         specifier: ^5.0.0
         version: 5.2.0(eslint@9.37.0(jiti@2.6.1))
@@ -29,9 +29,12 @@ importers:
       prettier:
         specifier: ^3.4.2
         version: 3.6.2
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
       typescript-eslint:
         specifier: ^8.22.0
-        version: 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.7.3)
+        version: 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.7.0)(jiti@2.6.1)(jsdom@24.1.3)(lightningcss@1.30.1)
@@ -4766,6 +4769,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
@@ -7457,10 +7465,10 @@ snapshots:
 
   '@types/webxr@0.5.24': {}
 
-  '@typescript-eslint/eslint-plugin@8.46.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.7.3))(eslint@9.37.0(jiti@2.6.1))(typescript@5.7.3)':
+  '@typescript-eslint/eslint-plugin@8.46.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1))(typescript@5.7.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.46.0
       '@typescript-eslint/type-utils': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.7.3)
       '@typescript-eslint/utils': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.7.3)
@@ -7471,6 +7479,23 @@ snapshots:
       natural-compare: 1.4.0
       ts-api-utils: 2.1.0(typescript@5.7.3)
       typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/eslint-plugin@8.46.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+      '@typescript-eslint/parser': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.46.0
+      '@typescript-eslint/type-utils': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.46.0
+      eslint: 9.37.0(jiti@2.6.1)
+      graphemer: 1.4.0
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.1.0(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -7486,12 +7511,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.46.0
+      '@typescript-eslint/types': 8.46.0
+      '@typescript-eslint/typescript-estree': 8.46.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.46.0
+      debug: 4.4.3
+      eslint: 9.37.0(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/project-service@8.46.0(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.46.0(typescript@5.7.3)
       '@typescript-eslint/types': 8.46.0
       debug: 4.4.3
       typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.46.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.46.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.46.0
+      debug: 4.4.3
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -7504,6 +7550,10 @@ snapshots:
     dependencies:
       typescript: 5.7.3
 
+  '@typescript-eslint/tsconfig-utils@8.46.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
   '@typescript-eslint/type-utils@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/types': 8.46.0
@@ -7513,6 +7563,18 @@ snapshots:
       eslint: 9.37.0(jiti@2.6.1)
       ts-api-utils: 2.1.0(typescript@5.7.3)
       typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/type-utils@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.46.0
+      '@typescript-eslint/typescript-estree': 8.46.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 9.37.0(jiti@2.6.1)
+      ts-api-utils: 2.1.0(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -7534,6 +7596,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.46.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.46.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.46.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.46.0
+      '@typescript-eslint/visitor-keys': 8.46.0
+      debug: 4.4.3
+      fast-glob: 3.3.3
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.3
+      ts-api-utils: 2.1.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.7.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.37.0(jiti@2.6.1))
@@ -7542,6 +7620,17 @@ snapshots:
       '@typescript-eslint/typescript-estree': 8.46.0(typescript@5.7.3)
       eslint: 9.37.0(jiti@2.6.1)
       typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.37.0(jiti@2.6.1))
+      '@typescript-eslint/scope-manager': 8.46.0
+      '@typescript-eslint/types': 8.46.0
+      '@typescript-eslint/typescript-estree': 8.46.0(typescript@5.9.3)
+      eslint: 9.37.0(jiti@2.6.1)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -8207,17 +8296,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint@9.37.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.37.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.37.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.7.3))(eslint@9.37.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -8228,7 +8317,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.37.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint@9.37.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.37.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -8240,7 +8329,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -9714,6 +9803,10 @@ snapshots:
     dependencies:
       typescript: 5.7.3
 
+  ts-api-utils@2.1.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
   ts-interface-checker@0.1.13: {}
 
   tsconfig-paths@3.15.0:
@@ -9803,7 +9896,7 @@ snapshots:
 
   typescript-eslint@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.7.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.46.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.7.3))(eslint@9.37.0(jiti@2.6.1))(typescript@5.7.3)
+      '@typescript-eslint/eslint-plugin': 8.46.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1))(typescript@5.7.3)
       '@typescript-eslint/parser': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.7.3)
       '@typescript-eslint/typescript-estree': 8.46.0(typescript@5.7.3)
       '@typescript-eslint/utils': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.7.3)
@@ -9812,7 +9905,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  typescript-eslint@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.46.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.46.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.37.0(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   typescript@5.7.3: {}
+
+  typescript@5.9.3: {}
 
   ufo@1.6.1: {}
 


### PR DESCRIPTION
## Summary
- replace the per-face gaze wiring with a shared `data/gazeMappings.ts` table so the panel and orchestrator stay aligned as rigs grow
- refresh the gaze panel UI to expose bridge readiness, unsupported-face messaging, and a proper reset flow
- keep the orchestrator inputs list clean by hiding all gaze-controlled paths from the sliders

