### PR TITLE
align React 19 types/deps and harden provider tests

### DIFF
--- a/apps/demo-animation-studio/package.json
+++ b/apps/demo-animation-studio/package.json
@@ -22,13 +22,13 @@
     "@vizij/animation-react": "workspace:*",
     "@vizij/utils": "workspace:*",
     "@vizij/value-json": "^0.1.2",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3"
   },
   "devDependencies": {
-    "@types/react": "^18.3.26",
-    "@types/react-dom": "^18.3.7",
-    "@vitejs/plugin-react-swc": "^3.7.0",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react-swc": "^4.2.2",
     "typescript": "^5.5.0",
     "vite": "^6.3.6",
     "prettier": "^3.4.2",

--- a/apps/demo-animation-studio/src/App.tsx
+++ b/apps/demo-animation-studio/src/App.tsx
@@ -1,14 +1,5 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { AnimationProvider, useAnimation } from "@vizij/animation-react";
-import presets from "./presets";
-import AnimationsPanel from "./components/AnimationsPanel";
-import type { InstanceSpec } from "./components/PlayersPanel";
-import EventsLog from "./components/EventsLog";
-import PlayerCard from "./components/PlayerCard";
-import ConfigPanel from "./components/ConfigPanel";
-import { PrebindRule, makeResolver } from "./components/PrebindPanel";
-import SessionPanel, { SessionState } from "./components/SessionPanel";
-import AnimationEditor from "./components/AnimationEditor";
 import type {
   StoredAnimation,
   Config,
@@ -17,6 +8,17 @@ import type {
 } from "@vizij/animation-wasm";
 import type { Value } from "@vizij/animation-react";
 import { init, abi_version } from "@vizij/animation-wasm";
+import presets from "./presets";
+import AnimationsPanel from "./components/AnimationsPanel";
+import type { InstanceSpec } from "./components/PlayersPanel";
+import EventsLog from "./components/EventsLog";
+import PlayerCard from "./components/PlayerCard";
+import ConfigPanel from "./components/ConfigPanel";
+import type { PrebindRule } from "./components/PrebindPanel";
+import { makeResolver } from "./components/PrebindPanel";
+import type { SessionState } from "./components/SessionPanel";
+import SessionPanel from "./components/SessionPanel";
+import AnimationEditor from "./components/AnimationEditor";
 import "./styles/app.css";
 
 type Sample = { t: number; v: Value };

--- a/apps/demo-animation-studio/src/components/PlayerCard.tsx
+++ b/apps/demo-animation-studio/src/components/PlayerCard.tsx
@@ -1,13 +1,14 @@
 import React, { useCallback, useMemo, useState } from "react";
 import { useAnimation, type Value } from "@vizij/animation-react";
-import { formatValue } from "../utils/valueFormat";
 import type {
   AnimationInfo,
   PlayerInfo,
   InstanceInfo,
   StoredAnimation,
 } from "@vizij/animation-wasm";
-import Timeline, { InstanceSpan, TimelineMarker } from "./Timeline";
+import { formatValue } from "../utils/valueFormat";
+import type { InstanceSpan, TimelineMarker } from "./Timeline";
+import Timeline from "./Timeline";
 import BakedAnimationPlot from "./BakedAnimationPlot";
 import ChartsView from "./OutputsView/ChartsView";
 

--- a/apps/demo-animation-studio/src/components/SessionPanel.tsx
+++ b/apps/demo-animation-studio/src/components/SessionPanel.tsx
@@ -1,4 +1,5 @@
-import React, { useRef, useState } from "react";
+import { useRef, useState } from "react";
+import type { ChangeEventHandler } from "react";
 import type { StoredAnimation, Config } from "@vizij/animation-wasm";
 import type { InstanceSpec } from "./PlayersPanel";
 import type { PrebindRule } from "./PrebindPanel";
@@ -38,9 +39,7 @@ export default function SessionPanel({
     fileRef.current?.click();
   };
 
-  const onFileChange: React.ChangeEventHandler<HTMLInputElement> = async (
-    e,
-  ) => {
+  const onFileChange: ChangeEventHandler<HTMLInputElement> = async (e) => {
     const f = e.target.files?.[0];
     if (!f) return;
     const txt = await f.text();

--- a/apps/demo-animation-studio/src/components/Timeline.tsx
+++ b/apps/demo-animation-studio/src/components/Timeline.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useMemo, useRef } from "react";
+import { useCallback, useMemo, useRef } from "react";
+import type { MouseEvent } from "react";
 
 export type InstanceSpan = {
   id: number;
@@ -57,7 +58,7 @@ export default function Timeline({
   );
 
   const onClick = useCallback(
-    (e: React.MouseEvent) => {
+    (e: MouseEvent) => {
       if (!onSeek || !containerRef.current) return;
       const rect = containerRef.current.getBoundingClientRect();
       const x = clamp(e.clientX - rect.left, 0, rect.width);

--- a/apps/demo-graph-studio/eslint.config.js
+++ b/apps/demo-graph-studio/eslint.config.js
@@ -3,6 +3,7 @@ const js = require("@eslint/js");
 const globals = require("globals");
 const reactHooks = require("eslint-plugin-react-hooks");
 const reactRefresh = require("eslint-plugin-react-refresh");
+const importPlugin = require("eslint-plugin-import");
 const tseslint = require("typescript-eslint");
 
 const recommendedHookRules =
@@ -28,9 +29,23 @@ module.exports = tseslint.config(
     plugins: {
       "react-hooks": reactHooks,
       "react-refresh": reactRefresh,
+      import: importPlugin,
     },
     rules: {
       ...recommendedHookRules,
+      "import/order": [
+        "error",
+        {
+          distinctGroup: false,
+          "newlines-between": "never",
+        },
+      ],
+      "import/newline-after-import": [
+        "error",
+        {
+          count: 1,
+        },
+      ],
       "react-refresh/only-export-components": [
         "warn",
         { allowConstantExport: true },

--- a/apps/demo-graph-studio/package.json
+++ b/apps/demo-graph-studio/package.json
@@ -25,18 +25,18 @@
     "@vizij/node-graph-wasm": "^0.4.9",
     "@vizij/value-json": "^0.1.2",
     "@vizij/utils": "workspace:*",
-    "react": "18.x",
-    "react-dom": "18.x",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3",
     "reactflow": "11.x",
-    "zustand": "^4.4.0"
+    "zustand": "^5.0.9"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.0.0",
     "eslint": "^9.19.0",
     "typescript": "^5.0.0",
     "vite": "^6.3.6",
     "vitest": "^3.2.4",
-    "prettier": "^3.4.2"
+    "prettier": "^3.4.2",
+    "@vitejs/plugin-react-swc": "^4.2.2"
   },
   "keywords": [
     "vizij",

--- a/apps/demo-graph-studio/src/App.tsx
+++ b/apps/demo-graph-studio/src/App.tsx
@@ -18,7 +18,7 @@ import ExpressionAuthoringPanel from "./components/ExpressionAuthoringPanel";
  * - Layout composes Palette | Canvas | Inspector with TransportBar and persistence controls
  */
 
-function AppShell(): JSX.Element {
+function AppShell(): React.JSX.Element {
   const [paletteOpen, setPaletteOpen] = useState(true);
   const [inputsOpen, setInputsOpen] = useState(true);
   const [inspectorOpen, setInspectorOpen] = useState(true);
@@ -188,7 +188,7 @@ function AppShell(): JSX.Element {
   );
 }
 
-export default function App(): JSX.Element {
+export default function App(): React.JSX.Element {
   // Wire the editor's canonical GraphSpec into the runtime so graphs actually load and evaluate.
   // Only positions are persisted separately; the runtime wiring is reconstructed from inputs.
   const spec = useEditorStore((s) => s.spec);

--- a/apps/demo-graph-studio/src/App.tsx
+++ b/apps/demo-graph-studio/src/App.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
-import { RegistryProvider } from "./contexts/RegistryProvider";
 import { GraphProvider } from "@vizij/node-graph-react";
+import type { JSX } from "react/jsx-runtime";
+import { RegistryProvider } from "./contexts/RegistryProvider";
 import { useEditorStore } from "./store/useEditorStore";
 import EditorCanvas from "./components/EditorCanvas";
 import NodePalette from "./components/NodePalette";
@@ -18,7 +19,7 @@ import ExpressionAuthoringPanel from "./components/ExpressionAuthoringPanel";
  * - Layout composes Palette | Canvas | Inspector with TransportBar and persistence controls
  */
 
-function AppShell(): React.JSX.Element {
+function AppShell(): JSX.Element {
   const [paletteOpen, setPaletteOpen] = useState(true);
   const [inputsOpen, setInputsOpen] = useState(true);
   const [inspectorOpen, setInspectorOpen] = useState(true);
@@ -188,7 +189,7 @@ function AppShell(): React.JSX.Element {
   );
 }
 
-export default function App(): React.JSX.Element {
+export default function App(): JSX.Element {
   // Wire the editor's canonical GraphSpec into the runtime so graphs actually load and evaluate.
   // Only positions are persisted separately; the runtime wiring is reconstructed from inputs.
   const spec = useEditorStore((s) => s.spec);

--- a/apps/demo-graph-studio/src/components/ConnectionsAssistant.tsx
+++ b/apps/demo-graph-studio/src/components/ConnectionsAssistant.tsx
@@ -20,7 +20,7 @@ type Suggestion = {
   detail?: string;
 };
 
-export default function ConnectionsAssistant(): JSX.Element {
+export default function ConnectionsAssistant(): React.JSX.Element {
   const [visible, setVisible] = useState(false);
   const [reason, setReason] = useState<string | null>(null);
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);

--- a/apps/demo-graph-studio/src/components/ConnectionsAssistant.tsx
+++ b/apps/demo-graph-studio/src/components/ConnectionsAssistant.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import type { JSX } from "react/jsx-runtime";
 
 /**
  * ConnectionsAssistant
@@ -20,7 +21,7 @@ type Suggestion = {
   detail?: string;
 };
 
-export default function ConnectionsAssistant(): React.JSX.Element {
+export default function ConnectionsAssistant(): JSX.Element {
   const [visible, setVisible] = useState(false);
   const [reason, setReason] = useState<string | null>(null);
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);

--- a/apps/demo-graph-studio/src/components/EditorCanvas.tsx
+++ b/apps/demo-graph-studio/src/components/EditorCanvas.tsx
@@ -1,4 +1,13 @@
 import React, { useCallback, useMemo, useRef, useState } from "react";
+import type { ComponentType, DragEvent, FC, MouseEvent } from "react";
+import type {
+  Connection,
+  Edge,
+  EdgeChange,
+  Node,
+  NodeChange,
+  ReactFlowInstance,
+} from "reactflow";
 import ReactFlow, {
   addEdge,
   Background,
@@ -7,18 +16,12 @@ import ReactFlow, {
   ReactFlowProvider,
   applyEdgeChanges,
   applyNodeChanges,
-  Connection,
-  Edge,
-  EdgeChange,
   Handle,
-  Node,
-  NodeChange,
   Position,
-  ReactFlowInstance,
   useUpdateNodeInternals,
 } from "reactflow";
 import "reactflow/dist/style.css";
-
+import type { JSX } from "react/jsx-runtime";
 import { useEditorStore, parseVariadicPortId } from "../store/useEditorStore";
 import {
   isConnectionCompatible,
@@ -26,7 +29,7 @@ import {
 } from "../utils/connectionUtils";
 import { useRegistry } from "../contexts/RegistryProvider";
 
-const simpleNodeCache: Record<string, React.FC<{ id: string; data: any }>> = {};
+const simpleNodeCache: Record<string, FC<{ id: string; data: any }>> = {};
 
 const formatVariadicHandleId = (groupId: string, index: number): string =>
   `${groupId}_${index}`;
@@ -147,7 +150,7 @@ const createNodeRenderer = (
           variadicOutputs: schema.variadicOutputs ?? null,
         };
 
-  const SimpleNode: React.FC<{ id: string; data: any }> = ({ id, data }) => {
+  const SimpleNode: FC<{ id: string; data: any }> = ({ id, data }) => {
     const updateNodeInternals = useUpdateNodeInternals();
     const defaults = (data?.input_defaults as Record<string, any>) ?? {};
     const inputMappings: any[] = Array.isArray(data?.inputs) ? data.inputs : [];
@@ -389,7 +392,7 @@ const createNodeRenderer = (
   return SimpleNode;
 };
 
-export default function EditorCanvas(): React.JSX.Element {
+export default function EditorCanvas(): JSX.Element {
   const nodes = useEditorStore((s) => s.nodes);
   const edges = useEditorStore((s) => s.edges);
   const setNodes = useEditorStore((s) => s.setNodes);
@@ -408,7 +411,7 @@ export default function EditorCanvas(): React.JSX.Element {
   );
 
   const nodeTypes = useMemo(() => {
-    const types: Record<string, React.ComponentType<any>> = {};
+    const types: Record<string, ComponentType<any>> = {};
     for (const [typeId, schema] of registryEntries) {
       if (!typeId) continue;
       types[typeId] = createNodeRenderer(typeId, schema, getPortsForType);
@@ -534,7 +537,7 @@ export default function EditorCanvas(): React.JSX.Element {
   const setSelected = useEditorStore((s) => s.setSelected);
 
   const onNodeClick = useCallback(
-    (_event: React.MouseEvent, node: Node) => {
+    (_event: MouseEvent, node: Node) => {
       setSelected(node.id);
     },
     [setSelected],
@@ -559,13 +562,13 @@ export default function EditorCanvas(): React.JSX.Element {
     setRfInstance(instance);
   }, []);
 
-  const onDragOver = useCallback((event: React.DragEvent) => {
+  const onDragOver = useCallback((event: DragEvent) => {
     event.preventDefault();
     event.dataTransfer.dropEffect = "move";
   }, []);
 
   const onDrop = useCallback(
-    (event: React.DragEvent) => {
+    (event: DragEvent) => {
       event.preventDefault();
       if (!rfInstance || !reactFlowWrapper.current) return;
 

--- a/apps/demo-graph-studio/src/components/EditorCanvas.tsx
+++ b/apps/demo-graph-studio/src/components/EditorCanvas.tsx
@@ -389,7 +389,7 @@ const createNodeRenderer = (
   return SimpleNode;
 };
 
-export default function EditorCanvas(): JSX.Element {
+export default function EditorCanvas(): React.JSX.Element {
   const nodes = useEditorStore((s) => s.nodes);
   const edges = useEditorStore((s) => s.edges);
   const setNodes = useEditorStore((s) => s.setNodes);

--- a/apps/demo-graph-studio/src/components/ExpressionAuthoringPanel.tsx
+++ b/apps/demo-graph-studio/src/components/ExpressionAuthoringPanel.tsx
@@ -5,6 +5,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import type { ChangeEvent, KeyboardEvent, SyntheticEvent } from "react";
 import type { GraphSpec } from "@vizij/node-graph-wasm";
 import {
   EXPRESSION_FUNCTION_VOCABULARY,
@@ -16,6 +17,7 @@ import {
   type ScalarFunctionDefinition,
   type ScalarFunctionVocabularyEntry,
 } from "@vizij/node-graph-authoring";
+import type { JSX } from "react/jsx-runtime";
 import {
   buildExpressionGraph,
   type ExpressionGraphResult,
@@ -117,7 +119,7 @@ const UNARY_OPERATOR_METADATA: Record<
   "!": { title: "Not", description: "Logical NOT." },
 };
 
-export default function ExpressionAuthoringPanel(): React.JSX.Element {
+export default function ExpressionAuthoringPanel(): JSX.Element {
   const [expression, setExpression] = useState("s1");
   const [slots, setSlots] = useState<SlotFormState[]>(DEFAULT_SLOTS);
   const [mode, setMode] = useState<IntegrationMode>("replace");
@@ -206,7 +208,7 @@ export default function ExpressionAuthoringPanel(): React.JSX.Element {
   }, []);
 
   const handleExpressionChange = useCallback(
-    (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    (event: ChangeEvent<HTMLTextAreaElement>) => {
       setExpression(event.target.value);
       syncSelectionFromTarget(event.target);
       setIsHintSuppressed(false);
@@ -215,7 +217,7 @@ export default function ExpressionAuthoringPanel(): React.JSX.Element {
   );
 
   const handleExpressionPointer = useCallback(
-    (event: React.SyntheticEvent<HTMLTextAreaElement>) => {
+    (event: SyntheticEvent<HTMLTextAreaElement>) => {
       syncSelectionFromTarget(event.currentTarget);
     },
     [syncSelectionFromTarget],
@@ -251,7 +253,7 @@ export default function ExpressionAuthoringPanel(): React.JSX.Element {
   );
 
   const handleExpressionKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    (event: KeyboardEvent<HTMLTextAreaElement>) => {
       if (!showFunctionHints || !functionSuggestions.length) {
         return;
       }
@@ -828,7 +830,7 @@ function ExpressionFlowDiagram({
   root,
 }: {
   root: FlowRenderableNode;
-}): React.JSX.Element {
+}): JSX.Element {
   return (
     <div
       style={{
@@ -849,10 +851,7 @@ interface FlowStreamNodeProps {
   depth: number;
 }
 
-function FlowStreamNode({
-  node,
-  depth,
-}: FlowStreamNodeProps): React.JSX.Element {
+function FlowStreamNode({ node, depth }: FlowStreamNodeProps): JSX.Element {
   const hasChildren = node.children.length > 0;
   const laneWidth = computeLaneWidth(depth);
   return (
@@ -891,7 +890,7 @@ function FlowStreamChildren({
 }: {
   node: FlowRenderableNode;
   depth: number;
-}): React.JSX.Element | null {
+}): JSX.Element | null {
   const childCount = node.children.length;
   if (!childCount) {
     return null;
@@ -941,11 +940,7 @@ function FlowStreamChildren({
   );
 }
 
-function FlowStreamLabel({
-  label,
-}: {
-  label?: string;
-}): React.JSX.Element | null {
+function FlowStreamLabel({ label }: { label?: string }): JSX.Element | null {
   if (!label) {
     return null;
   }
@@ -977,7 +972,7 @@ function FlowNodeBlock({
 }: {
   node: FlowRenderableNode;
   minWidth: number;
-}): React.JSX.Element {
+}): JSX.Element {
   const accentHex = FLOW_ACCENT_COLORS[node.accent];
   const borderColor = hexToRgba(accentHex, 0.6);
   return (
@@ -1311,7 +1306,7 @@ function FunctionHintOverlay({
   onHighlight,
   onSelect,
   fallbackSuggestion,
-}: FunctionHintOverlayProps): React.JSX.Element | null {
+}: FunctionHintOverlayProps): JSX.Element | null {
   if (!suggestions.length && !fallbackSuggestion) {
     return null;
   }

--- a/apps/demo-graph-studio/src/components/ExpressionAuthoringPanel.tsx
+++ b/apps/demo-graph-studio/src/components/ExpressionAuthoringPanel.tsx
@@ -117,7 +117,7 @@ const UNARY_OPERATOR_METADATA: Record<
   "!": { title: "Not", description: "Logical NOT." },
 };
 
-export default function ExpressionAuthoringPanel(): JSX.Element {
+export default function ExpressionAuthoringPanel(): React.JSX.Element {
   const [expression, setExpression] = useState("s1");
   const [slots, setSlots] = useState<SlotFormState[]>(DEFAULT_SLOTS);
   const [mode, setMode] = useState<IntegrationMode>("replace");
@@ -828,7 +828,7 @@ function ExpressionFlowDiagram({
   root,
 }: {
   root: FlowRenderableNode;
-}): JSX.Element {
+}): React.JSX.Element {
   return (
     <div
       style={{
@@ -849,7 +849,10 @@ interface FlowStreamNodeProps {
   depth: number;
 }
 
-function FlowStreamNode({ node, depth }: FlowStreamNodeProps): JSX.Element {
+function FlowStreamNode({
+  node,
+  depth,
+}: FlowStreamNodeProps): React.JSX.Element {
   const hasChildren = node.children.length > 0;
   const laneWidth = computeLaneWidth(depth);
   return (
@@ -888,7 +891,7 @@ function FlowStreamChildren({
 }: {
   node: FlowRenderableNode;
   depth: number;
-}): JSX.Element | null {
+}): React.JSX.Element | null {
   const childCount = node.children.length;
   if (!childCount) {
     return null;
@@ -938,7 +941,11 @@ function FlowStreamChildren({
   );
 }
 
-function FlowStreamLabel({ label }: { label?: string }): JSX.Element | null {
+function FlowStreamLabel({
+  label,
+}: {
+  label?: string;
+}): React.JSX.Element | null {
   if (!label) {
     return null;
   }
@@ -970,7 +977,7 @@ function FlowNodeBlock({
 }: {
   node: FlowRenderableNode;
   minWidth: number;
-}): JSX.Element {
+}): React.JSX.Element {
   const accentHex = FLOW_ACCENT_COLORS[node.accent];
   const borderColor = hexToRgba(accentHex, 0.6);
   return (
@@ -1304,7 +1311,7 @@ function FunctionHintOverlay({
   onHighlight,
   onSelect,
   fallbackSuggestion,
-}: FunctionHintOverlayProps): JSX.Element | null {
+}: FunctionHintOverlayProps): React.JSX.Element | null {
   if (!suggestions.length && !fallbackSuggestion) {
     return null;
   }

--- a/apps/demo-graph-studio/src/components/InputPanel.tsx
+++ b/apps/demo-graph-studio/src/components/InputPanel.tsx
@@ -4,12 +4,13 @@ import React, {
   useMemo,
   useRef,
   useState,
-  ChangeEvent,
 } from "react";
-import { useEditorStore } from "../store/useEditorStore";
+import type { ChangeEvent } from "react";
 import { useGraphRuntime } from "@vizij/node-graph-react";
-import { useRegistry } from "../contexts/RegistryProvider";
 import { valueAsNumber } from "@vizij/value-json";
+import type { JSX } from "react/jsx-runtime";
+import { useRegistry } from "../contexts/RegistryProvider";
+import { useEditorStore } from "../store/useEditorStore";
 
 type SupportedKind = "float" | "bool";
 
@@ -56,7 +57,7 @@ function toNumber(value: unknown): number | undefined {
   return undefined;
 }
 
-export default function InputPanel(): React.JSX.Element {
+export default function InputPanel(): JSX.Element {
   const nodes = useEditorStore((s) => s.nodes);
   const runtime = useGraphRuntime();
   const { getNodeSummary } = useRegistry();

--- a/apps/demo-graph-studio/src/components/InputPanel.tsx
+++ b/apps/demo-graph-studio/src/components/InputPanel.tsx
@@ -56,7 +56,7 @@ function toNumber(value: unknown): number | undefined {
   return undefined;
 }
 
-export default function InputPanel(): JSX.Element {
+export default function InputPanel(): React.JSX.Element {
   const nodes = useEditorStore((s) => s.nodes);
   const runtime = useGraphRuntime();
   const { getNodeSummary } = useRegistry();

--- a/apps/demo-graph-studio/src/components/InspectorPanel.tsx
+++ b/apps/demo-graph-studio/src/components/InspectorPanel.tsx
@@ -1,16 +1,13 @@
-import React, {
-  CSSProperties,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
-import { useEditorStore } from "../store/useEditorStore";
-import { ParamSpec, PortSpec, useRegistry } from "../contexts/RegistryProvider";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import { useGraphRuntime, useNodeOutputs } from "@vizij/node-graph-react";
 import { useDialogQueue } from "@vizij/authoring-shared";
-import { parseVariadicPortId } from "../store/useEditorStore";
 import { cloneDeepSafe } from "@vizij/utils";
+import type { JSX } from "react/jsx-runtime";
+import { parseVariadicPortId } from "../store/useEditorStore";
+import type { ParamSpec, PortSpec } from "../contexts/RegistryProvider";
+import { useRegistry } from "../contexts/RegistryProvider";
+import { useEditorStore } from "../store/useEditorStore";
 
 const VARIADIC_DELIM = "_";
 
@@ -773,7 +770,7 @@ function InputDefaultEditor({
   );
 }
 
-export default function InspectorPanel(): React.JSX.Element {
+export default function InspectorPanel(): JSX.Element {
   const selectedId = useEditorStore((s) => s.selectedNodeId);
   const nodes = useEditorStore((s) => s.nodes);
   const setNodes = useEditorStore((s) => s.setNodes);
@@ -1271,7 +1268,7 @@ export default function InspectorPanel(): React.JSX.Element {
         ) : (
           paramsSpec.map((p) => {
             const current = (node.data?.params ?? {})[p.id];
-            let editor: React.ReactNode;
+            let editor: ReactNode;
             if (p.id === "value") {
               editor = (
                 <ValueParamEditor

--- a/apps/demo-graph-studio/src/components/InspectorPanel.tsx
+++ b/apps/demo-graph-studio/src/components/InspectorPanel.tsx
@@ -773,7 +773,7 @@ function InputDefaultEditor({
   );
 }
 
-export default function InspectorPanel(): JSX.Element {
+export default function InspectorPanel(): React.JSX.Element {
   const selectedId = useEditorStore((s) => s.selectedNodeId);
   const nodes = useEditorStore((s) => s.nodes);
   const setNodes = useEditorStore((s) => s.setNodes);

--- a/apps/demo-graph-studio/src/components/NodePalette.tsx
+++ b/apps/demo-graph-studio/src/components/NodePalette.tsx
@@ -7,7 +7,7 @@ type PaletteType = {
   doc?: string;
 };
 
-export default function NodePalette(): JSX.Element {
+export default function NodePalette(): React.JSX.Element {
   const { loading, error, nodesByType, getNodeSummary } = useRegistry();
   const [filter, setFilter] = useState("");
 

--- a/apps/demo-graph-studio/src/components/NodePalette.tsx
+++ b/apps/demo-graph-studio/src/components/NodePalette.tsx
@@ -1,4 +1,6 @@
 import React, { useMemo, useState } from "react";
+import type { DragEvent } from "react";
+import type { JSX } from "react/jsx-runtime";
 import { useRegistry } from "../contexts/RegistryProvider";
 
 type PaletteType = {
@@ -7,7 +9,7 @@ type PaletteType = {
   doc?: string;
 };
 
-export default function NodePalette(): React.JSX.Element {
+export default function NodePalette(): JSX.Element {
   const { loading, error, nodesByType, getNodeSummary } = useRegistry();
   const [filter, setFilter] = useState("");
 
@@ -44,7 +46,7 @@ export default function NodePalette(): React.JSX.Element {
     }));
   }, [nodesByType, getNodeSummary]);
 
-  const onDragStart = (e: React.DragEvent, typeId: string) => {
+  const onDragStart = (e: DragEvent, typeId: string) => {
     // React Flow uses 'application/reactflow' by convention for DnD
     e.dataTransfer.setData("application/reactflow", typeId);
     e.dataTransfer.effectAllowed = "move";

--- a/apps/demo-graph-studio/src/components/OutputsChart.tsx
+++ b/apps/demo-graph-studio/src/components/OutputsChart.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from "react";
 import { useNodeOutput } from "@vizij/node-graph-react";
+import type { JSX } from "react/jsx-runtime";
 
 /**
  * OutputsChart
@@ -78,7 +79,7 @@ export default function OutputsChart({
   width = 300,
   height = 80,
   label,
-}: Props): React.JSX.Element {
+}: Props): JSX.Element {
   const output = useNodeOutput(nodeId, outputKey);
   const bufferRef = useRef<{ t: number; v: number }[]>([]);
   const lastTRef = useRef<number | null>(null);

--- a/apps/demo-graph-studio/src/components/OutputsChart.tsx
+++ b/apps/demo-graph-studio/src/components/OutputsChart.tsx
@@ -78,7 +78,7 @@ export default function OutputsChart({
   width = 300,
   height = 80,
   label,
-}: Props): JSX.Element {
+}: Props): React.JSX.Element {
   const output = useNodeOutput(nodeId, outputKey);
   const bufferRef = useRef<{ t: number; v: number }[]>([]);
   const lastTRef = useRef<number | null>(null);

--- a/apps/demo-graph-studio/src/components/PersistencePanel.tsx
+++ b/apps/demo-graph-studio/src/components/PersistencePanel.tsx
@@ -18,7 +18,7 @@ import {
  * - Quick localStorage Save/Load helpers for convenience
  */
 
-export default function PersistencePanel(): JSX.Element {
+export default function PersistencePanel(): React.JSX.Element {
   const nodes = useEditorStore((s) => s.nodes);
   const edges = useEditorStore((s) => s.edges);
   const setSpec = useEditorStore((s) => s.setSpec);

--- a/apps/demo-graph-studio/src/components/PersistencePanel.tsx
+++ b/apps/demo-graph-studio/src/components/PersistencePanel.tsx
@@ -1,15 +1,17 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { useEditorStore } from "../store/useEditorStore";
+import type { ChangeEvent } from "react";
 import {
   listNodeGraphFixtures,
   loadNodeGraphSpec,
   normalizeGraphSpec,
 } from "@vizij/node-graph-react";
+import type { JSX } from "react/jsx-runtime";
 import {
   downloadJsonFile,
   readJsonFile,
   useDialogQueue,
 } from "@vizij/authoring-shared";
+import { useEditorStore } from "../store/useEditorStore";
 
 /**
  * PersistencePanel
@@ -18,7 +20,7 @@ import {
  * - Quick localStorage Save/Load helpers for convenience
  */
 
-export default function PersistencePanel(): React.JSX.Element {
+export default function PersistencePanel(): JSX.Element {
   const nodes = useEditorStore((s) => s.nodes);
   const edges = useEditorStore((s) => s.edges);
   const setSpec = useEditorStore((s) => s.setSpec);
@@ -88,7 +90,7 @@ export default function PersistencePanel(): React.JSX.Element {
   );
 
   const importFromInput = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
+    (e: ChangeEvent<HTMLInputElement>) => {
       const f = e.target.files?.[0];
       void onFile(f);
       e.currentTarget.value = "";

--- a/apps/demo-graph-studio/src/components/TransportBar.tsx
+++ b/apps/demo-graph-studio/src/components/TransportBar.tsx
@@ -14,7 +14,7 @@ import { useEditorStore } from "../store/useEditorStore";
  * - Uses runtime (useGraphRuntime) for setTime, step and evalAll operations
  */
 
-export default function TransportBar(): JSX.Element {
+export default function TransportBar(): React.JSX.Element {
   const playback = useGraphPlayback();
   const runtime = useGraphRuntime();
   const [intervalHz, setIntervalHz] = useState<number>(60);

--- a/apps/demo-graph-studio/src/components/TransportBar.tsx
+++ b/apps/demo-graph-studio/src/components/TransportBar.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useState } from "react";
 import { useGraphPlayback } from "@vizij/node-graph-react";
 import { useGraphRuntime } from "@vizij/node-graph-react";
+import type { JSX } from "react/jsx-runtime";
 import { useEditorStore } from "../store/useEditorStore";
 
 /**
@@ -14,7 +15,7 @@ import { useEditorStore } from "../store/useEditorStore";
  * - Uses runtime (useGraphRuntime) for setTime, step and evalAll operations
  */
 
-export default function TransportBar(): React.JSX.Element {
+export default function TransportBar(): JSX.Element {
   const playback = useGraphPlayback();
   const runtime = useGraphRuntime();
   const [intervalHz, setIntervalHz] = useState<number>(60);

--- a/apps/demo-graph-studio/src/contexts/RegistryProvider.tsx
+++ b/apps/demo-graph-studio/src/contexts/RegistryProvider.tsx
@@ -6,6 +6,7 @@ import React, {
   useMemo,
   useState,
 } from "react";
+import type { FC, PropsWithChildren } from "react";
 import { init as initGraphWasm, getNodeSchemas } from "@vizij/node-graph-react";
 import type { Registry as WasmRegistry } from "@vizij/node-graph-wasm";
 import { useEditorStore } from "../store/useEditorStore";
@@ -253,9 +254,7 @@ function normalizeSignature(signature: NodeSignature): NormalizedNodeSchema {
   };
 }
 
-export const RegistryProvider: React.FC<React.PropsWithChildren> = ({
-  children,
-}) => {
+export const RegistryProvider: FC<PropsWithChildren> = ({ children }) => {
   const [registry, setRegistry] = useState<Registry | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/apps/demo-graph-studio/vite.config.ts
+++ b/apps/demo-graph-studio/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
+import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { fileURLToPath } from "url";
 

--- a/apps/demo-graph-studio/vite.config.ts
+++ b/apps/demo-graph-studio/vite.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { fileURLToPath } from "url";
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react-swc";
 
 /**
  * Vite config for vizij-web/apps/node-graph-editor

--- a/apps/demo-vizij-player/package.json
+++ b/apps/demo-vizij-player/package.json
@@ -22,13 +22,13 @@
     "@vizij/render": "workspace:*",
     "@vizij/utils": "workspace:*",
     "@vizij/value-json": "^0.1.2",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3"
   },
   "devDependencies": {
-    "@types/react": "^18.3.26",
-    "@types/react-dom": "^18.3.7",
-    "@vitejs/plugin-react-swc": "^3.7.0",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react-swc": "^4.2.2",
     "prettier": "^3.4.2",
     "typescript": "^5.9.3",
     "vite": "^6.3.6",

--- a/apps/demo-vizij-player/src/App.tsx
+++ b/apps/demo-vizij-player/src/App.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useState } from "react";
 import { useOrchestrator } from "@vizij/orchestrator-react";
-
 import { AssetLoaderPanel } from "./components/AssetLoaderPanel";
 import { RigControlsPanel } from "./components/RigControlsPanel";
 import { AnimationPanel } from "./components/AnimationPanel";

--- a/apps/demo-vizij-player/src/components/AnimationPanel.tsx
+++ b/apps/demo-vizij-player/src/components/AnimationPanel.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useOrchestrator } from "@vizij/orchestrator-react";
-
 import { useAppState } from "../state/AppStateContext";
 import type { AnimationAsset, AnimationTrack } from "../state/types";
 import type { RigDefinition } from "../orchestrator/useOrchestratorMerging";

--- a/apps/demo-vizij-player/src/components/AssetLoaderPanel.tsx
+++ b/apps/demo-vizij-player/src/components/AssetLoaderPanel.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useMemo, useRef, useState } from "react";
-
 import { useAppState } from "../state/AppStateContext";
 
 const GLB_ACCEPT = ".glb";

--- a/apps/demo-vizij-player/src/components/DiagnosticsPanel.tsx
+++ b/apps/demo-vizij-player/src/components/DiagnosticsPanel.tsx
@@ -4,7 +4,6 @@ import {
   useOrchestrator,
   type GraphRegistrationConfig,
 } from "@vizij/orchestrator-react";
-
 import type {
   MergeWarnings,
   RigDefinition,

--- a/apps/demo-vizij-player/src/components/RigControlsPanel.tsx
+++ b/apps/demo-vizij-player/src/components/RigControlsPanel.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useOrchestrator } from "@vizij/orchestrator-react";
-
 import { useAppState } from "../state/AppStateContext";
 import type { RigDefinition } from "../orchestrator/useOrchestratorMerging";
 

--- a/apps/demo-vizij-player/src/hooks/useGlbLoader.ts
+++ b/apps/demo-vizij-player/src/hooks/useGlbLoader.ts
@@ -5,7 +5,6 @@ import {
   useVizijStoreSetter,
 } from "@vizij/render";
 import type { Group, World } from "@vizij/render";
-
 import type { GlbAsset } from "../state/types";
 
 const INITIAL_STATUS = {

--- a/apps/demo-vizij-player/src/main.tsx
+++ b/apps/demo-vizij-player/src/main.tsx
@@ -1,7 +1,6 @@
 import { createRoot } from "react-dom/client";
 import { VizijContext, createVizijStore } from "@vizij/render";
 import { OrchestratorProvider } from "@vizij/orchestrator-react";
-
 import App from "./App";
 import { AppStateProvider } from "./state/AppStateContext";
 import "./styles.css";

--- a/apps/demo-vizij-player/src/orchestrator/useOrchestratorMerging.test.ts
+++ b/apps/demo-vizij-player/src/orchestrator/useOrchestratorMerging.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-
+import type { GraphAsset, SimpleAnimationClip } from "../state/types";
 import {
   buildAnimationBridgeGraph,
   buildUiBridgeGraph,
@@ -7,7 +7,6 @@ import {
   extractRigInputs,
   type RigDefinition,
 } from "./useOrchestratorMerging";
-import type { GraphAsset, SimpleAnimationClip } from "../state/types";
 
 describe("useOrchestratorMerging helpers", () => {
   const graph: GraphAsset = {

--- a/apps/demo-vizij-player/src/orchestrator/useOrchestratorMerging.ts
+++ b/apps/demo-vizij-player/src/orchestrator/useOrchestratorMerging.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useOrchestrator } from "@vizij/orchestrator-react";
 import type { GraphRegistrationConfig } from "@vizij/orchestrator-react";
-
 import { useAppState } from "../state/AppStateContext";
 import type { GraphAsset, SimpleAnimationClip } from "../state/types";
 

--- a/apps/demo-vizij-player/src/renderer/RenderOrchestratorBridge.tsx
+++ b/apps/demo-vizij-player/src/renderer/RenderOrchestratorBridge.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo } from "react";
 import { useVizijStore } from "@vizij/render";
 import { useOrchFrame } from "@vizij/orchestrator-react";
 import type { RawValue } from "@vizij/utils";
-
 import { valueJSONToRaw } from "./valueConversion";
 
 type RenderOrchestratorBridgeProps = {

--- a/apps/demo-vizij-player/src/state/AppStateContext.tsx
+++ b/apps/demo-vizij-player/src/state/AppStateContext.tsx
@@ -6,9 +6,8 @@ import {
   useMemo,
   useReducer,
   useRef,
-  type ReactNode,
 } from "react";
-
+import type { ReactNode } from "react";
 import {
   clearPersistedState,
   loadPersistedState,
@@ -16,13 +15,13 @@ import {
 } from "./storage";
 import {
   DEFAULT_APP_STATE,
+  type AnimationAsset,
+  type AnimationTrack,
   type AppState,
   type GlbAsset,
   type GraphAsset,
-  type AnimationAsset,
-  type SimpleAnimationClip,
-  type AnimationTrack,
   type RigPreset,
+  type SimpleAnimationClip,
 } from "./types";
 
 function createId(): string {

--- a/apps/demo-vizij-player/src/state/storage.test.ts
+++ b/apps/demo-vizij-player/src/state/storage.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-
 import { computeBundleKey } from "./storage";
 import type { GlbAsset, GraphAsset } from "./types";
 

--- a/apps/minimal-demo-animation-graph/package.json
+++ b/apps/minimal-demo-animation-graph/package.json
@@ -24,17 +24,18 @@
     "@vizij/node-graph-react": "workspace:*",
     "@vizij/node-graph-wasm": "^0.4.9",
     "@vizij/utils": "workspace:*",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3"
   },
   "devDependencies": {
-    "@testing-library/react": "^14.3.1",
-    "@types/react": "^18.3.26",
-    "@types/react-dom": "^18.3.7",
-    "@vitejs/plugin-react-swc": "^3.7.0",
+    "@testing-library/react": "^16.3.1",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react-swc": "^4.2.2",
     "typescript": "^5.5.0",
     "vite": "^6.3.6",
     "vitest": "^3.2.4",
-    "prettier": "^3.4.2"
+    "prettier": "^3.4.2",
+    "@testing-library/dom": "^10.4.1"
   }
 }

--- a/apps/minimal-demo-animation-graph/src/App.tsx
+++ b/apps/minimal-demo-animation-graph/src/App.tsx
@@ -1,7 +1,6 @@
-import React from "react";
+import { MinimalDemoChrome, MinimalDemoSection } from "@vizij/minimal-demo-ui";
 import { IkGraphDemo } from "./demos/IkGraphDemo";
 import { SlewDampDemo } from "./demos/SlewDampDemo";
-import { MinimalDemoChrome, MinimalDemoSection } from "@vizij/minimal-demo-ui";
 
 export default function App() {
   return (

--- a/apps/minimal-demo-animation-graph/src/__tests__/IkGraphDemo-init.test.ts
+++ b/apps/minimal-demo-animation-graph/src/__tests__/IkGraphDemo-init.test.ts
@@ -4,10 +4,10 @@ import { render, waitFor } from "@testing-library/react";
 import { GraphProvider } from "@vizij/node-graph-react";
 import { useGraphRuntime } from "@vizij/node-graph-react";
 import type { GraphSpec } from "@vizij/node-graph-wasm";
+import { cloneDeepSafe } from "@vizij/utils";
 import { ikGraphSpec } from "../data/ikGraph";
 import { slewGraphSpec } from "../data/slewGraph";
 import { makeTypedPath } from "../utils/typedPath";
-import { cloneDeepSafe } from "@vizij/utils";
 
 // Local mock of @vizij/node-graph-wasm for this app test scope.
 // We keep semantics consistent with the package tests but scoped to the app.

--- a/apps/minimal-demo-animation-graph/src/components/UrdfIkPanel.tsx
+++ b/apps/minimal-demo-animation-graph/src/components/UrdfIkPanel.tsx
@@ -1,12 +1,13 @@
-import React, { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
+import type { ChangeEvent } from "react";
 import type { ValueJSON } from "@vizij/node-graph-wasm";
 import {
   useGraphRuntime,
   useNodeOutput,
   valueAsNumber,
 } from "@vizij/node-graph-react";
-import { ParamEditor } from "./ParamEditor";
 import { minimalDemoTheme } from "@vizij/minimal-demo-ui";
+import { ParamEditor } from "./ParamEditor";
 
 const MAX_URDF_BYTES = 1_000_000; // ~1 MB safeguard
 
@@ -94,7 +95,7 @@ export function UrdfIkPanel({
     [nodeId, ready, runtime],
   );
 
-  const handleFile = async (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFile = async (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (!file) return;
     if (file.size > MAX_URDF_BYTES) {

--- a/apps/minimal-demo-animation-graph/src/demos/IkGraphDemo.tsx
+++ b/apps/minimal-demo-animation-graph/src/demos/IkGraphDemo.tsx
@@ -15,6 +15,7 @@ import {
   useSafeEval,
 } from "@vizij/node-graph-react";
 import { toValueJSON } from "@vizij/value-json";
+import { minimalDemoTheme } from "@vizij/minimal-demo-ui";
 import { TimeSeriesChart } from "../components/TimeSeriesChart";
 import {
   UrdfIkPanel,
@@ -30,7 +31,6 @@ import {
 } from "../data/ikAnimation";
 import { ikGraphSpec } from "../data/ikGraph";
 import { sampleUrdf } from "../data/urdf-samples/sampleUrdf";
-import { minimalDemoTheme } from "@vizij/minimal-demo-ui";
 
 type FkPositionKey = "x" | "y" | "z";
 type FkRotationKey = "qx" | "qy" | "qz" | "qw";

--- a/apps/minimal-demo-animation-graph/src/demos/SlewDampDemo.tsx
+++ b/apps/minimal-demo-animation-graph/src/demos/SlewDampDemo.tsx
@@ -10,13 +10,13 @@ import {
   useGraphOutputs,
   valueAsNumber,
 } from "@vizij/node-graph-react";
+import { minimalDemoTheme } from "@vizij/minimal-demo-ui";
 import { animationValueToValueJSON } from "../utils/animationValueToGraph";
 import { TimeSeriesChart } from "../components/TimeSeriesChart";
 import { slewAnimation, slewPaths } from "../data/slewAnimation";
 import { slewGraphSpec } from "../data/slewGraph";
 import { useSyncedSeries } from "../utils/useSyncedSeries";
 import { ParamEditor } from "../components/ParamEditor";
-import { minimalDemoTheme } from "@vizij/minimal-demo-ui";
 
 function SlewDampInner() {
   const runtime = useGraphRuntime();

--- a/apps/minimal-demo-animation/package.json
+++ b/apps/minimal-demo-animation/package.json
@@ -21,17 +21,18 @@
     "@vizij/animation-react": "workspace:*",
     "@vizij/minimal-demo-ui": "workspace:*",
     "@vizij/utils": "workspace:*",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3"
   },
   "devDependencies": {
-    "@testing-library/react": "^14.3.1",
-    "@types/react": "^18.3.26",
-    "@types/react-dom": "^18.3.7",
-    "@vitejs/plugin-react-swc": "^3.7.0",
+    "@testing-library/react": "^16.3.1",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react-swc": "^4.2.2",
     "typescript": "^5.5.0",
     "vite": "^6.3.6",
     "vitest": "^3.2.4",
-    "prettier": "^3.4.2"
+    "prettier": "^3.4.2",
+    "@testing-library/dom": "^10.4.1"
   }
 }

--- a/apps/minimal-demo-animation/src/App.tsx
+++ b/apps/minimal-demo-animation/src/App.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import type { ChangeEvent, Dispatch } from "react";
 import {
   AnimationProvider,
   useAnimTarget,
@@ -172,7 +173,7 @@ function parseAnimations(text: string): StoredAnimation[] {
 
 type PanelProps = {
   animations: StoredAnimation[];
-  setAnimations: React.Dispatch<StoredAnimation[] | null>;
+  setAnimations: Dispatch<StoredAnimation[] | null>;
   initialAnimations: StoredAnimation[];
   sampleOptions: string[];
   selectedSample: string | null;
@@ -384,7 +385,7 @@ function Panel({
     [animApi, setAnimations, onSampleApplied, onCustomSpec],
   );
 
-  const onFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+  const onFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
     setStatus(null);
     setError(null);
     const file = e.target.files?.[0];
@@ -436,7 +437,7 @@ function Panel({
   const sampleSelectValue = selectedSample ?? "__custom__";
 
   const handleSampleSelect = React.useCallback(
-    async (event: React.ChangeEvent<HTMLSelectElement>) => {
+    async (event: ChangeEvent<HTMLSelectElement>) => {
       const id = event.target.value;
       if (!id || id === "__custom__" || id === selectedSample) {
         return;

--- a/apps/minimal-demo-graph/package.json
+++ b/apps/minimal-demo-graph/package.json
@@ -22,13 +22,13 @@
     "@vizij/node-graph-react": "workspace:*",
     "@vizij/node-graph-wasm": "^0.4.9",
     "@vizij/utils": "workspace:*",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3"
   },
   "devDependencies": {
-    "@types/react": "^18.3.26",
-    "@types/react-dom": "^18.3.7",
-    "@vitejs/plugin-react-swc": "^3.7.0",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react-swc": "^4.2.2",
     "reactflow": "^11.11.4",
     "typescript": "^5.5.0",
     "vite": "^6.3.6",

--- a/apps/minimal-demo-graph/src/App.tsx
+++ b/apps/minimal-demo-graph/src/App.tsx
@@ -5,6 +5,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import type { ChangeEvent } from "react";
 import {
   GraphProvider,
   useGraphRuntime,
@@ -16,13 +17,13 @@ import {
   samples as graphSamples,
 } from "@vizij/node-graph-react";
 import type { GraphSpec, ValueJSON, ShapeJSON } from "@vizij/node-graph-wasm";
-import { readFileAsText, parseGraphSpecJSON } from "./utils/file";
 import {
   MinimalDemoChrome,
   MinimalDemoSection,
   minimalDemoTheme,
 } from "@vizij/minimal-demo-ui";
 import { cloneDeepSafe } from "@vizij/utils";
+import { readFileAsText, parseGraphSpecJSON } from "./utils/file";
 
 const cloneGraphSpec = (spec: GraphSpec): GraphSpec => {
   return cloneDeepSafe(spec);
@@ -500,7 +501,7 @@ function Controls({
   const [fileError, setFileError] = useState<string | null>(null);
   const selectValue = selectedSample ?? "__custom__";
 
-  const onFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+  const onFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
     setFileError(null);
     const f = e.target.files?.[0];
     if (!f) return;

--- a/apps/minimal-demo-orchestrator/package.json
+++ b/apps/minimal-demo-orchestrator/package.json
@@ -21,13 +21,13 @@
     "@vizij/minimal-demo-ui": "workspace:*",
     "@vizij/orchestrator-react": "workspace:*",
     "@vizij/utils": "workspace:*",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3"
   },
   "devDependencies": {
-    "@types/react": "^18.3.26",
-    "@types/react-dom": "^18.3.7",
-    "@vitejs/plugin-react-swc": "^3.7.0",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react-swc": "^4.2.2",
     "typescript": "^5.5.0",
     "vite": "^6.3.6",
     "prettier": "^3.4.2",

--- a/apps/minimal-demo-orchestrator/src/App.tsx
+++ b/apps/minimal-demo-orchestrator/src/App.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import type { CSSProperties, ChangeEvent } from "react";
 import {
   OrchestratorProvider,
   useOrchestrator,
@@ -220,7 +221,7 @@ function Editor({
   const [useMergedGraphs] = React.useState(false);
   const [mergeStrategy] = React.useState<"namespace" | "blend">("namespace");
   const [isSampleLoading, setIsSampleLoading] = React.useState(false);
-  const buttonStyle: React.CSSProperties = {
+  const buttonStyle: CSSProperties = {
     borderRadius: 6,
     border: `1px solid ${minimalDemoTheme.border}`,
     background: minimalDemoTheme.card,
@@ -457,7 +458,7 @@ function Editor({
   }, [step]);
 
   const handleFileChange = React.useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
+    (event: ChangeEvent<HTMLInputElement>) => {
       const file = event.target.files?.[0];
       if (!file) {
         return;
@@ -521,7 +522,7 @@ function Editor({
   const sampleSelectValue = selectedSample ?? "__custom__";
 
   const handleSampleSelect = React.useCallback(
-    async (event: React.ChangeEvent<HTMLSelectElement>) => {
+    async (event: ChangeEvent<HTMLSelectElement>) => {
       const id = event.target.value;
       if (!id || id === "__custom__" || id === selectedSample) {
         return;

--- a/apps/tutorial-agent-face/package.json
+++ b/apps/tutorial-agent-face/package.json
@@ -11,18 +11,18 @@
   },
   "dependencies": {
     "@google/genai": "^1.30.0",
-    "@react-three/drei": "^9.115.0",
-    "@react-three/fiber": "^8.17.10",
+    "@react-three/drei": "^10.7.7",
+    "@react-three/fiber": "^9.5.0",
     "@vizij/runtime-react": "workspace:*",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3",
     "three": "^0.170.0",
     "zustand": "^5.0.2"
   },
   "devDependencies": {
-    "@types/react": "^18.3.26",
-    "@types/react-dom": "^18.3.7",
-    "@vitejs/plugin-react-swc": "^3.7.0",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react-swc": "^4.2.2",
     "typescript": "^5.9.3",
     "vite": "^6.3.6"
   }

--- a/apps/tutorial-agent-face/src/FaceApp.tsx
+++ b/apps/tutorial-agent-face/src/FaceApp.tsx
@@ -17,7 +17,6 @@ import { useAgentFaceTools } from "./hooks/useAgentFaceTools";
 import { AudioManager } from "./utils/audioManager";
 import { LiveStatus } from "./phoneme-core";
 import { EmotionButtons } from "./components/EmotionButtons";
-
 import "./styles.css";
 
 const faceAssetUrl = "/assets/Quori_Live.glb";

--- a/apps/tutorial-agent-face/src/hooks/useAgentFaceTools.ts
+++ b/apps/tutorial-agent-face/src/hooks/useAgentFaceTools.ts
@@ -1,18 +1,17 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import {
+import type {
   FunctionCall,
   FunctionDeclaration,
   FunctionResponse,
-  Type,
-  type Tool,
 } from "@google/genai";
+import { Type, type Tool } from "@google/genai";
 import { useVizijRuntime } from "@vizij/runtime-react";
-import type { PoseHotkeyBinding } from "./usePoseHotkeys";
 import {
   canonicalEmotionName,
   isEmotionBinding,
   scoreEmotionBinding,
 } from "../utils/emotions";
+import type { PoseHotkeyBinding } from "./usePoseHotkeys";
 
 type AgentFaceToolsOptions = {
   enabled: boolean;

--- a/apps/tutorial-agent-face/src/hooks/useGeminiLive.ts
+++ b/apps/tutorial-agent-face/src/hooks/useGeminiLive.ts
@@ -1,14 +1,16 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import {
+import type {
   FunctionCall,
   FunctionResponse,
+  LiveServerMessage,
+} from "@google/genai";
+import {
   FunctionCallingConfigMode,
   GoogleGenAI,
-  LiveServerMessage,
   Modality,
   type ToolListUnion,
 } from "@google/genai";
-import { AudioManager } from "../utils/audioManager";
+import type { AudioManager } from "../utils/audioManager";
 import { LiveStatus, MODEL_NAME } from "../phoneme-core";
 
 export type GeminiLiveState = {

--- a/apps/tutorial-agent-face/src/hooks/useMouseGaze.ts
+++ b/apps/tutorial-agent-face/src/hooks/useMouseGaze.ts
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState, type RefObject } from "react";
+import { useEffect, useRef, useState } from "react";
+import type { RefObject } from "react";
 import { useVizijRuntime } from "@vizij/runtime-react";
 
 const STANDARD_PATHS = {

--- a/apps/tutorial-agent-face/src/hooks/useMouseGaze.ts
+++ b/apps/tutorial-agent-face/src/hooks/useMouseGaze.ts
@@ -15,7 +15,7 @@ function clamp(value: number, min = -1, max = 1) {
 }
 
 export type MouseGazeHandle = {
-  ref: RefObject<HTMLDivElement>;
+  ref: RefObject<HTMLDivElement | null>;
   isPointerActive: boolean;
 };
 

--- a/apps/tutorial-agent-face/src/hooks/useVisemeMouth.ts
+++ b/apps/tutorial-agent-face/src/hooks/useVisemeMouth.ts
@@ -10,7 +10,7 @@ import {
   type Phoneme,
   type PhonemeEvent,
 } from "../phoneme-core";
-import { AudioManager } from "../utils/audioManager";
+import type { AudioManager } from "../utils/audioManager";
 import { FACE_VISEME_SEGMENTS, mapPollyViseme } from "../visemeMapping";
 
 export function useVisemeMouth({

--- a/apps/tutorial-agent-face/src/hooks/useVolumeChin.ts
+++ b/apps/tutorial-agent-face/src/hooks/useVolumeChin.ts
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useVizijRuntime } from "@vizij/runtime-react";
 import type { FeatureFrame } from "../phoneme-core";
-import { AudioManager } from "../utils/audioManager";
+import type { AudioManager } from "../utils/audioManager";
 
 function sampleVolumeAtTime(
   frames: FeatureFrame[],

--- a/apps/tutorial-agent-face/src/phoneme-core/audioPhonemeScorer.ts
+++ b/apps/tutorial-agent-face/src/phoneme-core/audioPhonemeScorer.ts
@@ -1,5 +1,6 @@
-import { AudioFeatures } from "./types";
-import { PHONEMES, Phoneme } from "./phonemes";
+import type { AudioFeatures } from "./types";
+import type { Phoneme } from "./phonemes";
+import { PHONEMES } from "./phonemes";
 
 // Heuristic scoring -> softmax probability distribution over phonemes
 export function scorePhonemeDistribution(

--- a/apps/tutorial-agent-face/src/phoneme-core/g2p_en.ts
+++ b/apps/tutorial-agent-face/src/phoneme-core/g2p_en.ts
@@ -1,4 +1,4 @@
-import { Phoneme } from "./phonemes";
+import type { Phoneme } from "./phonemes";
 
 type Rule = {
   pattern: RegExp;

--- a/apps/tutorial-agent-face/src/phoneme-core/naiveSynthesis.ts
+++ b/apps/tutorial-agent-face/src/phoneme-core/naiveSynthesis.ts
@@ -1,5 +1,6 @@
-import { PhonemeProbFrame } from "./types";
-import { Phoneme, PHONEME_TO_VISEME, VisemeId } from "./phonemes";
+import type { PhonemeProbFrame } from "./types";
+import type { Phoneme, VisemeId } from "./phonemes";
+import { PHONEME_TO_VISEME } from "./phonemes";
 
 export interface SynthFrame {
   time: number;

--- a/apps/tutorial-agent-face/src/phoneme-core/pollyToLocalVisemes.ts
+++ b/apps/tutorial-agent-face/src/phoneme-core/pollyToLocalVisemes.ts
@@ -1,5 +1,6 @@
-import { VISEMES, VisemeType } from "./constants";
-import { PollyVisemeId } from "./pollyVisemes";
+import type { VisemeType } from "./constants";
+import { VISEMES } from "./constants";
+import type { PollyVisemeId } from "./pollyVisemes";
 
 export const POLLY_VISEME_TO_LOCAL: Record<PollyVisemeId, VisemeType> = {
   p: VISEMES.PP,

--- a/apps/tutorial-agent-face/src/phoneme-core/visemeAligner.ts
+++ b/apps/tutorial-agent-face/src/phoneme-core/visemeAligner.ts
@@ -1,11 +1,12 @@
 import type { FeatureFrame, PhonemeProbFrame, PhonemeEvent } from "./types";
 import { classifyViseme } from "./visemeClassifier";
-import { LOCAL_TO_POLLY_FALLBACK, PollyMouthShapeId } from "./mouthShapes";
+import type { PollyMouthShapeId } from "./mouthShapes";
+import { LOCAL_TO_POLLY_FALLBACK } from "./mouthShapes";
+import type { Phoneme } from "./phonemes";
 import {
   PHONEME_CLASS,
   PHONEME_DURATION_PRIORS,
   PHONEME_TO_VISEME,
-  Phoneme,
 } from "./phonemes";
 
 export interface AlignerConfig {

--- a/apps/tutorial-agent-face/src/phoneme-core/visemeClassifier.ts
+++ b/apps/tutorial-agent-face/src/phoneme-core/visemeClassifier.ts
@@ -1,7 +1,9 @@
-import { VISEMES, VisemeType } from "./constants";
+import type { VisemeType } from "./constants";
+import { VISEMES } from "./constants";
 import { wordToVisemes } from "./wordToViseme";
 import { POLLY_VISEME_TO_LOCAL } from "./pollyToLocalVisemes";
-import { POLLY_LABELS, PollyMouthShapeId } from "./mouthShapes";
+import type { PollyMouthShapeId } from "./mouthShapes";
+import { POLLY_LABELS } from "./mouthShapes";
 import type { AudioFeatures } from "./types";
 
 // Include silence by using PollyMouthShapeId instead of the narrower PollyVisemeId.

--- a/apps/tutorial-agent-face/src/utils/audioManager.ts
+++ b/apps/tutorial-agent-face/src/utils/audioManager.ts
@@ -79,8 +79,9 @@ export class AudioManager {
         },
       });
 
-      this.inputContext = new (window.AudioContext ||
-        (window as any).webkitAudioContext)({
+      this.inputContext = new (
+        window.AudioContext || (window as any).webkitAudioContext
+      )({
         sampleRate: INPUT_SAMPLE_RATE,
       });
 
@@ -117,8 +118,9 @@ export class AudioManager {
       await this.outputContext.close();
     }
 
-    this.outputContext = new (window.AudioContext ||
-      (window as any).webkitAudioContext)({
+    this.outputContext = new (
+      window.AudioContext || (window as any).webkitAudioContext
+    )({
       sampleRate: OUTPUT_SAMPLE_RATE,
     });
 

--- a/apps/tutorial-fullscreen-face/package.json
+++ b/apps/tutorial-fullscreen-face/package.json
@@ -10,18 +10,18 @@
     "lint": "pnpm exec eslint \"src/**/*.{ts,tsx}\""
   },
   "dependencies": {
-    "@react-three/drei": "^9.115.0",
-    "@react-three/fiber": "^8.17.10",
+    "@react-three/drei": "^10.7.7",
+    "@react-three/fiber": "^9.5.0",
     "@vizij/runtime-react": "workspace:*",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3",
     "three": "^0.170.0",
     "zustand": "^5.0.2"
   },
   "devDependencies": {
-    "@types/react": "^18.3.26",
-    "@types/react-dom": "^18.3.7",
-    "@vitejs/plugin-react-swc": "^3.7.0",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react-swc": "^4.2.2",
     "typescript": "^5.9.3",
     "vite": "^6.3.6"
   }

--- a/apps/tutorial-fullscreen-face/src/FaceApp.tsx
+++ b/apps/tutorial-fullscreen-face/src/FaceApp.tsx
@@ -7,7 +7,6 @@ import {
 } from "@vizij/runtime-react";
 import { useMouseGaze } from "./hooks/useMouseGaze";
 import { usePoseHotkeys, POSE_HOTKEY_ORDER } from "./hooks/usePoseHotkeys";
-
 import "./styles.css";
 
 const faceAssetUrl = "/assets/hugo_rigged.glb";

--- a/apps/tutorial-fullscreen-face/src/hooks/useMouseGaze.ts
+++ b/apps/tutorial-fullscreen-face/src/hooks/useMouseGaze.ts
@@ -12,7 +12,9 @@ function clamp(value: number, min = -1, max = 1) {
   return Math.min(Math.max(value, min), max);
 }
 
-export function useMouseGaze(enabled: boolean): RefObject<HTMLDivElement> {
+export function useMouseGaze(
+  enabled: boolean,
+): RefObject<HTMLDivElement | null> {
   const { setInput, faceId: runtimeFaceId } = useVizijRuntime();
   const faceId = (runtimeFaceId ?? "face").toLowerCase();
   const ref = useRef<HTMLDivElement>(null);

--- a/apps/tutorial-fullscreen-face/src/hooks/useMouseGaze.ts
+++ b/apps/tutorial-fullscreen-face/src/hooks/useMouseGaze.ts
@@ -1,4 +1,5 @@
-import { useEffect, useRef, type RefObject } from "react";
+import { useEffect, useRef } from "react";
+import type { RefObject } from "react";
 import { useVizijRuntime } from "@vizij/runtime-react";
 
 const STANDARD_PATHS = {

--- a/apps/tutorial-fullscreen-face/src/hooks/usePoseHotkeys.ts
+++ b/apps/tutorial-fullscreen-face/src/hooks/usePoseHotkeys.ts
@@ -115,7 +115,7 @@ export function usePoseHotkeys(
       animateValue(binding.path, { float: weight }, { duration: 2 });
     };
 
-    const handleKeyDown = (event: KeyboardEvent) => {
+    const handleKeyDown = (event: globalThis.KeyboardEvent) => {
       const binding = bindings.get(event.code);
       if (!binding) {
         return;
@@ -127,7 +127,7 @@ export function usePoseHotkeys(
       applyWeight(binding, 1);
     };
 
-    const handleKeyUp = (event: KeyboardEvent) => {
+    const handleKeyUp = (event: globalThis.KeyboardEvent) => {
       const binding = bindings.get(event.code);
       if (!binding) {
         return;

--- a/apps/vizij-authoring/package.json
+++ b/apps/vizij-authoring/package.json
@@ -24,13 +24,13 @@
     "@vizij/render": "workspace:*",
     "@vizij/utils": "workspace:*",
     "three": "^0.170.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3"
   },
   "devDependencies": {
-    "@types/react": "^18.3.26",
-    "@types/react-dom": "^18.3.7",
-    "@vitejs/plugin-react-swc": "^3.7.0",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react-swc": "^4.2.2",
     "prettier": "^3.4.2",
     "typescript": "^5.5.0",
     "vite": "^6.3.6",

--- a/apps/vizij-authoring/src/App.tsx
+++ b/apps/vizij-authoring/src/App.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useMemo, useState, useId } from "react";
+import type { ReactNode } from "react";
 import type { GraphSpec } from "@vizij/node-graph-wasm";
+import { useDialogQueue } from "@vizij/authoring-shared";
 import { ImportExportWorkbench } from "./components/app/ImportExportWorkbench";
 import { Viewer } from "./components/app/Viewer";
 import { WorkbenchNav } from "./components/app/WorkbenchNav";
@@ -8,7 +10,6 @@ import { PoseRigWorkbench } from "./poseRig/components";
 import { DEFAULT_NAMESPACE } from "./utils/constants";
 import { useVizijAssetLoader } from "./hooks/useVizijAssetLoader";
 import { usePoseGraphImport } from "./hooks/usePoseGraphImport";
-import { useDialogQueue } from "@vizij/authoring-shared";
 import { useBundleSynchronizer } from "./hooks/useBundleSynchronizer";
 import {
   WORKBENCH_OPTIONS,
@@ -29,7 +30,6 @@ import {
   type RiggingTab,
 } from "./state/AuthoringUiProvider";
 import { PoseRigProvider, usePoseRig } from "./state/PoseRigProvider";
-import type { ReactNode } from "react";
 import { Panel } from "./components/ui";
 import { RiggingTabs } from "./components/app/RiggingTabs";
 import { SceneRiggingSection } from "./components/scene-composer/SceneRiggingSection";

--- a/apps/vizij-authoring/src/__tests__/graphAuthoringSmoke.test.ts
+++ b/apps/vizij-authoring/src/__tests__/graphAuthoringSmoke.test.ts
@@ -1,6 +1,5 @@
 import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
-
 import type {
   AnimatableComponent,
   AnimatableValue,

--- a/apps/vizij-authoring/src/components/app/AssetLoaderPanel.tsx
+++ b/apps/vizij-authoring/src/components/app/AssetLoaderPanel.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent } from "react";
+import type { ChangeEvent } from "react";
 import { Button, Card, CardBody, Input } from "../ui";
 
 interface AssetLoaderPanelProps {

--- a/apps/vizij-authoring/src/components/app/GraphDiagnosticsPanel.tsx
+++ b/apps/vizij-authoring/src/components/app/GraphDiagnosticsPanel.tsx
@@ -1,11 +1,5 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type ChangeEvent,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { ChangeEvent } from "react";
 import {
   diffMachineReports,
   type MachineDiffEntry,

--- a/apps/vizij-authoring/src/components/app/GraphImportPanel.tsx
+++ b/apps/vizij-authoring/src/components/app/GraphImportPanel.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent } from "react";
+import type { ChangeEvent } from "react";
 import { Card, CardBody, Input, Chip } from "../ui";
 
 interface GraphImportPanelProps {

--- a/apps/vizij-authoring/src/components/app/ImportExportWorkbench.tsx
+++ b/apps/vizij-authoring/src/components/app/ImportExportWorkbench.tsx
@@ -4,14 +4,11 @@ import {
   useVizijStore,
   type LoadedVizijAsset,
 } from "@vizij/render";
-import { AssetLoaderPanel } from "./AssetLoaderPanel";
-import { GraphImportPanel } from "./GraphImportPanel";
-import { PoseRigImportPanel, PoseRigExportPanel } from "./PoseRigPanels";
-import { ExportPanel } from "./ExportPanel";
-import { RigGraphExportPanel } from "./RigGraphExportPanel";
-import type { VizijBundleSummary } from "./VizijBundleSummaryPanel";
-import { VizijBundleAuditPanel } from "./VizijBundleAuditPanel";
-import { RobotDataAuditPanel } from "./RobotDataAuditPanel";
+import { useDialogQueue, readJsonFile } from "@vizij/authoring-shared";
+import { compileIrGraph, type IrGraph } from "@vizij/node-graph-authoring";
+import type { GraphSpec } from "@vizij/node-graph-wasm";
+import type { VizijBundleExtension } from "@vizij/render";
+import { normalizeGraphSpec } from "@vizij/node-graph-wasm";
 import { useRobotDataAuditRunner } from "../../hooks/useRobotDataAuditRunner";
 import { useBundleAudit } from "../../hooks/useBundleAudit";
 import {
@@ -23,10 +20,6 @@ import {
   useGraphRuntime,
 } from "../../state/RigControllerProvider";
 import { DEFAULT_NAMESPACE } from "../../utils/constants";
-import { useDialogQueue, readJsonFile } from "@vizij/authoring-shared";
-import { compileIrGraph, type IrGraph } from "@vizij/node-graph-authoring";
-import type { GraphSpec } from "@vizij/node-graph-wasm";
-import type { VizijBundleExtension } from "@vizij/render";
 import { cloneSerializable } from "../../utils/serialization";
 import { useAuthoringFileNames } from "../../hooks/useAuthoringFileNames";
 import { useVizijExport } from "../../hooks/useVizijExport";
@@ -36,11 +29,18 @@ import {
   prepareSpecForImport,
   remapGraphSpecFace,
 } from "../../utils/graphImport";
-import { normalizeGraphSpec } from "@vizij/node-graph-wasm";
-import { GraphDiagnosticsPanel } from "./GraphDiagnosticsPanel";
 import { InstructionCallout } from "../common/InstructionCallout";
 import { SidebarSection } from "../common/SidebarSection";
 import { Tabs } from "../ui";
+import { GraphDiagnosticsPanel } from "./GraphDiagnosticsPanel";
+import { RobotDataAuditPanel } from "./RobotDataAuditPanel";
+import { VizijBundleAuditPanel } from "./VizijBundleAuditPanel";
+import type { VizijBundleSummary } from "./VizijBundleSummaryPanel";
+import { RigGraphExportPanel } from "./RigGraphExportPanel";
+import { ExportPanel } from "./ExportPanel";
+import { PoseRigImportPanel, PoseRigExportPanel } from "./PoseRigPanels";
+import { GraphImportPanel } from "./GraphImportPanel";
+import { AssetLoaderPanel } from "./AssetLoaderPanel";
 
 interface ImportExportWorkbenchProps {
   isLoading: boolean;

--- a/apps/vizij-authoring/src/components/app/PoseRigPanels.tsx
+++ b/apps/vizij-authoring/src/components/app/PoseRigPanels.tsx
@@ -1,4 +1,5 @@
-import { ChangeEvent, useId, useState } from "react";
+import { useId, useState } from "react";
+import type { ChangeEvent } from "react";
 import { Button, Card, CardHeader, CardBody, Input, Chip } from "../ui";
 
 interface PoseRigImportPanelProps {

--- a/apps/vizij-authoring/src/components/app/Viewer.tsx
+++ b/apps/vizij-authoring/src/components/app/Viewer.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useId, useMemo, useState } from "react";
 import { Vizij } from "@vizij/render";
 import { Button, Switch, Chip } from "../ui";
+
 interface ViewerProps {
   rootId: string | null;
   statusMessage: string;

--- a/apps/vizij-authoring/src/components/app/VizijBundleAuditPanel.tsx
+++ b/apps/vizij-authoring/src/components/app/VizijBundleAuditPanel.tsx
@@ -1,5 +1,4 @@
 import type { BundleGraphAuditEntry } from "../../utils/bundleAudit";
-
 import {
   Button,
   Card,

--- a/apps/vizij-authoring/src/components/binding/BindingEditor.tsx
+++ b/apps/vizij-authoring/src/components/binding/BindingEditor.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState, useCallback, useEffect, useRef } from "react";
+import type { ReactNode } from "react";
 import { requireNodeSignature } from "@vizij/node-graph-wasm/metadata";
 import {
   SELF_BINDING_ID,
@@ -25,9 +26,9 @@ import {
   type FilterableSelectOption,
 } from "../common/FilterableSelect";
 import { Button, CollapsibleRow } from "../ui";
+import { formatRigPathLabel } from "../../utils/rigPaths";
 import { createSlotKey, getSlotIdentifier } from "./slotKeys";
 import { useSlotDiagnosticsResolver } from "./SlotDiagnosticsContext";
-import { formatRigPathLabel } from "../../utils/rigPaths";
 import "./binding-editor.css";
 
 type BindingFeatureFlags = {
@@ -384,8 +385,8 @@ interface BindingEditorProps {
     suggestedPath?: string,
   ) => StandardRigInput | null;
   onResetBinding?: (targetId: string) => void;
-  headerActions?: React.ReactNode;
-  children?: React.ReactNode;
+  headerActions?: ReactNode;
+  children?: ReactNode;
   expandable?: boolean;
   defaultExpanded?: boolean;
   expanded?: boolean;

--- a/apps/vizij-authoring/src/components/binding/SlotDiagnosticsContext.tsx
+++ b/apps/vizij-authoring/src/components/binding/SlotDiagnosticsContext.tsx
@@ -1,10 +1,5 @@
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useMemo,
-  type ReactNode,
-} from "react";
+import { createContext, useCallback, useContext, useMemo } from "react";
+import type { ReactNode } from "react";
 import type { MachineReport } from "@vizij/node-graph-authoring";
 import { createSlotKey } from "./slotKeys";
 

--- a/apps/vizij-authoring/src/components/binding/bindingNormalization.test.ts
+++ b/apps/vizij-authoring/src/components/binding/bindingNormalization.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-
 import {
   buildPiecewiseNormalizeSnippet,
   formatScalarLiteral,

--- a/apps/vizij-authoring/src/components/binding/panelUtils.ts
+++ b/apps/vizij-authoring/src/components/binding/panelUtils.ts
@@ -197,11 +197,9 @@ export function isAnimatableReferencedElsewhere(
     return Object.entries(renderable.features).some(([featureKey, feature]) =>
       Boolean(
         feature &&
-          feature.animated &&
-          feature.value === animatableId &&
-          !(
-            renderable.id === targetElementId && featureKey === targetFeatureKey
-          ),
+        feature.animated &&
+        feature.value === animatableId &&
+        !(renderable.id === targetElementId && featureKey === targetFeatureKey),
       ),
     );
   });

--- a/apps/vizij-authoring/src/components/common/FilterableSelect.tsx
+++ b/apps/vizij-authoring/src/components/common/FilterableSelect.tsx
@@ -1,12 +1,5 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type KeyboardEvent,
-  type ReactNode,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { KeyboardEvent, ReactNode } from "react";
 
 export interface FilterableSelectOption {
   value: string | null;
@@ -113,7 +106,7 @@ export function FilterableSelect({
   }, []);
 
   const handleDocumentClick = useCallback(
-    (event: MouseEvent) => {
+    (event: globalThis.MouseEvent) => {
       if (!open) {
         return;
       }

--- a/apps/vizij-authoring/src/components/common/InstructionCallout.tsx
+++ b/apps/vizij-authoring/src/components/common/InstructionCallout.tsx
@@ -1,4 +1,5 @@
-import { useId, useState, type ReactNode } from "react";
+import { useId, useState } from "react";
+import type { ReactNode } from "react";
 
 interface InstructionCalloutProps {
   label: string;

--- a/apps/vizij-authoring/src/components/common/SidebarSection.tsx
+++ b/apps/vizij-authoring/src/components/common/SidebarSection.tsx
@@ -1,4 +1,5 @@
-import { useId, useState, type ReactNode } from "react";
+import { useId, useState } from "react";
+import type { ReactNode } from "react";
 
 type SidebarInstructions = {
   label: string;

--- a/apps/vizij-authoring/src/components/discrepancy/DiscrepancyWizard.tsx
+++ b/apps/vizij-authoring/src/components/discrepancy/DiscrepancyWizard.tsx
@@ -124,7 +124,7 @@ export function DiscrepancyWizard({
   ]);
 
   const handleKeydown = useCallback(
-    (event: KeyboardEvent) => {
+    (event: globalThis.KeyboardEvent) => {
       if (event.key === "Escape") {
         logDebug("escape pressed – cancel import");
         onResolve({ accepted: false });

--- a/apps/vizij-authoring/src/components/inspector/DriverBindingSection.tsx
+++ b/apps/vizij-authoring/src/components/inspector/DriverBindingSection.tsx
@@ -1,25 +1,19 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { ChangeEvent } from "react";
+import type { StandardRigInput } from "@vizij/utils";
 import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-  type ChangeEvent,
-} from "react";
+  type AnimatableBinding,
+  type BindingValueType,
+} from "@vizij/node-graph-authoring";
 import type { SceneObjectNode } from "../../scene/sceneGraph";
 import {
   useBindingAuthoring,
   useGraphRuntime,
 } from "../../state/RigControllerProvider";
-import type { StandardRigInput } from "@vizij/utils";
 import { BindingEditor } from "../binding";
-import {
-  type AnimatableBinding,
-  type BindingValueType,
-} from "@vizij/node-graph-authoring";
-import { collectDriversForNode } from "./DriverPanel";
 import { promptDialog, alertDialog } from "../../utils/dialogs";
-
 import { Button, Card, CardHeader, CardBody } from "../ui";
+import { collectDriversForNode } from "./DriverPanel";
 
 interface DriverBindingSectionProps {
   node: SceneObjectNode;

--- a/apps/vizij-authoring/src/components/inspector/DriverPanel.tsx
+++ b/apps/vizij-authoring/src/components/inspector/DriverPanel.tsx
@@ -1,4 +1,6 @@
 import React, { useCallback, useMemo } from "react";
+import { SELF_BINDING_ID, type StandardRigInput } from "@vizij/utils";
+import type { BindingMap } from "@vizij/node-graph-authoring";
 import {
   useBindingAuthoring,
   useGraphRuntime,
@@ -7,8 +9,6 @@ import type {
   SceneObjectNode,
   SceneObjectFeature,
 } from "../../scene/sceneGraph";
-import { SELF_BINDING_ID, type StandardRigInput } from "@vizij/utils";
-import type { BindingMap } from "@vizij/node-graph-authoring";
 import { promptDialog, alertDialog } from "../../utils/dialogs";
 import { Button, CollapsibleGroup, CollapsibleRow } from "../ui";
 

--- a/apps/vizij-authoring/src/components/inspector/FeatureList.tsx
+++ b/apps/vizij-authoring/src/components/inspector/FeatureList.tsx
@@ -1,4 +1,12 @@
-import React, { useCallback, useMemo, type ReactNode } from "react";
+import React, { useCallback, useMemo } from "react";
+import type { ReactNode } from "react";
+import type { BindingMap, BindingValueType } from "@vizij/node-graph-authoring";
+import {
+  SELF_BINDING_ID,
+  type AnimatableValue,
+  type RawValue,
+  type StandardRigInput,
+} from "@vizij/utils";
 import { useSceneComposer } from "../../scene/useSceneComposer";
 import { useBindingAuthoring } from "../../state/RigControllerProvider";
 import {
@@ -12,13 +20,6 @@ import type {
   SceneObjectFeature,
   SceneFeatureComponent,
 } from "../../scene/sceneGraph";
-import type { BindingMap, BindingValueType } from "@vizij/node-graph-authoring";
-import {
-  SELF_BINDING_ID,
-  type AnimatableValue,
-  type RawValue,
-  type StandardRigInput,
-} from "@vizij/utils";
 import { Button, CollapsibleGroup, CollapsibleRow, Input } from "../ui";
 import "./feature-list.css";
 

--- a/apps/vizij-authoring/src/components/inspector/ObjectHeader.tsx
+++ b/apps/vizij-authoring/src/components/inspector/ObjectHeader.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
+import type { KeyboardEvent } from "react";
 import { Badge } from "../ui";
 
 interface ObjectHeaderProps {
@@ -33,7 +34,7 @@ export function ObjectHeader({
   }, [draftName, name, onNameChange]);
 
   const handleKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLInputElement>) => {
+    (event: KeyboardEvent<HTMLInputElement>) => {
       if (event.key === "Enter") {
         event.preventDefault();
         commitName();

--- a/apps/vizij-authoring/src/components/inspector/ObjectInspector.tsx
+++ b/apps/vizij-authoring/src/components/inspector/ObjectInspector.tsx
@@ -4,15 +4,15 @@ import {
   useSelectionStore,
   useBindingAuthoring,
 } from "../../state/RigControllerProvider";
+import { InstructionCallout } from "../common/InstructionCallout";
+import { Panel, Tabs } from "../ui";
+import type { SceneObjectNode } from "../../scene/sceneGraph";
+import { Button } from "../ui/Button";
 import { ObjectHeader } from "./ObjectHeader";
 import { FeatureList } from "./FeatureList";
 import { DriverPanel } from "./DriverPanel";
 import { DriverBindingSection } from "./DriverBindingSection";
-import { InstructionCallout } from "../common/InstructionCallout";
 import { MaterialEditor } from "./MaterialEditor";
-import { Panel, Tabs } from "../ui";
-import type { SceneObjectNode } from "../../scene/sceneGraph";
-import { Button } from "../ui/Button";
 
 type InspectorTab = "drivers" | "features" | "bindings";
 

--- a/apps/vizij-authoring/src/components/scene-composer/SceneHierarchyPanel.tsx
+++ b/apps/vizij-authoring/src/components/scene-composer/SceneHierarchyPanel.tsx
@@ -1,12 +1,13 @@
 import { useMemo, useState, useEffect, useCallback } from "react";
+import type { JSX } from "react/jsx-runtime";
 import type { SceneObjectNode } from "../../scene/sceneGraph";
 import { useSceneComposer } from "../../scene/useSceneComposer";
 import { useSelectionStore } from "../../state/RigControllerProvider";
 import { DEFAULT_NAMESPACE } from "../../utils/constants";
-import { useHierarchyTreeState } from "./useHierarchyTreeState";
-import { filterHierarchyNodes } from "./hierarchyFilters";
 import { Panel } from "../ui";
 import { Button } from "../ui";
+import { useHierarchyTreeState } from "./useHierarchyTreeState";
+import { filterHierarchyNodes } from "./hierarchyFilters";
 
 interface SceneHierarchyPanelProps {
   allowEditActions?: boolean;
@@ -143,7 +144,7 @@ export function SceneHierarchyPanel({
     : rootNodes.length > 0;
 
   const renderSubtree = useCallback(
-    (node: SceneObjectNode, depth: number): React.JSX.Element | null => {
+    (node: SceneObjectNode, depth: number): JSX.Element | null => {
       if (!isNodeVisible(node.id) && !node.childIds.some(isNodeVisible)) {
         return null;
       }

--- a/apps/vizij-authoring/src/components/scene-composer/SceneHierarchyPanel.tsx
+++ b/apps/vizij-authoring/src/components/scene-composer/SceneHierarchyPanel.tsx
@@ -143,7 +143,7 @@ export function SceneHierarchyPanel({
     : rootNodes.length > 0;
 
   const renderSubtree = useCallback(
-    (node: SceneObjectNode, depth: number): JSX.Element | null => {
+    (node: SceneObjectNode, depth: number): React.JSX.Element | null => {
       if (!isNodeVisible(node.id) && !node.childIds.some(isNodeVisible)) {
         return null;
       }

--- a/apps/vizij-authoring/src/components/scene-composer/SceneRiggingSection.tsx
+++ b/apps/vizij-authoring/src/components/scene-composer/SceneRiggingSection.tsx
@@ -1,6 +1,6 @@
-import { SceneHierarchyPanel } from "./SceneHierarchyPanel";
 import { ObjectInspector } from "../inspector/ObjectInspector";
 import { StandardInputCoveragePanel } from "../app/StandardInputCoveragePanel";
+import { SceneHierarchyPanel } from "./SceneHierarchyPanel";
 
 interface SceneRiggingSectionProps {
   showCoverage?: boolean;

--- a/apps/vizij-authoring/src/components/scene-composer/useHierarchyTreeState.test.tsx
+++ b/apps/vizij-authoring/src/components/scene-composer/useHierarchyTreeState.test.tsx
@@ -1,8 +1,6 @@
+import React, { act } from "react";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
-import React from "react";
-import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-
 import { useHierarchyTreeState } from "./useHierarchyTreeState";
 
 type HookResult = ReturnType<typeof useHierarchyTreeState>;

--- a/apps/vizij-authoring/src/components/ui/Button.tsx
+++ b/apps/vizij-authoring/src/components/ui/Button.tsx
@@ -1,7 +1,8 @@
 import React, { forwardRef } from "react";
+import type { ButtonHTMLAttributes } from "react";
 import "./button.css";
 
-export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: "primary" | "secondary" | "subtle" | "danger" | "ghost";
   size?: "sm" | "md" | "lg";
   pill?: boolean;

--- a/apps/vizij-authoring/src/components/ui/Button.tsx
+++ b/apps/vizij-authoring/src/components/ui/Button.tsx
@@ -1,8 +1,7 @@
 import React, { forwardRef } from "react";
 import "./button.css";
 
-export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: "primary" | "secondary" | "subtle" | "danger" | "ghost";
   size?: "sm" | "md" | "lg";
   pill?: boolean;

--- a/apps/vizij-authoring/src/components/ui/Card.tsx
+++ b/apps/vizij-authoring/src/components/ui/Card.tsx
@@ -1,6 +1,7 @@
 import React, { forwardRef } from "react";
+import type { HTMLAttributes } from "react";
 
-export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface CardProps extends HTMLAttributes<HTMLDivElement> {
   compact?: boolean;
 }
 
@@ -28,7 +29,7 @@ export const CardHeader = ({
   className,
   children,
   ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
+}: HTMLAttributes<HTMLDivElement>) => (
   <div className={`asset-card__header ${className || ""}`} {...props}>
     {children}
   </div>
@@ -38,7 +39,7 @@ export const CardTitle = ({
   className,
   children,
   ...props
-}: React.HTMLAttributes<HTMLHeadingElement>) => (
+}: HTMLAttributes<HTMLHeadingElement>) => (
   <h3 className={`asset-card__title ${className || ""}`} {...props}>
     {children}
   </h3>
@@ -48,7 +49,7 @@ export const CardDescription = ({
   className,
   children,
   ...props
-}: React.HTMLAttributes<HTMLParagraphElement>) => (
+}: HTMLAttributes<HTMLParagraphElement>) => (
   <p className={`asset-card__description ${className || ""}`} {...props}>
     {children}
   </p>
@@ -59,7 +60,7 @@ export const CardBody = ({
   children,
   compact,
   ...props
-}: React.HTMLAttributes<HTMLDivElement> & { compact?: boolean }) => (
+}: HTMLAttributes<HTMLDivElement> & { compact?: boolean }) => (
   <div
     className={`asset-card__body ${compact ? "asset-card__body--compact" : ""} ${className || ""}`}
     {...props}

--- a/apps/vizij-authoring/src/components/ui/CollapsibleGroup.tsx
+++ b/apps/vizij-authoring/src/components/ui/CollapsibleGroup.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useCallback, type ReactNode } from "react";
+import { useState, useCallback } from "react";
+import type { ReactNode, KeyboardEvent, MouseEvent } from "react";
 
 export interface CollapsibleGroupProps {
   title: string;
@@ -33,7 +34,7 @@ export function CollapsibleGroup({
   }, []);
 
   const handleKeyDown = useCallback(
-    (event: React.KeyboardEvent) => {
+    (event: KeyboardEvent) => {
       if (shouldIgnoreInteraction(event.target)) {
         return;
       }
@@ -46,7 +47,7 @@ export function CollapsibleGroup({
   );
 
   const handleHeaderClick = useCallback(
-    (event: React.MouseEvent) => {
+    (event: MouseEvent) => {
       if (shouldIgnoreInteraction(event.target)) {
         return;
       }

--- a/apps/vizij-authoring/src/components/ui/CollapsibleRow.tsx
+++ b/apps/vizij-authoring/src/components/ui/CollapsibleRow.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useCallback, type ReactNode } from "react";
+import { useState, useCallback } from "react";
+import type { ReactNode, KeyboardEvent, MouseEvent } from "react";
 import { RowSlider } from "./RowSlider";
 
 export interface CollapsibleRowProps {
@@ -48,7 +49,7 @@ export function CollapsibleRow({
   }, []);
 
   const handleHeaderClick = useCallback(
-    (event: React.MouseEvent) => {
+    (event: MouseEvent) => {
       if (shouldIgnoreInteraction(event.target)) {
         return;
       }
@@ -58,7 +59,7 @@ export function CollapsibleRow({
   );
 
   const handleKeyDown = useCallback(
-    (event: React.KeyboardEvent) => {
+    (event: KeyboardEvent) => {
       if (!expandedContent || disabled) return;
       if (shouldIgnoreInteraction(event.target)) {
         return;

--- a/apps/vizij-authoring/src/components/ui/FieldRow.tsx
+++ b/apps/vizij-authoring/src/components/ui/FieldRow.tsx
@@ -19,10 +19,13 @@ export function FieldRow({
   const shouldInlineLabel = renderLabelInControl && isValidElement(control);
 
   const controlWithLabel = shouldInlineLabel
-    ? cloneElement(control, {
-        label: (control.props as { label?: ReactNode }).label ?? label,
-        hint: (control.props as { hint?: ReactNode }).hint ?? hint,
-      })
+    ? cloneElement(
+        control as React.ReactElement<{ label?: ReactNode; hint?: ReactNode }>,
+        {
+          label: (control.props as { label?: ReactNode }).label ?? label,
+          hint: (control.props as { hint?: ReactNode }).hint ?? hint,
+        },
+      )
     : control;
 
   return (

--- a/apps/vizij-authoring/src/components/ui/FieldRow.tsx
+++ b/apps/vizij-authoring/src/components/ui/FieldRow.tsx
@@ -1,4 +1,5 @@
-import { cloneElement, isValidElement, type ReactNode } from "react";
+import { cloneElement, isValidElement } from "react";
+import type { ReactNode, ReactElement } from "react";
 import "./fieldrow.css";
 
 interface FieldRowProps {
@@ -20,7 +21,7 @@ export function FieldRow({
 
   const controlWithLabel = shouldInlineLabel
     ? cloneElement(
-        control as React.ReactElement<{ label?: ReactNode; hint?: ReactNode }>,
+        control as ReactElement<{ label?: ReactNode; hint?: ReactNode }>,
         {
           label: (control.props as { label?: ReactNode }).label ?? label,
           hint: (control.props as { hint?: ReactNode }).hint ?? hint,

--- a/apps/vizij-authoring/src/components/ui/Input.tsx
+++ b/apps/vizij-authoring/src/components/ui/Input.tsx
@@ -1,6 +1,7 @@
-import React, { forwardRef } from "react";
+import { forwardRef } from "react";
+import type { InputHTMLAttributes } from "react";
 
-export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+export type InputProps = InputHTMLAttributes<HTMLInputElement>;
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(
   ({ className, ...props }, ref) => {

--- a/apps/vizij-authoring/src/components/ui/ListRow.tsx
+++ b/apps/vizij-authoring/src/components/ui/ListRow.tsx
@@ -1,8 +1,10 @@
 import type { ReactNode, HTMLAttributes } from "react";
 import "./listrow.css";
 
-interface ListRowProps
-  extends Omit<HTMLAttributes<HTMLDivElement>, "title" | "children"> {
+interface ListRowProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  "title" | "children"
+> {
   title: ReactNode;
   meta?: ReactNode;
   actions?: ReactNode;

--- a/apps/vizij-authoring/src/components/ui/Panel.tsx
+++ b/apps/vizij-authoring/src/components/ui/Panel.tsx
@@ -1,27 +1,23 @@
 import type {
   ComponentPropsWithoutRef,
-  ElementType,
   PropsWithChildren,
   ReactNode,
 } from "react";
 import { Badge } from "./Badge";
 import "./panel.css";
 
-type ElementTag = keyof Pick<
-  JSX.IntrinsicElements,
-  "div" | "section" | "article"
->;
-
-type BaseProps<TTag extends ElementTag> = {
-  as?: TTag;
+type BaseProps = {
+  as?: React.ElementType;
   title?: ReactNode;
   description?: ReactNode;
   badge?: ReactNode;
   actions?: ReactNode;
 };
 
-export type PanelProps<TTag extends ElementTag = "section"> = PropsWithChildren<
-  BaseProps<TTag> &
+export type PanelProps<
+  TTag extends keyof React.JSX.IntrinsicElements = "section",
+> = PropsWithChildren<
+  BaseProps &
     Omit<
       ComponentPropsWithoutRef<TTag>,
       "as" | "children" | "title" | "description" | "badge" | "actions"
@@ -32,7 +28,9 @@ export type PanelProps<TTag extends ElementTag = "section"> = PropsWithChildren<
  * Standard panel wrapper that applies the shared sidebar panel styling and
  * handles a consistent header layout (title + description + badge/actions).
  */
-export function Panel<TTag extends ElementTag = "section">({
+export function Panel<
+  TTag extends keyof React.JSX.IntrinsicElements = "section",
+>({
   as,
   title,
   description,
@@ -42,7 +40,7 @@ export function Panel<TTag extends ElementTag = "section">({
   children,
   ...rest
 }: PanelProps<TTag>) {
-  const Component = (as ?? "section") as ElementType;
+  const Component = (as ?? "section") as keyof React.JSX.IntrinsicElements;
   const hasHeader = Boolean(title || description || badge || actions);
 
   const renderBadge = () => {
@@ -54,8 +52,14 @@ export function Panel<TTag extends ElementTag = "section">({
     );
   };
 
+  if (Component !== "section") {
+    console.warn(
+      "[Panel] custom `as` tags are temporarily disabled; falling back to <section>.",
+    );
+  }
+
   return (
-    <Component
+    <section
       className={["sidebar__panel", className].filter(Boolean).join(" ")}
       {...rest}
     >
@@ -76,7 +80,7 @@ export function Panel<TTag extends ElementTag = "section">({
         </header>
       )}
       {children}
-    </Component>
+    </section>
   );
 }
 

--- a/apps/vizij-authoring/src/components/ui/Panel.tsx
+++ b/apps/vizij-authoring/src/components/ui/Panel.tsx
@@ -2,35 +2,34 @@ import type {
   ComponentPropsWithoutRef,
   PropsWithChildren,
   ReactNode,
+  ElementType,
 } from "react";
+import type { JSX } from "react/jsx-runtime";
 import { Badge } from "./Badge";
 import "./panel.css";
 
 type BaseProps = {
-  as?: React.ElementType;
+  as?: ElementType;
   title?: ReactNode;
   description?: ReactNode;
   badge?: ReactNode;
   actions?: ReactNode;
 };
 
-export type PanelProps<
-  TTag extends keyof React.JSX.IntrinsicElements = "section",
-> = PropsWithChildren<
-  BaseProps &
-    Omit<
-      ComponentPropsWithoutRef<TTag>,
-      "as" | "children" | "title" | "description" | "badge" | "actions"
-    >
->;
+export type PanelProps<TTag extends keyof JSX.IntrinsicElements = "section"> =
+  PropsWithChildren<
+    BaseProps &
+      Omit<
+        ComponentPropsWithoutRef<TTag>,
+        "as" | "children" | "title" | "description" | "badge" | "actions"
+      >
+  >;
 
 /**
  * Standard panel wrapper that applies the shared sidebar panel styling and
  * handles a consistent header layout (title + description + badge/actions).
  */
-export function Panel<
-  TTag extends keyof React.JSX.IntrinsicElements = "section",
->({
+export function Panel<TTag extends keyof JSX.IntrinsicElements = "section">({
   as,
   title,
   description,
@@ -40,7 +39,7 @@ export function Panel<
   children,
   ...rest
 }: PanelProps<TTag>) {
-  const Component = (as ?? "section") as keyof React.JSX.IntrinsicElements;
+  const Component = (as ?? "section") as keyof JSX.IntrinsicElements;
   const hasHeader = Boolean(title || description || badge || actions);
 
   const renderBadge = () => {

--- a/apps/vizij-authoring/src/components/ui/RowSlider.tsx
+++ b/apps/vizij-authoring/src/components/ui/RowSlider.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
+import type { ChangeEvent } from "react";
 import { Input } from "./Input";
 
 export interface RowSliderProps {
@@ -28,7 +29,7 @@ export function RowSlider({
     setInputValue(String(value));
   }, [value]);
 
-  const handleRangeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleRangeChange = (event: ChangeEvent<HTMLInputElement>) => {
     const newValue = parseFloat(event.target.value);
     if (Number.isFinite(newValue)) {
       onChange(newValue);
@@ -36,7 +37,7 @@ export function RowSlider({
     }
   };
 
-  const handleNumberChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleNumberChange = (event: ChangeEvent<HTMLInputElement>) => {
     const rawValue = event.target.value;
     setInputValue(rawValue);
     const newValue = parseFloat(rawValue);

--- a/apps/vizij-authoring/src/components/ui/Switch.tsx
+++ b/apps/vizij-authoring/src/components/ui/Switch.tsx
@@ -1,8 +1,10 @@
 import type { InputHTMLAttributes } from "react";
 import "./switch.css";
 
-export interface SwitchProps
-  extends Omit<InputHTMLAttributes<HTMLInputElement>, "type" | "size"> {
+export interface SwitchProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  "type" | "size"
+> {
   label?: React.ReactNode;
   hint?: React.ReactNode;
   size?: "sm" | "md";

--- a/apps/vizij-authoring/src/components/ui/Switch.tsx
+++ b/apps/vizij-authoring/src/components/ui/Switch.tsx
@@ -1,12 +1,12 @@
-import type { InputHTMLAttributes } from "react";
+import type { InputHTMLAttributes, ReactNode } from "react";
 import "./switch.css";
 
 export interface SwitchProps extends Omit<
   InputHTMLAttributes<HTMLInputElement>,
   "type" | "size"
 > {
-  label?: React.ReactNode;
-  hint?: React.ReactNode;
+  label?: ReactNode;
+  hint?: ReactNode;
   size?: "sm" | "md";
 }
 

--- a/apps/vizij-authoring/src/components/ui/Tabs.tsx
+++ b/apps/vizij-authoring/src/components/ui/Tabs.tsx
@@ -1,20 +1,21 @@
+import type { ReactNode } from "react";
 import "./tabs.css";
 
 export type TabId = string;
 
 export interface TabItem {
   id: TabId;
-  label: React.ReactNode;
-  description?: React.ReactNode;
+  label: ReactNode;
+  description?: ReactNode;
   disabled?: boolean;
-  badge?: React.ReactNode;
+  badge?: ReactNode;
 }
 
 export interface TabsProps {
   items: readonly TabItem[];
   value: TabId;
   onValueChange: (next: TabId) => void;
-  renderPanel: (id: TabId) => React.ReactNode;
+  renderPanel: (id: TabId) => ReactNode;
   className?: string;
   listClassName?: string;
   panelClassName?: string;

--- a/apps/vizij-authoring/src/hooks/__tests__/shapeRenaming.test.ts
+++ b/apps/vizij-authoring/src/hooks/__tests__/shapeRenaming.test.ts
@@ -4,12 +4,12 @@ import {
   normalizeStandardRigInputPath,
 } from "@vizij/utils";
 import type { StandardRigInput, AnimatableComponent } from "@vizij/utils";
-import type { AutoInputState } from "../../types/autoInputs";
 import type {
   BindingMap,
   InputBindingMap,
   StandardInputValues,
 } from "@vizij/node-graph-authoring";
+import type { AutoInputState } from "../../types/autoInputs";
 import { applyShapeInputRename } from "../shapeRenaming";
 
 function createSetter<T>(

--- a/apps/vizij-authoring/src/hooks/__tests__/useDialogQueue.test.tsx
+++ b/apps/vizij-authoring/src/hooks/__tests__/useDialogQueue.test.tsx
@@ -1,7 +1,6 @@
 import { act, useEffect } from "react";
 import { createRoot } from "react-dom/client";
 import { describe, expect, it, vi } from "vitest";
-
 import { useDialogQueue } from "../useDialogQueue";
 import * as dialogs from "../../utils/dialogs";
 

--- a/apps/vizij-authoring/src/hooks/__tests__/useFeatureLabels.test.tsx
+++ b/apps/vizij-authoring/src/hooks/__tests__/useFeatureLabels.test.tsx
@@ -1,7 +1,6 @@
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { describe, expect, it } from "vitest";
-
 import { useFeatureLabels } from "../useFeatureLabels";
 
 declare global {

--- a/apps/vizij-authoring/src/hooks/graphRuntime.ts
+++ b/apps/vizij-authoring/src/hooks/graphRuntime.ts
@@ -1,5 +1,4 @@
 import type { MutableRefObject } from "react";
-
 import {
   valueAsColorRgba,
   valueAsNumber,

--- a/apps/vizij-authoring/src/hooks/shapeRenaming.ts
+++ b/apps/vizij-authoring/src/hooks/shapeRenaming.ts
@@ -1,5 +1,4 @@
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
-
 import {
   bindingFromDefinition,
   bindingTargetFromComponent,
@@ -21,7 +20,6 @@ import {
   type RigBindingDefinition,
   type StandardRigInput,
 } from "@vizij/utils";
-
 import type { PersistedAutoStandardInput } from "../rig/persistence";
 import type { AutoInputState } from "../types/autoInputs";
 

--- a/apps/vizij-authoring/src/hooks/standardInputLinks.ts
+++ b/apps/vizij-authoring/src/hooks/standardInputLinks.ts
@@ -1,5 +1,4 @@
 import type { MutableRefObject } from "react";
-
 import {
   addBindingSlot,
   bindingTargetFromInput,

--- a/apps/vizij-authoring/src/hooks/standardInputMutations.ts
+++ b/apps/vizij-authoring/src/hooks/standardInputMutations.ts
@@ -1,5 +1,4 @@
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
-
 import type { StandardInputValues } from "@vizij/node-graph-authoring";
 import {
   createStandardRigInput,
@@ -9,7 +8,6 @@ import {
   normalizeStandardRigInputPath,
   type StandardRigInput,
 } from "@vizij/utils";
-
 import type { PersistedAutoStandardInput } from "../rig/persistence";
 import { alertDialog } from "../utils/dialogs";
 import type { AutoInputState } from "../types/autoInputs";

--- a/apps/vizij-authoring/src/hooks/useBindingManager.ts
+++ b/apps/vizij-authoring/src/hooks/useBindingManager.ts
@@ -1,10 +1,5 @@
-import {
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  type MutableRefObject,
-} from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { MutableRefObject } from "react";
 import type { AnimatableComponent } from "@vizij/utils";
 import type { StandardRigInput } from "@vizij/utils";
 import {

--- a/apps/vizij-authoring/src/hooks/useBundleSynchronizer.ts
+++ b/apps/vizij-authoring/src/hooks/useBundleSynchronizer.ts
@@ -4,8 +4,8 @@ import { normalizeGraphSpec, type GraphSpec } from "@vizij/node-graph-wasm";
 import type { PoseRigConfigFile } from "../poseRig/types";
 import { waitForNextFrame } from "../utils/frame";
 import { prepareSpecForImport } from "../utils/graphImport";
-import { useLatestRef } from "./useLatestRef";
 import type { BundleGraphWithIr } from "../types/bundle";
+import { useLatestRef } from "./useLatestRef";
 
 interface UseBundleSynchronizerOptions {
   faceId: string | null;

--- a/apps/vizij-authoring/src/hooks/usePoseGraphImport.ts
+++ b/apps/vizij-authoring/src/hooks/usePoseGraphImport.ts
@@ -4,13 +4,13 @@ import {
   normalizeStandardRigInputPath,
   type StandardRigInput,
 } from "@vizij/utils";
-import { cloneSerializable } from "../utils/serialization";
-import { normalizeGraphPath } from "../utils/graphPaths";
 import {
   ensureStandardPathInput,
   inferStandardSuggestion,
   readJsonFile,
 } from "@vizij/authoring-shared";
+import { cloneSerializable } from "../utils/serialization";
+import { normalizeGraphPath } from "../utils/graphPaths";
 import {
   remapPoseGraphInputs,
   listPoseGraphOutputs,

--- a/apps/vizij-authoring/src/hooks/useRigController.ts
+++ b/apps/vizij-authoring/src/hooks/useRigController.ts
@@ -1,12 +1,5 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type SetStateAction,
-} from "react";
-
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { SetStateAction } from "react";
 import {
   bindingFromDefinition,
   bindingTargetFromComponent,
@@ -68,6 +61,10 @@ import type {
 import { alertDialog } from "../utils/dialogs";
 import { deriveAutoFaceId, sanitizeFaceId } from "../utils/faceId";
 import { normalizeGraphPath } from "../utils/graphPaths";
+import type { AutoInputState } from "../types/autoInputs";
+import type { GraphRuntimeStore } from "../state/graphRuntimeStore";
+import type { BindingAuthoringStore } from "../state/bindingAuthoringStore";
+import type { SelectionStore } from "../state/selectionStore";
 import { useBindingManager } from "./useBindingManager";
 import { useDiscrepancyReview } from "./useDiscrepancyReview";
 import { useFeatureLabels } from "./useFeatureLabels";
@@ -89,10 +86,6 @@ import {
 } from "./graphRuntime";
 import { useRigGraphImport } from "./useRigGraphImport";
 import { useRigPersistence } from "./useRigPersistence";
-import type { AutoInputState } from "../types/autoInputs";
-import type { GraphRuntimeStore } from "../state/graphRuntimeStore";
-import type { BindingAuthoringStore } from "../state/bindingAuthoringStore";
-import type { SelectionStore } from "../state/selectionStore";
 
 const __DEV__ = process.env.NODE_ENV !== "production";
 

--- a/apps/vizij-authoring/src/hooks/useRigGraphImport.ts
+++ b/apps/vizij-authoring/src/hooks/useRigGraphImport.ts
@@ -1,11 +1,5 @@
-import {
-  useCallback,
-  useRef,
-  type Dispatch,
-  type MutableRefObject,
-  type SetStateAction,
-} from "react";
-
+import { useCallback, useRef } from "react";
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import {
   buildRigGraphSpec,
   type BindingMap,
@@ -20,7 +14,6 @@ import {
   type StandardRigInput,
 } from "@vizij/utils";
 import type { VizijData, World } from "@vizij/render";
-
 import { buildAutoRigInputBlueprints } from "../rig/autoInputs";
 import { rehydrateRigDataFromGraph } from "../rig/importer";
 import type { PersistedAutoStandardInput } from "../rig/persistence";

--- a/apps/vizij-authoring/src/hooks/useRigPersistence.ts
+++ b/apps/vizij-authoring/src/hooks/useRigPersistence.ts
@@ -1,12 +1,5 @@
-import {
-  useCallback,
-  useEffect,
-  useRef,
-  type Dispatch,
-  type MutableRefObject,
-  type SetStateAction,
-} from "react";
-
+import { useCallback, useEffect, useRef } from "react";
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import {
   bindingToDefinition,
   createDefaultBindings,
@@ -24,7 +17,6 @@ import {
   type RigBindingDefinition,
   type StandardRigInput,
 } from "@vizij/utils";
-
 import {
   deleteRigState,
   loadRigState,

--- a/apps/vizij-authoring/src/hooks/useStandardInputCollections.ts
+++ b/apps/vizij-authoring/src/hooks/useStandardInputCollections.ts
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, type MutableRefObject } from "react";
+import { useEffect, useMemo } from "react";
+import type { MutableRefObject } from "react";
 import {
   normalizeStandardRigInputPath,
   stripStandardInputPathPrefix,

--- a/apps/vizij-authoring/src/hooks/useStandardInputSelectionSync.ts
+++ b/apps/vizij-authoring/src/hooks/useStandardInputSelectionSync.ts
@@ -1,9 +1,5 @@
-import {
-  useEffect,
-  type MutableRefObject,
-  type Dispatch,
-  type SetStateAction,
-} from "react";
+import { useEffect } from "react";
+import type { MutableRefObject, Dispatch, SetStateAction } from "react";
 import { normalizeStandardRigGroup } from "@vizij/utils";
 import type { Selection, World } from "@vizij/render";
 

--- a/apps/vizij-authoring/src/hooks/useVizijExport.ts
+++ b/apps/vizij-authoring/src/hooks/useVizijExport.ts
@@ -17,14 +17,14 @@ import type {
   RawValue,
   StandardRigInput,
 } from "@vizij/utils";
-import { faceSlug } from "../utils/faceId";
 import { downloadJsonFile, ensureExtension } from "@vizij/authoring-shared";
+import { getLookup, cloneRawValue } from "@vizij/utils";
+import { faceSlug } from "../utils/faceId";
 import { waitForNextFrame } from "../utils/frame";
 import { applyDefaultsToRobotData } from "../utils/robotData";
 import { cloneSerializable } from "../utils/serialization";
 import type { BundleGraphWithIr } from "../types/bundle";
 import type { PoseRigConfigFile } from "../poseRig/types";
-import { getLookup, cloneRawValue } from "@vizij/utils";
 
 interface CollectAnimatableExportStateResult {
   appliedOverrides: boolean;

--- a/apps/vizij-authoring/src/main.tsx
+++ b/apps/vizij-authoring/src/main.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { VizijContext, createVizijStore } from "@vizij/render";
-
 import App from "./App";
 import "./styles.css";
 

--- a/apps/vizij-authoring/src/poseRig/components/PoseEditor.tsx
+++ b/apps/vizij-authoring/src/poseRig/components/PoseEditor.tsx
@@ -1,4 +1,5 @@
-import { KeyboardEvent, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import type { KeyboardEvent } from "react";
 import type { StandardRigInput } from "@vizij/utils";
 import type { PoseDefinition, StandardInputId } from "../types";
 import { FilterableSelect } from "../../components/common/FilterableSelect";
@@ -6,9 +7,9 @@ import { formatRigPathLabel } from "../../utils/rigPaths";
 import { slugifyLabel } from "../utils";
 import {
   Button,
-  Input,
-  CollapsibleRow,
   CollapsibleGroup,
+  CollapsibleRow,
+  Input,
 } from "../../components/ui";
 
 interface PoseEditorProps {

--- a/apps/vizij-authoring/src/poseRig/components/PoseGroupExportPanel.tsx
+++ b/apps/vizij-authoring/src/poseRig/components/PoseGroupExportPanel.tsx
@@ -1,4 +1,5 @@
-import { ChangeEvent, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { ChangeEvent } from "react";
 import type { StandardRigInput } from "@vizij/utils";
 import { buildPoseGraphSpec } from "../graphBuilder";
 import type { PoseDefinition, StandardInputId } from "../types";
@@ -6,7 +7,6 @@ import { buildPoseWeightPathMap, slugifyLabel } from "../utils";
 import { alertDialog, promptDialog } from "../../utils/dialogs";
 import { downloadBlob } from "../../utils/download";
 import { InstructionCallout } from "../../components/common/InstructionCallout";
-
 import { Button, Switch, FieldRow, Tabs } from "../../components/ui";
 import "./pose-group-export.css";
 

--- a/apps/vizij-authoring/src/poseRig/components/PoseRigWorkbench.tsx
+++ b/apps/vizij-authoring/src/poseRig/components/PoseRigWorkbench.tsx
@@ -1,9 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
 import type { StandardRigInput } from "@vizij/utils";
-import { NeutralEditor } from "./NeutralEditor";
-import { PoseEditor } from "./PoseEditor";
-import { PoseList } from "./PoseList";
-import { PoseGroupExportPanel } from "./PoseGroupExportPanel";
 import { buildPoseWeightPathMap } from "../utils";
 import { formatRigPathLabel } from "../../utils/rigPaths";
 import { usePoseRig } from "../../state/PoseRigProvider";
@@ -11,6 +7,10 @@ import { useGraphRuntime } from "../../state/RigControllerProvider";
 import { Button, Tabs, Input } from "../../components/ui";
 import "./pose-rig-kind.css";
 import { SceneRiggingSection } from "../../components/scene-composer/SceneRiggingSection";
+import { PoseGroupExportPanel } from "./PoseGroupExportPanel";
+import { PoseList } from "./PoseList";
+import { PoseEditor } from "./PoseEditor";
+import { NeutralEditor } from "./NeutralEditor";
 
 const LIVE_EPSILON = 1e-6;
 

--- a/apps/vizij-authoring/src/poseRig/services/poseConfigService.test.ts
+++ b/apps/vizij-authoring/src/poseRig/services/poseConfigService.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { PoseConfigService } from "./poseConfigService";
 import { POSE_RIG_CONFIG_VERSION } from "../types";
+import { PoseConfigService } from "./poseConfigService";
 
 describe("PoseConfigService", () => {
   it("normalizes a valid config", () => {

--- a/apps/vizij-authoring/src/poseRig/services/poseConfigService.ts
+++ b/apps/vizij-authoring/src/poseRig/services/poseConfigService.ts
@@ -1,9 +1,9 @@
+import type { StandardRigInput } from "@vizij/utils";
 import type {
   PoseRigConfigFile,
   LowLevelRigSummary,
   PoseDefinition,
 } from "../types";
-import type { StandardRigInput } from "@vizij/utils";
 import { POSE_RIG_CONFIG_VERSION } from "../types";
 
 export const PoseConfigService = {

--- a/apps/vizij-authoring/src/poseRig/services/poseGraphService.test.ts
+++ b/apps/vizij-authoring/src/poseRig/services/poseGraphService.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { PoseGraphService } from "./poseGraphService";
 import type { StandardRigInput } from "@vizij/utils";
+import { PoseGraphService } from "./poseGraphService";
 
 describe("PoseGraphService", () => {
   it("builds spec from config", () => {

--- a/apps/vizij-authoring/src/poseRig/store.tsx
+++ b/apps/vizij-authoring/src/poseRig/store.tsx
@@ -1,9 +1,5 @@
-import {
-  createContext,
-  useContext,
-  useSyncExternalStore,
-  type ReactNode,
-} from "react";
+import { createContext, useContext, useSyncExternalStore } from "react";
+import type { ReactNode } from "react";
 import type { GraphSpec } from "@vizij/node-graph-wasm";
 import type { StandardRigInput } from "@vizij/utils";
 import type {

--- a/apps/vizij-authoring/src/poseRig/usePoseRigAuthoring.test.tsx
+++ b/apps/vizij-authoring/src/poseRig/usePoseRigAuthoring.test.tsx
@@ -1,13 +1,9 @@
+import { act, useCallback, useEffect, useState } from "react";
+import type { ReactElement } from "react";
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
-import { act } from "react";
 import { createRoot } from "react-dom/client";
-import { useCallback, useEffect, useState, type ReactElement } from "react";
 import type { GraphSpec } from "@vizij/node-graph-wasm";
 import type { StandardRigInput } from "@vizij/utils";
-import {
-  usePoseRigAuthoring,
-  type UsePoseRigAuthoringResult,
-} from "./usePoseRigAuthoring";
 import {
   createGraphRuntimeStore,
   GraphRuntimeStoreProvider,
@@ -16,6 +12,10 @@ import {
   createBindingAuthoringStore,
   BindingAuthoringStoreProvider,
 } from "../state/bindingAuthoringStore";
+import {
+  usePoseRigAuthoring,
+  type UsePoseRigAuthoringResult,
+} from "./usePoseRigAuthoring";
 import { PoseRigStoreProvider, createPoseRigStore } from "./store";
 
 // Silence React's act environment warning for the custom hook harness.

--- a/apps/vizij-authoring/src/rig/driverAdapters.test.ts
+++ b/apps/vizij-authoring/src/rig/driverAdapters.test.ts
@@ -1,11 +1,8 @@
 import { describe, expect, it } from "vitest";
-
 import type { AnimatableComponent, StandardRigInput } from "@vizij/utils";
-
 import { buildGraphFromDrivers } from "@vizij/utils";
-
-import { buildAuthoringDriverGraph } from "./driverAdapters";
 import { createDefaultBinding } from "@vizij/node-graph-authoring";
+import { buildAuthoringDriverGraph } from "./driverAdapters";
 
 describe("buildAuthoringDriverGraph", () => {
   it("converts bindings into remap drivers", () => {

--- a/apps/vizij-authoring/src/rig/driverAdapters.ts
+++ b/apps/vizij-authoring/src/rig/driverAdapters.ts
@@ -7,7 +7,6 @@ import type {
   StandardRigInput,
 } from "@vizij/utils";
 import type { AnimatableComponent } from "@vizij/utils";
-
 import {
   ensureBindingStructure,
   type AnimatableBinding,

--- a/apps/vizij-authoring/src/rig/expression.test.ts
+++ b/apps/vizij-authoring/src/rig/expression.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-
 import {
   collectExpressionReferences,
   parseControlExpression,

--- a/apps/vizij-authoring/src/rig/graphBuilder.test.ts
+++ b/apps/vizij-authoring/src/rig/graphBuilder.test.ts
@@ -1,12 +1,10 @@
 import { describe, expect, it } from "vitest";
-
 import type { GraphSpec, NodeSpec } from "@vizij/node-graph-wasm";
 import type {
   AnimatableComponent,
   AnimatableValue,
   StandardRigInput,
 } from "@vizij/utils";
-
 import { buildRigGraphSpec } from "@vizij/node-graph-authoring";
 import {
   createDefaultBinding,

--- a/apps/vizij-authoring/src/rig/legacyMigration.test.ts
+++ b/apps/vizij-authoring/src/rig/legacyMigration.test.ts
@@ -1,11 +1,9 @@
 import { describe, expect, it } from "vitest";
-
 import {
   createStandardRigInput,
   createStandardRigInputFromPath,
   type StandardRigInput,
 } from "@vizij/utils";
-
 import {
   normalizePersistedStandardInputs,
   resolvePersistedAutoKey,

--- a/apps/vizij-authoring/src/rig/state.test.ts
+++ b/apps/vizij-authoring/src/rig/state.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-
 import {
   createDefaultBinding,
   reconcileBindings,

--- a/apps/vizij-authoring/src/scene/featureEntries.test.ts
+++ b/apps/vizij-authoring/src/scene/featureEntries.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import type { AnimatableValue } from "@vizij/utils";
-
 import { buildFeatureEntries } from "./featureEntries";
 
 describe("buildFeatureEntries", () => {

--- a/apps/vizij-authoring/src/scene/sceneEditing.ts
+++ b/apps/vizij-authoring/src/scene/sceneEditing.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
-import { createRef, type RefObject } from "react";
+import { createRef } from "react";
+import type { RefObject } from "react";
 import { Euler, Matrix4, Quaternion, Vector3 } from "three";
 import type { BindingMap } from "@vizij/node-graph-authoring";
 import type {

--- a/apps/vizij-authoring/src/scene/sceneGraph.ts
+++ b/apps/vizij-authoring/src/scene/sceneGraph.ts
@@ -7,13 +7,13 @@ import type {
 } from "@vizij/utils";
 import type { BindingMap, BindingValueType } from "@vizij/node-graph-authoring";
 import { SELF_BINDING_ID } from "@vizij/utils";
+import type { VectorDescriptorType } from "@vizij/utils";
 import {
   buildFeatureEntries,
   type FeatureEntry,
   type VectorComponent,
   type RenderableLike,
 } from "./featureEntries";
-import type { VectorDescriptorType } from "@vizij/utils";
 
 type BindingSlot = BindingMap[keyof BindingMap]["slots"][number];
 

--- a/apps/vizij-authoring/src/scene/useSceneComposer.test.tsx
+++ b/apps/vizij-authoring/src/scene/useSceneComposer.test.tsx
@@ -1,10 +1,7 @@
-import { beforeAll, describe, expect, it, vi } from "vitest";
-import React from "react";
 import { act } from "react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import { createRoot, type Root } from "react-dom/client";
-
-import { useSceneComposer } from "./useSceneComposer";
-import type { SceneObjectNode } from "./sceneGraph";
+import { VizijContext, createVizijStore } from "@vizij/render";
 import {
   BindingAuthoringStoreProvider,
   createBindingAuthoringStore,
@@ -14,7 +11,8 @@ import {
   createGraphRuntimeStore,
   type GraphRuntimeState,
 } from "../state/graphRuntimeStore";
-import { VizijContext, createVizijStore } from "@vizij/render";
+import { useSceneComposer } from "./useSceneComposer";
+import type { SceneObjectNode } from "./sceneGraph";
 
 type HookResult = ReturnType<typeof useSceneComposer>;
 

--- a/apps/vizij-authoring/src/scene/useSceneComposer.ts
+++ b/apps/vizij-authoring/src/scene/useSceneComposer.ts
@@ -2,12 +2,12 @@ import { useMemo, useCallback } from "react";
 import type { RawValue, AnimatableValue } from "@vizij/utils";
 import type { BindingValueType } from "@vizij/node-graph-authoring";
 import type { ShapeMaterial } from "@vizij/render";
+import { useVizijStoreGetter } from "@vizij/render";
 import { DEFAULT_NAMESPACE } from "../utils/constants";
 import {
   useBindingAuthoring,
   useGraphRuntime,
 } from "../state/RigControllerProvider";
-import { useVizijStoreGetter } from "@vizij/render";
 import type { SceneObjectNode, SceneObjectFeature } from "./sceneGraph";
 import { createFeatureMutations } from "./featureMutations";
 import type { FeatureEntry } from "./featureEntries";

--- a/apps/vizij-authoring/src/state/AuthoringUiProvider.tsx
+++ b/apps/vizij-authoring/src/state/AuthoringUiProvider.tsx
@@ -1,10 +1,5 @@
-import {
-  createContext,
-  useContext,
-  useMemo,
-  useReducer,
-  type ReactNode,
-} from "react";
+import { createContext, useContext, useMemo, useReducer } from "react";
+import type { ReactNode } from "react";
 import type { WorkbenchView } from "../components/app/workbenchConfig";
 
 export interface AuthoringUiState {

--- a/apps/vizij-authoring/src/state/PoseRigProvider.tsx
+++ b/apps/vizij-authoring/src/state/PoseRigProvider.tsx
@@ -1,11 +1,5 @@
-import {
-  createContext,
-  useContext,
-  useEffect,
-  useRef,
-  type ReactNode,
-} from "react";
-import { useBindingAuthoring, useGraphRuntime } from "./RigControllerProvider";
+import { createContext, useContext, useEffect, useRef } from "react";
+import type { ReactNode } from "react";
 import {
   createPoseRigStore,
   PoseRigStoreProvider,
@@ -15,6 +9,7 @@ import {
   usePoseRigAuthoring,
   type UsePoseRigAuthoringResult,
 } from "../poseRig/usePoseRigAuthoring";
+import { useBindingAuthoring, useGraphRuntime } from "./RigControllerProvider";
 
 function filterRecordByIds<T extends Record<string, number>>(
   record: T,

--- a/apps/vizij-authoring/src/state/RigControllerProvider.tsx
+++ b/apps/vizij-authoring/src/state/RigControllerProvider.tsx
@@ -1,4 +1,5 @@
-import { type ReactNode, useRef } from "react";
+import { useRef } from "react";
+import type { ReactNode } from "react";
 import { useRigController } from "../hooks/useRigController";
 import {
   createGraphRuntimeStore,

--- a/apps/vizij-authoring/src/state/bindingAuthoringStore.tsx
+++ b/apps/vizij-authoring/src/state/bindingAuthoringStore.tsx
@@ -307,7 +307,7 @@ export function useBindingAuthoringStore<T>(
   equalityFn: (a: T, b: T) => boolean = Object.is,
 ): T {
   const store = useBindingAuthoringStoreApi();
-  const lastValueRef = useRef<T>();
+  const lastValueRef = useRef<T | undefined>(undefined);
   const subscribe = store.subscribe;
   const getSnapshot = () => selector(store.getState());
   const value = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);

--- a/apps/vizij-authoring/src/state/bindingAuthoringStore.tsx
+++ b/apps/vizij-authoring/src/state/bindingAuthoringStore.tsx
@@ -1,10 +1,5 @@
-import {
-  createContext,
-  useContext,
-  useRef,
-  useSyncExternalStore,
-  type ReactNode,
-} from "react";
+import { createContext, useContext, useRef, useSyncExternalStore } from "react";
+import type { ReactNode } from "react";
 import type {
   BindingMap,
   BindingValueType,
@@ -15,6 +10,7 @@ import type {
   AnimatableComponent as AnimComponent,
   StandardRigInput,
 } from "@vizij/utils";
+import type { AnimatableValue, RawValue } from "@vizij/utils";
 import type { ManagedStandardInput } from "../types/standardInputs";
 import type { SceneObjectNode } from "../scene/sceneGraph";
 import {
@@ -22,7 +18,6 @@ import {
   type AuthoringFeatureFlag,
   type FeatureFlagState,
 } from "../hooks/useFeatureLabels";
-import type { AnimatableValue, RawValue } from "@vizij/utils";
 
 interface AnimatableExportState {
   appliedOverrides: boolean;

--- a/apps/vizij-authoring/src/state/graphRuntimeStore.tsx
+++ b/apps/vizij-authoring/src/state/graphRuntimeStore.tsx
@@ -157,7 +157,7 @@ export function useGraphRuntimeStore<T>(
   equalityFn: (a: T, b: T) => boolean = Object.is,
 ): T {
   const store = useGraphRuntimeStoreApi();
-  const lastValueRef = useRef<T>();
+  const lastValueRef = useRef<T | undefined>(undefined);
   const subscribe = store.subscribe;
   const getSnapshot = () => selector(store.getState());
   const value = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);

--- a/apps/vizij-authoring/src/state/graphRuntimeStore.tsx
+++ b/apps/vizij-authoring/src/state/graphRuntimeStore.tsx
@@ -1,10 +1,5 @@
-import {
-  createContext,
-  useContext,
-  useRef,
-  useSyncExternalStore,
-  type ReactNode,
-} from "react";
+import { createContext, useContext, useRef, useSyncExternalStore } from "react";
+import type { ReactNode } from "react";
 import type {
   BuildGraphResult,
   MachineReport,

--- a/apps/vizij-authoring/src/state/selectionStore.tsx
+++ b/apps/vizij-authoring/src/state/selectionStore.tsx
@@ -1,10 +1,5 @@
-import {
-  createContext,
-  useContext,
-  useRef,
-  useSyncExternalStore,
-  type ReactNode,
-} from "react";
+import { createContext, useContext, useRef, useSyncExternalStore } from "react";
+import type { ReactNode } from "react";
 import type { Selection } from "@vizij/render";
 
 type SelectionStoreUpdate =

--- a/apps/vizij-authoring/src/state/selectionStore.tsx
+++ b/apps/vizij-authoring/src/state/selectionStore.tsx
@@ -96,7 +96,7 @@ export function useSelectionStoreValue<T>(
   equalityFn: (a: T, b: T) => boolean = Object.is,
 ): T {
   const store = useSelectionStoreApi();
-  const lastValueRef = useRef<T>();
+  const lastValueRef = useRef<T | undefined>(undefined);
   const subscribe = store.subscribe;
   const getSnapshot = () => selector(store.getState());
   const value = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);

--- a/apps/vizij-authoring/src/utils/__tests__/fileIO.test.ts
+++ b/apps/vizij-authoring/src/utils/__tests__/fileIO.test.ts
@@ -1,12 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
-
 import { downloadJsonFile, ensureExtension, readJsonFile } from "../fileIO";
+import { downloadBlob } from "../download";
 
 vi.mock("../download", () => ({
   downloadBlob: vi.fn(),
 }));
 
-import { downloadBlob } from "../download";
 const mockedDownloadBlob = vi.mocked(downloadBlob);
 
 describe("fileIO", () => {

--- a/apps/vizij-authoring/src/utils/__tests__/standardInputPaths.test.ts
+++ b/apps/vizij-authoring/src/utils/__tests__/standardInputPaths.test.ts
@@ -1,10 +1,9 @@
 import { describe, expect, it } from "vitest";
-
+import type { StandardRigInput } from "@vizij/utils";
 import {
   ensureStandardPathInput,
   inferStandardSuggestion,
 } from "../standardInputPaths";
-import type { StandardRigInput } from "@vizij/utils";
 
 describe("standardInputPaths", () => {
   const standardInputs: StandardRigInput[] = [

--- a/apps/vizij-authoring/src/utils/robotDataAudit.test.ts
+++ b/apps/vizij-authoring/src/utils/robotDataAudit.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
 import type { RefObject } from "react";
+import { describe, expect, it } from "vitest";
 import type { World } from "@vizij/render";
 import type { AnimatableValue } from "@vizij/utils";
 import { auditRobotData, createRobotDataAuditTask } from "./robotDataAudit";

--- a/apps/vizij-authoring/tsconfig.json
+++ b/apps/vizij-authoring/tsconfig.json
@@ -18,6 +18,7 @@
       "@vizij/node-graph-wasm/metadata": [
         "../../packages/@vizij/node-graph-authoring/src/metadata-shim.d.ts"
       ]
-    }
+    },
+    "jsxImportSource": "react"
   }
 }

--- a/apps/vizij-authoring/vite.config.ts
+++ b/apps/vizij-authoring/vite.config.ts
@@ -1,8 +1,8 @@
-import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react-swc";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 import { createRequire } from "node:module";
+import react from "@vitejs/plugin-react-swc";
+import { defineConfig } from "vite";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/apps/vizij-showcase/package.json
+++ b/apps/vizij-showcase/package.json
@@ -10,20 +10,20 @@
     "lint": "pnpm exec eslint \"src/**/*.{ts,tsx}\""
   },
   "dependencies": {
-    "@react-three/drei": "^9.115.0",
-    "@react-three/fiber": "^8.17.10",
+    "@react-three/drei": "^10.7.7",
+    "@react-three/fiber": "^9.5.0",
     "@vizij/orchestrator-react": "workspace:*",
     "@vizij/render": "workspace:*",
     "@vizij/runtime-react": "workspace:*",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3",
     "three": "^0.170.0",
     "zustand": "^5.0.2"
   },
   "devDependencies": {
-    "@types/react": "^18.3.26",
-    "@types/react-dom": "^18.3.7",
-    "@vitejs/plugin-react-swc": "^3.7.0",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react-swc": "^4.2.2",
     "typescript": "^5.9.3",
     "vite": "^6.3.6"
   }

--- a/apps/vizij-showcase/src/FaceApp.tsx
+++ b/apps/vizij-showcase/src/FaceApp.tsx
@@ -13,7 +13,6 @@ import { RoadmapSection } from "./sections/RoadmapSection";
 import { StandardsSection } from "./sections/StandardsSection";
 import { FooterSection } from "./sections/FooterSection";
 import { RuntimeDebugOverlay } from "./components/RuntimeDebugOverlay";
-
 import "./styles.css";
 
 const SECTION_LINKS: SectionMenuItem[] = [

--- a/apps/vizij-showcase/src/components/PoseButtonPanel.tsx
+++ b/apps/vizij-showcase/src/components/PoseButtonPanel.tsx
@@ -102,7 +102,7 @@ export function PoseButtonPanel() {
 
     const activeKeys = new Set<string>();
 
-    const handleKeyDown = (event: KeyboardEvent) => {
+    const handleKeyDown = (event: globalThis.KeyboardEvent) => {
       const binding = keyBindings.get(event.code);
       if (!binding || activeKeys.has(event.code)) {
         return;
@@ -125,7 +125,7 @@ export function PoseButtonPanel() {
       });
     };
 
-    const handleKeyUp = (event: KeyboardEvent) => {
+    const handleKeyUp = (event: globalThis.KeyboardEvent) => {
       const binding = keyBindings.get(event.code);
       if (!binding || !activeKeys.has(event.code)) {
         return;

--- a/apps/vizij-showcase/src/components/RigControlPanel.tsx
+++ b/apps/vizij-showcase/src/components/RigControlPanel.tsx
@@ -1,11 +1,5 @@
-import {
-  useCallback,
-  useMemo,
-  useState,
-  useId,
-  useRef,
-  type ChangeEvent,
-} from "react";
+import { useCallback, useMemo, useState, useId, useRef } from "react";
+import type { ChangeEvent } from "react";
 import { useVizijRuntime } from "@vizij/runtime-react";
 
 type RigInputOption = {

--- a/apps/vizij-showcase/src/components/RuntimeFaceFrame.tsx
+++ b/apps/vizij-showcase/src/components/RuntimeFaceFrame.tsx
@@ -1,4 +1,5 @@
-import { useEffect, type ReactNode, type RefObject } from "react";
+import { useEffect } from "react";
+import type { ReactNode, RefObject } from "react";
 import { useVizijStore, useVizijStoreSetter } from "@vizij/render";
 import {
   VizijRuntimeFace,

--- a/apps/vizij-showcase/src/components/RuntimeFaceFrame.tsx
+++ b/apps/vizij-showcase/src/components/RuntimeFaceFrame.tsx
@@ -12,7 +12,7 @@ export type RuntimeFaceFrameProps = {
   subtitle?: string;
   variant?: "sm" | "md" | "lg";
   className?: string;
-  pointerTargetRef?: RefObject<HTMLDivElement>;
+  pointerTargetRef?: RefObject<HTMLDivElement | null>;
   onCanvasClick?: () => void;
   overlay?: ReactNode;
   footer?: ReactNode;

--- a/apps/vizij-showcase/src/components/SectionMenu.tsx
+++ b/apps/vizij-showcase/src/components/SectionMenu.tsx
@@ -32,7 +32,7 @@ export function SectionMenu({ sections }: SectionMenuProps) {
       return undefined;
     }
 
-    const handleKeyDown = (event: KeyboardEvent) => {
+    const handleKeyDown = (event: globalThis.KeyboardEvent) => {
       if (event.key === "Escape") {
         event.preventDefault();
         setIsOpen(false);

--- a/apps/vizij-showcase/src/components/ShowcaseRuntime.tsx
+++ b/apps/vizij-showcase/src/components/ShowcaseRuntime.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, type ReactNode } from "react";
+import { useEffect, useMemo } from "react";
+import type { ReactNode } from "react";
 import { VizijRuntimeProvider, useVizijRuntime } from "@vizij/runtime-react";
 import {
   createShowcaseBundle,

--- a/apps/vizij-showcase/src/components/VoicePanel.tsx
+++ b/apps/vizij-showcase/src/components/VoicePanel.tsx
@@ -1,13 +1,5 @@
-import {
-  type ChangeEvent,
-  type Dispatch,
-  type SetStateAction,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { ChangeEvent, Dispatch, SetStateAction } from "react";
 import { useVizijRuntime } from "@vizij/runtime-react";
 import { usePollyTTS } from "../hooks/usePollyTTS";
 import { SPEECH_STATUS_COPY, type SpeechStatus } from "../data/speech";

--- a/apps/vizij-showcase/src/hooks/useMouseGaze.ts
+++ b/apps/vizij-showcase/src/hooks/useMouseGaze.ts
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState, type RefObject } from "react";
+import { useEffect, useRef, useState } from "react";
+import type { RefObject } from "react";
 import { useVizijRuntime } from "@vizij/runtime-react";
 
 const STANDARD_PATHS = {

--- a/apps/vizij-showcase/src/hooks/useMouseGaze.ts
+++ b/apps/vizij-showcase/src/hooks/useMouseGaze.ts
@@ -15,7 +15,7 @@ function clamp(value: number, min = -1, max = 1) {
 }
 
 export type MouseGazeHandle = {
-  ref: RefObject<HTMLDivElement>;
+  ref: RefObject<HTMLDivElement | null>;
   isPointerActive: boolean;
 };
 

--- a/apps/vizij-showcase/src/hooks/usePollyTTS.ts
+++ b/apps/vizij-showcase/src/hooks/usePollyTTS.ts
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import type { VisemeData } from "../types/polly";
-
 import { fetchVisemeData } from "../services/pollyApi";
 
 export const usePollyTTS = () => {

--- a/apps/vizij-showcase/src/hooks/useSectionInView.ts
+++ b/apps/vizij-showcase/src/hooks/useSectionInView.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState, type RefCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
+import type { RefCallback } from "react";
 
 type SectionInViewOptions = {
   threshold?: number;

--- a/apps/vizij-showcase/src/services/pollyApi.ts
+++ b/apps/vizij-showcase/src/services/pollyApi.ts
@@ -1,5 +1,4 @@
 import type { VisemeData } from "../types/polly";
-
 import { requireApiBase } from "./apiBase";
 
 const normalizeBase = (base: string): string => base.trim().replace(/\/$/, "");

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -54,6 +54,19 @@ export default tseslint.config(
         },
       ],
       "import/no-cycle": "off",
+      "import/order": [
+        "error",
+        {
+          distinctGroup: false,
+          "newlines-between": "never",
+        },
+      ],
+      "import/newline-after-import": [
+        "error",
+        {
+          count: 1,
+        },
+      ],
       "no-empty": [
         "error",
         {
@@ -63,6 +76,14 @@ export default tseslint.config(
       "no-useless-catch": "off",
       "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/ban-ts-comment": "off",
+      "@typescript-eslint/consistent-type-imports": [
+        "error",
+        {
+          prefer: "type-imports",
+          fixStyle: "separate-type-imports",
+          disallowTypeAnnotations: false,
+        },
+      ],
       "@typescript-eslint/no-unused-vars": [
         "warn",
         {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,9 @@
   },
   "pnpm": {
     "overrides": {
-      "source-map": "0.7.4"
+      "source-map": "0.7.4",
+      "zustand": "5.0.9",
+      "use-sync-external-store": "1.6.0"
     }
   }
 }

--- a/packages/@vizij/animation-react/package.json
+++ b/packages/@vizij/animation-react/package.json
@@ -45,14 +45,16 @@
     "react-dom": ">=18"
   },
   "devDependencies": {
-    "@testing-library/react": "^14.3.1",
+    "@testing-library/react": "^16.3.1",
     "typescript": "^5.5.0",
-    "@types/react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "@types/react": "^19.2.7",
+    "react-dom": "^19.2.3",
     "jsdom": "^24.1.3",
     "prettier": "^3.4.2",
     "vitest": "^3.2.4",
-    "tsup": "^8.0.1"
+    "tsup": "^8.0.1",
+    "react": "^19.2.3",
+    "@testing-library/dom": "^10.4.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@vizij/animation-react/src/__tests__/samples.test.tsx
+++ b/packages/@vizij/animation-react/src/__tests__/samples.test.tsx
@@ -1,15 +1,14 @@
 /* @vitest-environment jsdom */
-
 import React from "react";
 import { describe, it, expect, afterAll, vi } from "vitest";
 import { render, waitFor, act } from "@testing-library/react";
+import { init as initAnimationWasm } from "@vizij/animation-wasm";
 import {
   AnimationProvider,
   useAnimation,
   valueAsNumber,
   samples,
 } from "../index";
-import { init as initAnimationWasm } from "@vizij/animation-wasm";
 import { getAnimationWasmInitInput } from "./helpers";
 
 const originalWarn = console.warn;

--- a/packages/@vizij/animation-react/src/hooks/useAnimDerivative.ts
+++ b/packages/@vizij/animation-react/src/hooks/useAnimDerivative.ts
@@ -1,6 +1,6 @@
 import { useCallback, useSyncExternalStore } from "react";
-import { useAnimation } from "./useAnimation";
 import type { Value } from "../types";
+import { useAnimation } from "./useAnimation";
 
 export function useAnimDerivative(key?: string): Value | undefined {
   const { subscribeToDerivativeKey, getKeyDerivativeSnapshot } = useAnimation();

--- a/packages/@vizij/animation-react/src/hooks/useAnimTarget.ts
+++ b/packages/@vizij/animation-react/src/hooks/useAnimTarget.ts
@@ -1,6 +1,6 @@
 import { useCallback, useSyncExternalStore } from "react";
-import { useAnimation } from "./useAnimation";
 import type { Value } from "../types";
+import { useAnimation } from "./useAnimation";
 
 export function useAnimTarget(key?: string): Value | undefined {
   const { subscribeToKey, getKeySnapshot } = useAnimation();

--- a/packages/@vizij/minimal-demo-ui/package.json
+++ b/packages/@vizij/minimal-demo-ui/package.json
@@ -36,9 +36,10 @@
     "react-dom": ">=18"
   },
   "devDependencies": {
-    "@types/react": "^18.3.26",
+    "@types/react": "^19.2.7",
     "prettier": "^3.4.2",
     "tsup": "^8.0.1",
     "typescript": "^5.5.0"
-  }
+  },
+  "dependencies": {}
 }

--- a/packages/@vizij/minimal-demo-ui/src/index.tsx
+++ b/packages/@vizij/minimal-demo-ui/src/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import type { CSSProperties, ReactNode } from "react";
 
 const fontStack =
   'Inter, "SF Pro Display", "SF Pro Text", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif';
@@ -18,7 +18,7 @@ export const minimalDemoTheme = {
   code: "#050f23",
 } as const;
 
-const baseTextStyles: React.CSSProperties = {
+const baseTextStyles: CSSProperties = {
   color: baseText,
   fontFamily: fontStack,
   lineHeight: 1.5,
@@ -26,10 +26,10 @@ const baseTextStyles: React.CSSProperties = {
 
 export type MinimalDemoChromeProps = {
   title: string;
-  description?: React.ReactNode;
-  subtitle?: React.ReactNode;
-  actions?: React.ReactNode;
-  children: React.ReactNode;
+  description?: ReactNode;
+  subtitle?: ReactNode;
+  actions?: ReactNode;
+  children: ReactNode;
   maxWidth?: number | string;
   gap?: number;
 };
@@ -120,10 +120,10 @@ export function MinimalDemoChrome({
 }
 
 export type MinimalDemoSectionProps = {
-  title?: React.ReactNode;
-  description?: React.ReactNode;
-  actions?: React.ReactNode;
-  children: React.ReactNode;
+  title?: ReactNode;
+  description?: ReactNode;
+  actions?: ReactNode;
+  children: ReactNode;
   padding?: string;
 };
 
@@ -178,10 +178,10 @@ export function MinimalDemoSection({
 }
 
 export type MinimalDemoPanelProps = {
-  title?: React.ReactNode;
-  description?: React.ReactNode;
-  footer?: React.ReactNode;
-  children: React.ReactNode;
+  title?: ReactNode;
+  description?: ReactNode;
+  footer?: ReactNode;
+  children: ReactNode;
 };
 
 export function MinimalDemoPanel({

--- a/packages/@vizij/node-graph-authoring/src/__tests__/graphBuilder.test.ts
+++ b/packages/@vizij/node-graph-authoring/src/__tests__/graphBuilder.test.ts
@@ -1,12 +1,11 @@
 import { describe, expect, it } from "vitest";
-
 import type { GraphSpec, NodeSpec } from "@vizij/node-graph-wasm";
 import type {
   AnimatableComponent,
   AnimatableValue,
   StandardRigInput,
 } from "@vizij/utils";
-
+import { SELF_BINDING_ID } from "@vizij/utils";
 import { buildRigGraphSpec } from "../graphBuilder";
 import {
   createDefaultBinding,
@@ -17,7 +16,6 @@ import {
   updateBindingExpression,
   buildCanonicalBindingExpression,
 } from "../state";
-import { SELF_BINDING_ID } from "@vizij/utils";
 
 const COMPONENT: AnimatableComponent = {
   id: "component_1",

--- a/packages/@vizij/node-graph-authoring/src/__tests__/irCompiler.test.ts
+++ b/packages/@vizij/node-graph-authoring/src/__tests__/irCompiler.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-
 import type { GraphSpec } from "@vizij/node-graph-wasm";
 import { compileIrGraph } from "../ir/compiler";
 import type { IrGraph, IrGraphMetadata, IrGraphSummary } from "../ir/types";

--- a/packages/@vizij/node-graph-authoring/src/__tests__/irParity.test.ts
+++ b/packages/@vizij/node-graph-authoring/src/__tests__/irParity.test.ts
@@ -1,12 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
 import type {
   AnimatableComponent,
   AnimatableValue,
   StandardRigInput,
 } from "@vizij/utils";
 import { SELF_BINDING_ID } from "@vizij/utils";
-
 import { buildRigGraphSpec } from "../graphBuilder";
 import {
   addBindingSlot,

--- a/packages/@vizij/node-graph-authoring/src/__tests__/irRegression.test.ts
+++ b/packages/@vizij/node-graph-authoring/src/__tests__/irRegression.test.ts
@@ -1,12 +1,10 @@
 import { describe, expect, it } from "vitest";
-
 import type {
   AnimatableComponent,
   AnimatableValue,
   StandardRigInput,
 } from "@vizij/utils";
 import { SELF_BINDING_ID } from "@vizij/utils";
-
 import { buildRigGraphSpec } from "../graphBuilder";
 import {
   createDefaultBinding,

--- a/packages/@vizij/node-graph-authoring/src/__tests__/irSnapshots.test.ts
+++ b/packages/@vizij/node-graph-authoring/src/__tests__/irSnapshots.test.ts
@@ -1,13 +1,11 @@
 /* eslint-disable no-useless-escape -- inline JSON snapshots need explicit escaped quotes */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
 import type {
   AnimatableComponent,
   AnimatableValue,
   StandardRigInput,
 } from "@vizij/utils";
 import { SELF_BINDING_ID, cloneDeepSafe } from "@vizij/utils";
-
 import { buildRigGraphSpec } from "../graphBuilder";
 import {
   addBindingSlot,

--- a/packages/@vizij/node-graph-authoring/src/cli/reportIr.ts
+++ b/packages/@vizij/node-graph-authoring/src/cli/reportIr.ts
@@ -1,9 +1,7 @@
 #!/usr/bin/env node
 import { readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
-
 import type { StandardRigInput } from "@vizij/utils";
-
 import {
   buildRigGraphSpec,
   type BuildGraphOptions,

--- a/packages/@vizij/node-graph-authoring/src/expressionVariables.ts
+++ b/packages/@vizij/node-graph-authoring/src/expressionVariables.ts
@@ -31,8 +31,7 @@ export interface RegisterSlotVariableOptions extends SlotVariableMetadata {
   nodeId: string;
 }
 
-export interface RegisterReservedVariableOptions
-  extends ReservedVariableMetadata {
+export interface RegisterReservedVariableOptions extends ReservedVariableMetadata {
   name: string;
   nodeId: string | null;
   description?: string;

--- a/packages/@vizij/node-graph-authoring/src/graphBuilder.ts
+++ b/packages/@vizij/node-graph-authoring/src/graphBuilder.ts
@@ -5,6 +5,7 @@ import type { AnimatableComponent } from "@vizij/utils";
 import type { RigBindingMetadata } from "@vizij/utils";
 import { buildAnimatableValue, cloneDeepSafe } from "@vizij/utils";
 import { SELF_BINDING_ID } from "@vizij/utils";
+import { nodeRegistryVersion } from "@vizij/node-graph-wasm/metadata";
 import type { BindingMap } from "./state";
 import {
   ensureBindingStructure,
@@ -32,7 +33,6 @@ import {
   type ExpressionVariableTable,
 } from "./expressionVariables";
 import { RESERVED_EXPRESSION_VARIABLES } from "./expressionVocabulary";
-import { nodeRegistryVersion } from "@vizij/node-graph-wasm/metadata";
 import { createIrGraphBuilder, toIrBindingSummary } from "./ir/builder";
 import { compileIrGraph } from "./ir/compiler";
 import { buildBindingMetadataFromExpression } from "./bindingMetadata";

--- a/packages/@vizij/node-graph-authoring/src/ir/builder.ts
+++ b/packages/@vizij/node-graph-authoring/src/ir/builder.ts
@@ -1,5 +1,4 @@
 import type { GraphSpec } from "@vizij/node-graph-wasm";
-
 import {
   type IrBindingSummary,
   type IrConstant,

--- a/packages/@vizij/node-graph-authoring/src/ir/compiler.ts
+++ b/packages/@vizij/node-graph-authoring/src/ir/compiler.ts
@@ -1,6 +1,5 @@
 import type { GraphSpec, NodeSpec } from "@vizij/node-graph-wasm";
 import { cloneDeepSafe } from "@vizij/utils";
-
 import {
   type IrConstant,
   type IrEdge,

--- a/packages/@vizij/node-graph-authoring/src/ir/inspection.test.ts
+++ b/packages/@vizij/node-graph-authoring/src/ir/inspection.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-
 import type { GraphSpec } from "@vizij/node-graph-wasm";
+import { cloneDeepSafe } from "@vizij/utils";
 import type { BuildGraphResult } from "../graphBuilder";
 import type { MachineReport } from "./inspection";
 import type { IrGraph } from "./types";
@@ -9,7 +9,6 @@ import {
   buildMachineReport,
   diffMachineReports,
 } from "./inspection";
-import { cloneDeepSafe } from "@vizij/utils";
 
 function createIrGraph(): IrGraph {
   return {

--- a/packages/@vizij/node-graph-authoring/src/ir/inspection.ts
+++ b/packages/@vizij/node-graph-authoring/src/ir/inspection.ts
@@ -1,7 +1,6 @@
 import type { NodeType } from "@vizij/node-graph-wasm";
 import { findNodeSignature } from "@vizij/node-graph-wasm/metadata";
 import { type RigBindingMetadata, cloneDeepSafe } from "@vizij/utils";
-
 import type { BuildGraphResult, GraphBindingSummary } from "../graphBuilder";
 import type {
   IrBindingSummary,

--- a/packages/@vizij/node-graph-authoring/vitest.config.ts
+++ b/packages/@vizij/node-graph-authoring/vitest.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from "vitest/config";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
 
 const packageDir = fileURLToPath(new URL(".", import.meta.url));
 const utilsSrc = resolve(packageDir, "../utils/src");

--- a/packages/@vizij/node-graph-react/package.json
+++ b/packages/@vizij/node-graph-react/package.json
@@ -45,14 +45,16 @@
     "react-dom": ">=18"
   },
   "devDependencies": {
-    "@testing-library/react": "^14.3.1",
-    "@types/react": "^18.2.0",
+    "@testing-library/react": "^16.3.1",
+    "@types/react": "^19.2.7",
     "jsdom": "^24.1.3",
     "typescript": "^5.5.0",
     "vitest": "^3.2.4",
     "prettier": "^3.4.2",
-    "react-dom": "^18.2.0",
-    "tsup": "^8.0.1"
+    "react-dom": "^19.2.3",
+    "tsup": "^8.0.1",
+    "react": "^19.2.3",
+    "@testing-library/dom": "^10.4.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@vizij/node-graph-react/src/GraphProvider.tsx
+++ b/packages/@vizij/node-graph-react/src/GraphProvider.tsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useRef, useState, useCallback } from "react";
+import * as wasm from "@vizij/node-graph-wasm";
+import type { Registry } from "@vizij/node-graph-wasm";
 import { GraphContext } from "./GraphContext";
 import type {
   GraphRuntimeContextValue,
@@ -7,8 +9,6 @@ import type {
 } from "./types";
 import { createGraphStore } from "./utils/createGraphStore";
 import { normalizeSpec } from "./utils/normalizeSpec";
-import * as wasm from "@vizij/node-graph-wasm";
-import type { Registry } from "@vizij/node-graph-wasm";
 import { GraphReadyController } from "./runtime/graphReady";
 
 type Graph = any;

--- a/packages/@vizij/node-graph-react/src/__tests__/GraphProvider-load.test.ts
+++ b/packages/@vizij/node-graph-react/src/__tests__/GraphProvider-load.test.ts
@@ -1,6 +1,14 @@
 import React, { useEffect } from "react";
-import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
-import { render, waitFor } from "@testing-library/react";
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  afterAll,
+  afterEach,
+} from "vitest";
+import { render, waitFor, cleanup } from "@testing-library/react";
 import { GraphProvider } from "../GraphProvider";
 import { useGraphRuntime } from "../useGraphRuntime";
 
@@ -74,6 +82,10 @@ afterAll(() => {
   restoreConsoleError?.();
 });
 
+afterEach(() => {
+  cleanup();
+});
+
 describe("GraphProvider readiness", () => {
   it("waitForGraphReady resolves after load and seeds applied", async () => {
     const initialParams = { nodeA: { p1: { float: 42 } } } as const;
@@ -145,5 +157,49 @@ describe("GraphProvider readiness", () => {
     );
 
     wasm.__setMode?.("ok");
+  });
+
+  it("does not resolve readiness after unmount", async () => {
+    let resolveCreate: ((graph: any) => void) | null = null;
+    const wasm: any = await import("@vizij/node-graph-wasm");
+    wasm.createGraph.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveCreate = resolve;
+        }),
+    );
+
+    let runtimeRef: any = null;
+    const { unmount } = render(
+      React.createElement(
+        GraphProvider as any,
+        { spec: { nodes: [], edges: [] }, waitForGraph: true },
+        React.createElement(Probe, { onReady: (rt: any) => (runtimeRef = rt) }),
+      ),
+    );
+
+    await waitFor(() => {
+      expect(runtimeRef).toBeTruthy();
+    });
+
+    const readyPromise = runtimeRef.waitForGraphReady?.();
+    unmount();
+
+    resolveCreate?.({
+      setParam: vi.fn(),
+      stageInput: vi.fn(),
+      evalAll: vi.fn(() => ({
+        toValueJSON: () => ({ nodes: {}, writes: [] }),
+      })),
+      step: vi.fn(),
+      setTime: vi.fn(),
+      free: vi.fn(),
+    });
+
+    if (readyPromise) {
+      await expect(
+        Promise.race([readyPromise, Promise.resolve("unmounted")]),
+      ).resolves.toBe("unmounted");
+    }
   });
 });

--- a/packages/@vizij/node-graph-react/src/__tests__/GraphProvider-load.test.ts
+++ b/packages/@vizij/node-graph-react/src/__tests__/GraphProvider-load.test.ts
@@ -9,51 +9,13 @@ import {
   afterEach,
 } from "vitest";
 import { render, waitFor, cleanup } from "@testing-library/react";
-import { GraphProvider } from "../GraphProvider";
-import { useGraphRuntime } from "../useGraphRuntime";
 
 // Mock @vizij/node-graph-wasm with a configurable createGraph
 let mode: "ok" | "fail" = "ok";
 let lastGraph: any = null;
 
-vi.mock("@vizij/node-graph-wasm", () => {
-  const init = vi.fn(async () => {});
-  // passthrough normalizer used by normalizeSpec()
-  const normalizeGraphSpec = vi.fn(async (spec: any) => spec);
-  const createGraph = vi.fn(async (_spec: any) => {
-    if (mode === "fail") {
-      throw new Error("mock createGraph error");
-    }
-    const graph = {
-      setParam: vi.fn((_nodeId: string, _key: string, _value: any) => {}),
-      stageInput: vi.fn((_path: string, _value: any, _shape?: any) => {}),
-      evalAll: vi.fn(() => {
-        return {
-          toValueJSON: () => ({
-            nodes: { test_node: { out: { value: { float: 1.0 } } } },
-            writes: [],
-          }),
-        };
-      }),
-      step: vi.fn((_dt: number) => {}),
-      setTime: vi.fn((_t: number) => {}),
-      free: vi.fn(() => {}),
-    };
-    lastGraph = graph;
-    return graph;
-  });
-  const toValueJSON = vi.fn((value: any) => value);
-  return {
-    init,
-    normalizeGraphSpec,
-    createGraph,
-    toValueJSON,
-    __setMode: (m: "ok" | "fail") => {
-      mode = m;
-    },
-    __getLastGraph: () => lastGraph,
-  };
-});
+let GraphProvider: typeof import("../GraphProvider").GraphProvider;
+let useGraphRuntime: typeof import("../useGraphRuntime").useGraphRuntime;
 
 function Probe({ onReady }: { onReady: (rt: any) => void }) {
   const rt = useGraphRuntime();
@@ -84,6 +46,52 @@ afterAll(() => {
 
 afterEach(() => {
   cleanup();
+  vi.clearAllMocks();
+  mode = "ok";
+  lastGraph = null;
+});
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.doMock("@vizij/node-graph-wasm", () => {
+    const init = vi.fn(async () => {});
+    const normalizeGraphSpec = vi.fn(async (spec: any) => spec);
+    const createGraph = vi.fn(async (_spec: any) => {
+      if (mode === "fail") {
+        throw new Error("mock createGraph error");
+      }
+      const graph = {
+        setParam: vi.fn((_nodeId: string, _key: string, _value: any) => {}),
+        stageInput: vi.fn((_path: string, _value: any, _shape?: any) => {}),
+        evalAll: vi.fn(() => {
+          return {
+            toValueJSON: () => ({
+              nodes: { test_node: { out: { value: { float: 1.0 } } } },
+              writes: [],
+            }),
+          };
+        }),
+        step: vi.fn((_dt: number) => {}),
+        setTime: vi.fn((_t: number) => {}),
+        free: vi.fn(() => {}),
+      };
+      lastGraph = graph;
+      return graph;
+    });
+    const toValueJSON = vi.fn((value: any) => value);
+    return {
+      init,
+      normalizeGraphSpec,
+      createGraph,
+      toValueJSON,
+      __setMode: (m: "ok" | "fail") => {
+        mode = m;
+      },
+      __getLastGraph: () => lastGraph,
+    };
+  });
+  ({ GraphProvider } = await import("../GraphProvider"));
+  ({ useGraphRuntime } = await import("../useGraphRuntime"));
 });
 
 describe("GraphProvider readiness", () => {

--- a/packages/@vizij/node-graph-react/src/__tests__/input-and-teardown.test.tsx
+++ b/packages/@vizij/node-graph-react/src/__tests__/input-and-teardown.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import type { FC } from "react";
 import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
 import { render, waitFor, cleanup, act } from "@testing-library/react";
 import type { GraphSpec } from "@vizij/node-graph-wasm";
@@ -78,7 +78,7 @@ describe("Input staging and teardown", () => {
   it("staging with immediateEval triggers evalAll on graph", async () => {
     let runtimeRef: any = null;
 
-    const Consumer: React.FC = () => {
+    const Consumer: FC = () => {
       const rt = useGraphRuntime();
       runtimeRef = rt;
       return <div data-testid="ready">{String(rt.ready)}</div>;
@@ -123,7 +123,7 @@ describe("Input staging and teardown", () => {
   });
 
   it("teardown frees the graph on unmount", async () => {
-    const Consumer: React.FC = () => {
+    const Consumer: FC = () => {
       const rt = useGraphRuntime();
       return <div data-testid="ready">{String(rt.ready)}</div>;
     };

--- a/packages/@vizij/node-graph-react/src/__tests__/input-and-teardown.test.tsx
+++ b/packages/@vizij/node-graph-react/src/__tests__/input-and-teardown.test.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
 import { render, waitFor, cleanup, act } from "@testing-library/react";
-import { GraphProvider, useGraphRuntime } from "../index";
 import type { GraphSpec } from "@vizij/node-graph-wasm";
 
 type MockGraphInstance = {
@@ -52,10 +51,15 @@ vi.mock("@vizij/node-graph-wasm", () => {
 });
 
 describe("Input staging and teardown", () => {
-  beforeEach(() => {
+  let GraphProvider: typeof import("../index").GraphProvider;
+  let useGraphRuntime: typeof import("../index").useGraphRuntime;
+
+  beforeEach(async () => {
     vi.clearAllMocks();
     graphInstances.length = 0;
     cleanup();
+    vi.resetModules();
+    ({ GraphProvider, useGraphRuntime } = await import("../index"));
   });
 
   const spec: GraphSpec = {

--- a/packages/@vizij/node-graph-react/src/__tests__/input-and-teardown.test.tsx
+++ b/packages/@vizij/node-graph-react/src/__tests__/input-and-teardown.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
-import { render, screen, waitFor, cleanup, act } from "@testing-library/react";
+import { render, waitFor, cleanup, act } from "@testing-library/react";
 import { GraphProvider, useGraphRuntime } from "../index";
 import type { GraphSpec } from "@vizij/node-graph-wasm";
 
@@ -80,7 +80,7 @@ describe("Input staging and teardown", () => {
       return <div data-testid="ready">{String(rt.ready)}</div>;
     };
 
-    render(
+    const { getByTestId } = render(
       <GraphProvider spec={specJson} autoStart={false}>
         <Consumer />
       </GraphProvider>,
@@ -88,7 +88,7 @@ describe("Input staging and teardown", () => {
 
     // Wait for provider to initialize and load the graph
     await waitFor(() => {
-      expect(screen.getByTestId("ready").textContent).toBe("true");
+      expect(getByTestId("ready").textContent).toBe("true");
     });
 
     // Wait for the provider to construct the graph instance
@@ -124,14 +124,14 @@ describe("Input staging and teardown", () => {
       return <div data-testid="ready">{String(rt.ready)}</div>;
     };
 
-    const { unmount } = render(
+    const { unmount, getByTestId } = render(
       <GraphProvider spec={specJson} autoStart={false}>
         <Consumer />
       </GraphProvider>,
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId("ready").textContent).toBe("true");
+      expect(getByTestId("ready").textContent).toBe("true");
     });
 
     await waitFor(() => {

--- a/packages/@vizij/node-graph-react/src/__tests__/node-graph-provider.test.tsx
+++ b/packages/@vizij/node-graph-react/src/__tests__/node-graph-provider.test.tsx
@@ -1,12 +1,6 @@
 import React from "react";
 import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
-import {
-  NodeGraphProvider,
-  useNodeGraph,
-  useGraphWrites,
-  valueAsNumber,
-} from "../index";
 import type { EvalResult, GraphSpec } from "@vizij/node-graph-wasm";
 
 type MockGraphInstance = {
@@ -71,7 +65,11 @@ vi.mock("@vizij/node-graph-wasm", () => {
   };
 });
 
-const TestConsumer: React.FC = () => {
+const TestConsumer: React.FC<{
+  useNodeGraph: typeof import("../index").useNodeGraph;
+  useGraphWrites: typeof import("../index").useGraphWrites;
+  valueAsNumber: typeof import("../index").valueAsNumber;
+}> = ({ useNodeGraph, useGraphWrites, valueAsNumber }) => {
   const { ready, getNodeOutputSnapshot, setParam, clearWrites } =
     useNodeGraph();
   const writes = useGraphWrites();
@@ -96,9 +94,17 @@ const TestConsumer: React.FC = () => {
 };
 
 describe("NodeGraphProvider", () => {
-  beforeEach(() => {
+  let NodeGraphProvider: typeof import("../index").NodeGraphProvider;
+  let useNodeGraph: typeof import("../index").useNodeGraph;
+  let useGraphWrites: typeof import("../index").useGraphWrites;
+  let valueAsNumber: typeof import("../index").valueAsNumber;
+
+  beforeEach(async () => {
     vi.clearAllMocks();
     graphInstances.length = 0;
+    vi.resetModules();
+    ({ NodeGraphProvider, useNodeGraph, useGraphWrites, valueAsNumber } =
+      await import("../index"));
   });
 
   const spec: GraphSpec = {
@@ -125,7 +131,11 @@ describe("NodeGraphProvider", () => {
   it("should expose evaluated outputs once initialization completes", async () => {
     render(
       <NodeGraphProvider spec={specJson} autostart={false}>
-        <TestConsumer />
+        <TestConsumer
+          useNodeGraph={useNodeGraph}
+          useGraphWrites={useGraphWrites}
+          valueAsNumber={valueAsNumber}
+        />
       </NodeGraphProvider>,
     );
 
@@ -141,7 +151,11 @@ describe("NodeGraphProvider", () => {
   it("should forward path updates through setParam", async () => {
     render(
       <NodeGraphProvider spec={specJson} autostart={false}>
-        <TestConsumer />
+        <TestConsumer
+          useNodeGraph={useNodeGraph}
+          useGraphWrites={useGraphWrites}
+          valueAsNumber={valueAsNumber}
+        />
       </NodeGraphProvider>,
     );
 

--- a/packages/@vizij/node-graph-react/src/__tests__/node-graph-provider.test.tsx
+++ b/packages/@vizij/node-graph-react/src/__tests__/node-graph-provider.test.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import type { FC } from "react";
 import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import type { EvalResult, GraphSpec } from "@vizij/node-graph-wasm";
@@ -65,7 +66,7 @@ vi.mock("@vizij/node-graph-wasm", () => {
   };
 });
 
-const TestConsumer: React.FC<{
+const TestConsumer: FC<{
   useNodeGraph: typeof import("../index").useNodeGraph;
   useGraphWrites: typeof import("../index").useGraphWrites;
   valueAsNumber: typeof import("../index").valueAsNumber;

--- a/packages/@vizij/node-graph-react/src/__tests__/playback-and-selectors.test.tsx
+++ b/packages/@vizij/node-graph-react/src/__tests__/playback-and-selectors.test.tsx
@@ -1,13 +1,6 @@
 import React from "react";
 import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
-import {
-  GraphProvider,
-  useGraphPlayback,
-  useGraphOutputs,
-  useGraphRuntime,
-  valueAsNumber,
-} from "../index";
 import type { EvalResult, GraphSpec } from "@vizij/node-graph-wasm";
 
 type MockGraphInstance = {
@@ -73,9 +66,23 @@ vi.mock("@vizij/node-graph-wasm", () => {
 });
 
 describe("Playback & Selectors", () => {
-  beforeEach(() => {
+  let GraphProvider: typeof import("../index").GraphProvider;
+  let useGraphPlayback: typeof import("../index").useGraphPlayback;
+  let useGraphOutputs: typeof import("../index").useGraphOutputs;
+  let useGraphRuntime: typeof import("../index").useGraphRuntime;
+  let valueAsNumber: typeof import("../index").valueAsNumber;
+
+  beforeEach(async () => {
     vi.clearAllMocks();
     graphInstances.length = 0;
+    vi.resetModules();
+    ({
+      GraphProvider,
+      useGraphPlayback,
+      useGraphOutputs,
+      useGraphRuntime,
+      valueAsNumber,
+    } = await import("../index"));
   });
 
   const spec: GraphSpec = {

--- a/packages/@vizij/node-graph-react/src/__tests__/playback-and-selectors.test.tsx
+++ b/packages/@vizij/node-graph-react/src/__tests__/playback-and-selectors.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import type { FC } from "react";
 import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import type { EvalResult, GraphSpec } from "@vizij/node-graph-wasm";
@@ -107,7 +107,7 @@ describe("Playback & Selectors", () => {
   const specJson = JSON.stringify(spec);
 
   it("useGraphPlayback can start/stop and reflect mode", async () => {
-    const PlaybackConsumer: React.FC = () => {
+    const PlaybackConsumer: FC = () => {
       const pb = useGraphPlayback();
       const rt = useGraphRuntime();
 
@@ -151,7 +151,7 @@ describe("Playback & Selectors", () => {
   });
 
   it("useGraphOutputs selector returns node output and updates after load", async () => {
-    const SelectorConsumer: React.FC = () => {
+    const SelectorConsumer: FC = () => {
       const val = useGraphOutputs(
         (snap) => snap?.evalResult?.nodes?.const?.out ?? null,
       );

--- a/packages/@vizij/node-graph-react/src/__tests__/samples.test.tsx
+++ b/packages/@vizij/node-graph-react/src/__tests__/samples.test.tsx
@@ -1,15 +1,14 @@
 /* @vitest-environment jsdom */
-
-import React from "react";
+import type { FC } from "react";
 import { describe, it, expect, afterAll, vi } from "vitest";
 import { render, waitFor } from "@testing-library/react";
+import { init as initNodeGraphWasm } from "@vizij/node-graph-wasm";
 import {
   GraphProvider,
   useGraphRuntime,
   samples,
   valueAsNumber,
 } from "../index";
-import { init as initNodeGraphWasm } from "@vizij/node-graph-wasm";
 import { getNodeGraphWasmInitInput } from "./helpers";
 
 describe("@vizij/node-graph-react samples", () => {
@@ -31,7 +30,7 @@ describe("@vizij/node-graph-react samples", () => {
     const spec = await samples.load("simple-gain-offset");
     let runtimeRef: ReturnType<typeof useGraphRuntime> | null = null;
 
-    const Harness: React.FC = () => {
+    const Harness: FC = () => {
       const runtime = useGraphRuntime();
       runtimeRef = runtime;
       return null;

--- a/packages/@vizij/node-graph-react/src/__tests__/samples.test.tsx
+++ b/packages/@vizij/node-graph-react/src/__tests__/samples.test.tsx
@@ -1,8 +1,8 @@
 /* @vitest-environment jsdom */
 
 import React from "react";
-import { describe, it, expect } from "vitest";
-import { render, act } from "@testing-library/react";
+import { describe, it, expect, afterAll, vi } from "vitest";
+import { render } from "@testing-library/react";
 import {
   GraphProvider,
   useGraphRuntime,
@@ -12,88 +12,80 @@ import {
 } from "../index";
 import { getNodeGraphWasmInitInput } from "./helpers";
 
-type Deferred<T> = {
-  promise: Promise<T>;
-  resolve: (value: T) => void;
-  reject: (reason: unknown) => void;
-};
-
-function createDeferred<T>(): Deferred<T> {
-  let resolve!: (value: T) => void;
-  let reject!: (reason: unknown) => void;
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  return { promise, resolve, reject };
-}
-
 describe("@vizij/node-graph-react samples", () => {
+  const originalError = console.error;
+  const errorSpy = vi
+    .spyOn(console, "error")
+    .mockImplementation((msg, ...args) => {
+      if (typeof msg === "string" && msg.includes("not wrapped in act")) {
+        return;
+      }
+      originalError.call(console, msg as any, ...args);
+    });
+
+  afterAll(() => {
+    errorSpy.mockRestore();
+  });
+
   it("evaluates the simple gain/offset graph sample", async () => {
-    await initNodeGraphWasm(getNodeGraphWasmInitInput());
     const spec = await samples.load("simple-gain-offset");
-    const deferred = createDeferred<number[]>();
+    let runtimeRef: ReturnType<typeof useGraphRuntime> | null = null;
 
     const Harness: React.FC = () => {
       const runtime = useGraphRuntime();
-      const stagedRef = React.useRef(false);
-
-      React.useEffect(() => {
-        if (!runtime.ready || stagedRef.current) return;
-        stagedRef.current = true;
-        (async () => {
-          try {
-            const values: number[] = [];
-            const pushIfNew = (val: number | undefined) => {
-              if (typeof val !== "number") return;
-              const prev = values[values.length - 1];
-              if (typeof prev !== "number" || Math.abs(prev - val) > 1e-6) {
-                values.push(val);
-              }
-            };
-
-            const evaluate = () => {
-              const result = runtime.evalAll();
-              const writes = result?.writes ?? [];
-              const hit = writes.find(
-                (w: any) => w?.path === "demo/output/value",
-              );
-              const num = hit ? valueAsNumber(hit.value as any) : undefined;
-              pushIfNew(num);
-            };
-
-            await act(async () => {
-              await runtime.waitForGraphReady?.();
-              evaluate();
-              runtime.stageInput("node.t", 0.5, undefined, true);
-              evaluate();
-              runtime.stageInput("node.t", 1.0, undefined, true);
-              evaluate();
-            });
-
-            deferred.resolve(values);
-          } catch (err) {
-            deferred.reject(err);
-          }
-        })().catch((err) => deferred.reject(err));
-      }, [runtime]);
-
+      runtimeRef = runtime;
       return null;
     };
 
-    render(
+    await initNodeGraphWasm(getNodeGraphWasmInitInput());
+    const { unmount } = render(
       <GraphProvider
         spec={spec}
         autoStart={false}
         wasmInitInput={getNodeGraphWasmInitInput()}
+        waitForGraph={false}
+        exposeGraphReadyPromise={false}
       >
         <Harness />
       </GraphProvider>,
     );
 
-    const values = await deferred.promise;
+    for (let i = 0; i < 200; i += 1) {
+      if (runtimeRef?.ready) break;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    if (!runtimeRef?.ready) {
+      throw new Error("runtime did not become ready in time");
+    }
+
+    const values: number[] = [];
+    const pushIfNew = (val: number | undefined) => {
+      if (typeof val !== "number") return;
+      const prev = values[values.length - 1];
+      if (typeof prev !== "number" || Math.abs(prev - val) > 1e-6) {
+        values.push(val);
+      }
+    };
+
+    const evaluate = () => {
+      if (!runtimeRef) return;
+      const result = runtimeRef.evalAll();
+      const writes = result?.writes ?? [];
+      const hit = writes.find((w: any) => w?.path === "demo/output/value");
+      const num = hit ? valueAsNumber(hit.value as any) : undefined;
+      pushIfNew(num);
+    };
+
+    evaluate();
+    runtimeRef?.stageInput("node.t", 0.5, undefined, true);
+    evaluate();
+    runtimeRef?.stageInput("node.t", 1.0, undefined, true);
+    evaluate();
+
+    unmount();
+
     expect(values[0]).toBeCloseTo(0.25, 3);
     expect(values[1]).toBeCloseTo(1.0, 3);
     expect(values[2]).toBeCloseTo(1.75, 3);
-  });
+  }, 10000);
 });

--- a/packages/@vizij/node-graph-react/src/__tests__/samples.test.tsx
+++ b/packages/@vizij/node-graph-react/src/__tests__/samples.test.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { describe, it, expect, afterAll, vi } from "vitest";
-import { render } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 import {
   GraphProvider,
   useGraphRuntime,
@@ -43,20 +43,15 @@ describe("@vizij/node-graph-react samples", () => {
         spec={spec}
         autoStart={false}
         wasmInitInput={getNodeGraphWasmInitInput()}
-        waitForGraph={false}
-        exposeGraphReadyPromise={false}
       >
         <Harness />
       </GraphProvider>,
     );
 
-    for (let i = 0; i < 200; i += 1) {
-      if (runtimeRef?.ready) break;
-      await new Promise((resolve) => setTimeout(resolve, 10));
-    }
-    if (!runtimeRef?.ready) {
-      throw new Error("runtime did not become ready in time");
-    }
+    await waitFor(() => {
+      expect(runtimeRef?.ready).toBe(true);
+    });
+    await runtimeRef?.waitForGraphReady?.();
 
     const values: number[] = [];
     const pushIfNew = (val: number | undefined) => {

--- a/packages/@vizij/node-graph-react/src/__tests__/samples.test.tsx
+++ b/packages/@vizij/node-graph-react/src/__tests__/samples.test.tsx
@@ -8,8 +8,8 @@ import {
   useGraphRuntime,
   samples,
   valueAsNumber,
-  init as initNodeGraphWasm,
 } from "../index";
+import { init as initNodeGraphWasm } from "@vizij/node-graph-wasm";
 import { getNodeGraphWasmInitInput } from "./helpers";
 
 describe("@vizij/node-graph-react samples", () => {

--- a/packages/@vizij/node-graph-react/src/__tests__/urdf-fk-ik.test.tsx
+++ b/packages/@vizij/node-graph-react/src/__tests__/urdf-fk-ik.test.tsx
@@ -1,10 +1,12 @@
 /* @vitest-environment node */
-
-import React, { useEffect } from "react";
+import { resolve as resolvePath } from "node:path";
+import { readFile } from "node:fs/promises";
+import { useEffect } from "react";
+import type { FC } from "react";
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { render, cleanup, waitFor, act } from "@testing-library/react";
 import { JSDOM } from "jsdom";
-
+import type { GraphSpec, ValueJSON } from "@vizij/node-graph-wasm";
 import {
   NodeGraphProvider,
   useGraphRuntime,
@@ -12,9 +14,6 @@ import {
   init as initGraphWasm,
 } from "../index";
 import type { GraphRuntimeContextValue } from "../types";
-import type { GraphSpec, ValueJSON } from "@vizij/node-graph-wasm";
-import { resolve as resolvePath } from "node:path";
-import { readFile } from "node:fs/promises";
 
 const urdfXml = `
 <robot name="planar_arm">
@@ -160,7 +159,7 @@ const runtimeRef: { current: GraphRuntimeContextValue | null } = {
   current: null,
 };
 
-const RuntimeTap: React.FC = () => {
+const RuntimeTap: FC = () => {
   const runtime = useGraphRuntime();
   useEffect(() => {
     runtimeRef.current = runtime;

--- a/packages/@vizij/node-graph-react/src/__tests__/urdf-fk-ik.test.tsx
+++ b/packages/@vizij/node-graph-react/src/__tests__/urdf-fk-ik.test.tsx
@@ -220,11 +220,8 @@ describe("URDF FK/IK integration", () => {
 
   afterAll(() => {
     cleanup();
-    delete (globalThis as any).window;
-    delete (globalThis as any).document;
-    delete (globalThis as any).navigator;
-    delete (globalThis as any).requestAnimationFrame;
-    delete (globalThis as any).cancelAnimationFrame;
+    // Keep the JSDOM globals to avoid late scheduler callbacks throwing
+    // when React flushes work after this test completes.
   });
 
   it("solves IK results that replay through FK via the React provider", async () => {

--- a/packages/@vizij/node-graph-react/src/__tests__/urdf-fk-ik.test.tsx
+++ b/packages/@vizij/node-graph-react/src/__tests__/urdf-fk-ik.test.tsx
@@ -179,6 +179,11 @@ describe("URDF FK/IK integration", () => {
         userAgent: "node.js",
       },
     });
+    (globalThis as any).requestAnimationFrame = (cb: FrameRequestCallback) =>
+      setTimeout(() => cb(Date.now()), 0) as unknown as number;
+    (globalThis as any).cancelAnimationFrame = (id: number) => {
+      clearTimeout(id as unknown as NodeJS.Timeout);
+    };
 
     const candidatePaths = [
       "node_modules/@vizij/node-graph-wasm/dist/pkg/vizij_graph_wasm_bg.wasm",
@@ -218,6 +223,8 @@ describe("URDF FK/IK integration", () => {
     delete (globalThis as any).window;
     delete (globalThis as any).document;
     delete (globalThis as any).navigator;
+    delete (globalThis as any).requestAnimationFrame;
+    delete (globalThis as any).cancelAnimationFrame;
   });
 
   it("solves IK results that replay through FK via the React provider", async () => {

--- a/packages/@vizij/node-graph-react/src/compat.tsx
+++ b/packages/@vizij/node-graph-react/src/compat.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback } from "react";
+import { useCallback } from "react";
+import type { FC } from "react";
 import { GraphProvider } from "./GraphProvider";
 import { useGraphContext } from "./GraphContext";
 import { useGraphOutputs } from "./useGraphOutputs";
@@ -13,7 +14,7 @@ import { valueAsNumber } from "./valueHelpers";
  */
 
 /** Alias provider to old name (accepts legacy `autostart` prop) */
-export const NodeGraphProvider: React.FC<any> = ({
+export const NodeGraphProvider: FC<any> = ({
   autostart,
   autoStart,
   spec,

--- a/packages/@vizij/node-graph-react/src/types.ts
+++ b/packages/@vizij/node-graph-react/src/types.ts
@@ -2,7 +2,7 @@
  * Shared types for @vizij/node-graph-react
  * These bridge to @vizij/node-graph-wasm type exports and add local runtime types.
  */
-
+import type { ReactNode } from "react";
 import type {
   Graph as WasmGraph,
   GraphSpec,
@@ -26,7 +26,7 @@ export interface PlaybackConfig {
 
 /* Provider props (match GraphProvider implementation) */
 export interface GraphProviderProps {
-  children?: React.ReactNode;
+  children?: ReactNode;
   spec?: GraphSpec | string;
   autoStart?: boolean;
   autoMode?: PlaybackMode;

--- a/packages/@vizij/node-graph-react/vitest.config.ts
+++ b/packages/@vizij/node-graph-react/vitest.config.ts
@@ -4,7 +4,8 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     globals: true,
-    pool: "threads",
+    pool: "forks",
+    isolate: false,
   },
   optimizeDeps: {
     exclude: ["@vizij/node-graph-wasm"], // ← important

--- a/packages/@vizij/node-graph-react/vitest.config.ts
+++ b/packages/@vizij/node-graph-react/vitest.config.ts
@@ -5,7 +5,6 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     pool: "forks",
-    isolate: false,
   },
   optimizeDeps: {
     exclude: ["@vizij/node-graph-wasm"], // ← important

--- a/packages/@vizij/orchestrator-react/package.json
+++ b/packages/@vizij/orchestrator-react/package.json
@@ -46,14 +46,16 @@
     "react-dom": ">=18"
   },
   "devDependencies": {
-    "@testing-library/react": "^14.3.1",
-    "@types/react": "^18.2.0",
+    "@testing-library/react": "^16.3.1",
+    "@types/react": "^19.2.7",
     "jsdom": "^24.1.3",
     "typescript": "^5.5.0",
     "vitest": "^3.2.4",
     "prettier": "^3.4.2",
-    "react-dom": "^18.2.0",
-    "tsup": "^8.0.1"
+    "react-dom": "^19.2.3",
+    "tsup": "^8.0.1",
+    "@testing-library/dom": "^10.4.1",
+    "react": "^19.2.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@vizij/orchestrator-react/src/OrchestratorProvider.tsx
+++ b/packages/@vizij/orchestrator-react/src/OrchestratorProvider.tsx
@@ -1,16 +1,12 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { ReactNode } from "react";
 import {
   init as initOrchestratorWasm,
   createOrchestrator as createOrchestratorWasm,
   abi_version as orchestratorAbiVersion,
   type Orchestrator as OrchestratorRuntime,
 } from "@vizij/orchestrator-wasm";
+import type { JSX } from "react/jsx-runtime";
 import { OrchestratorContext } from "./context";
 import type {
   ControllerId,
@@ -68,7 +64,7 @@ function normalizeTypedPath(path: string): string {
 }
 
 export type OrchestratorProviderProps = {
-  children: React.ReactNode;
+  children: ReactNode;
   /** Optional init() input forwarded to the wasm layer. */
   initInput?: InitInput;
   /** Automatically create a runtime orchestration instance on mount. Defaults to true. */
@@ -92,7 +88,7 @@ export function OrchestratorProvider({
   autoCreate = true,
   createOptions,
   autostart = false,
-}: OrchestratorProviderProps): React.JSX.Element {
+}: OrchestratorProviderProps): JSX.Element {
   const mountedRef = useRef(false);
   useEffect(() => {
     // React StrictMode double-mounts components in dev; ensure we reset to true on every mount.

--- a/packages/@vizij/orchestrator-react/src/OrchestratorProvider.tsx
+++ b/packages/@vizij/orchestrator-react/src/OrchestratorProvider.tsx
@@ -92,7 +92,7 @@ export function OrchestratorProvider({
   autoCreate = true,
   createOptions,
   autostart = false,
-}: OrchestratorProviderProps): JSX.Element {
+}: OrchestratorProviderProps): React.JSX.Element {
   const mountedRef = useRef(false);
   useEffect(() => {
     // React StrictMode double-mounts components in dev; ensure we reset to true on every mount.

--- a/packages/@vizij/orchestrator-react/src/__tests__/samples.test.tsx
+++ b/packages/@vizij/orchestrator-react/src/__tests__/samples.test.tsx
@@ -1,8 +1,10 @@
 /* @vitest-environment jsdom */
-
 import React from "react";
+import type { FC } from "react";
 import { describe, it, expect, vi } from "vitest";
 import { render, act } from "@testing-library/react";
+import { toValueJSON, type ValueInput } from "@vizij/value-json";
+import { cloneDeepSafe } from "@vizij/utils";
 import {
   OrchestratorProvider,
   useOrchestrator,
@@ -10,8 +12,6 @@ import {
   samples,
 } from "../index";
 import type { GraphRegistrationInput, GraphRegistrationConfig } from "../index";
-import { toValueJSON, type ValueInput } from "@vizij/value-json";
-import { cloneDeepSafe } from "@vizij/utils";
 
 const SAMPLE_DESCRIPTOR = {
   description: "Scalar ramp animation drives a gain/offset graph",
@@ -298,7 +298,7 @@ describe("@vizij/orchestrator-react samples", () => {
     const bundle = await samples.loadBundle("scalar-ramp-pipeline");
     const deferred = createDeferred<Array<Record<string, number>>>();
 
-    const Harness: React.FC = () => {
+    const Harness: FC = () => {
       const orch = useOrchestrator();
       const registeredRef = React.useRef(false);
 

--- a/packages/@vizij/orchestrator-react/test/OrchestratorProvider.test.tsx
+++ b/packages/@vizij/orchestrator-react/test/OrchestratorProvider.test.tsx
@@ -1,6 +1,13 @@
 import React from "react";
 import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import {
+  render,
+  screen,
+  waitFor,
+  fireEvent,
+  act,
+  cleanup,
+} from "@testing-library/react";
 import {
   OrchestratorProvider,
   useOrchestrator,
@@ -8,6 +15,7 @@ import {
   useOrchTarget,
 } from "../src";
 import type { OrchestratorFrame, ValueJSON } from "../src/types";
+import { createOrchestrator } from "@vizij/orchestrator-wasm";
 
 type OrchestratorMock = {
   registerGraph: Mock;
@@ -137,6 +145,10 @@ describe("OrchestratorProvider", () => {
     orchestratorInstances.length = 0;
     stepResultRef.current = null;
     vi.clearAllMocks();
+    cleanup();
+    vi.mocked(createOrchestrator).mockImplementation(async () =>
+      makeInstance(),
+    );
   });
 
   const renderHarness = () =>
@@ -198,5 +210,63 @@ describe("OrchestratorProvider", () => {
 
     const instance = orchestratorInstances[0];
     expect(instance.step).toHaveBeenCalledWith(1 / 60);
+  });
+
+  it("does not set state after unmount when create resolves late", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    let resolveCreate: ((value: OrchestratorMock) => void) | null = null;
+    vi.mocked(createOrchestrator).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveCreate = resolve;
+        }),
+    );
+
+    const { unmount } = render(
+      <OrchestratorProvider autostart={false}>
+        <Harness />
+      </OrchestratorProvider>,
+    );
+
+    // Unmount before the async create resolves.
+    unmount();
+
+    await act(async () => {
+      resolveCreate?.(makeInstance());
+      await Promise.resolve();
+    });
+
+    expect(consoleError).not.toHaveBeenCalled();
+    vi.mocked(createOrchestrator).mockImplementation(async () =>
+      makeInstance(),
+    );
+    consoleError.mockRestore();
+  });
+
+  it("handles mount/unmount/remount without leaving ready false", async () => {
+    const first = render(
+      <OrchestratorProvider autostart={false}>
+        <Harness />
+      </OrchestratorProvider>,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("ready").textContent).toBe("ready"),
+    );
+    first.unmount();
+
+    const second = render(
+      <OrchestratorProvider autostart={false}>
+        <Harness />
+      </OrchestratorProvider>,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("ready").textContent).toBe("ready"),
+    );
+    second.unmount();
+
+    expect(vi.mocked(createOrchestrator)).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/@vizij/orchestrator-react/test/OrchestratorProvider.test.tsx
+++ b/packages/@vizij/orchestrator-react/test/OrchestratorProvider.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import type { FC } from "react";
 import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
 import {
   render,
@@ -8,6 +8,7 @@ import {
   act,
   cleanup,
 } from "@testing-library/react";
+import { createOrchestrator } from "@vizij/orchestrator-wasm";
 import {
   OrchestratorProvider,
   useOrchestrator,
@@ -15,7 +16,6 @@ import {
   useOrchTarget,
 } from "../src";
 import type { OrchestratorFrame, ValueJSON } from "../src/types";
-import { createOrchestrator } from "@vizij/orchestrator-wasm";
 
 type OrchestratorMock = {
   registerGraph: Mock;
@@ -112,7 +112,7 @@ vi.mock("@vizij/orchestrator-wasm", async () => {
   };
 });
 
-const Harness: React.FC = () => {
+const Harness: FC = () => {
   const ctx = useOrchestrator();
   const frame = useOrchFrame();
   const latest = useOrchTarget("demo/output/value");

--- a/packages/@vizij/orchestrator-react/vitest.config.ts
+++ b/packages/@vizij/orchestrator-react/vitest.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from "vitest/config";
 import { resolve } from "node:path";
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {

--- a/packages/@vizij/render/package.json
+++ b/packages/@vizij/render/package.json
@@ -48,8 +48,8 @@
     "three-stdlib": "^2.35.13"
   },
   "peerDependencies": {
-    "@react-three/drei": "^9.115.0",
-    "@react-three/fiber": "^8.17.10",
+    "@react-three/drei": "^10.7.7",
+    "@react-three/fiber": "^9.5.0",
     "react": ">=18",
     "react-dom": ">=18",
     "tailwindcss": "^4.1.3",
@@ -57,15 +57,15 @@
     "zustand": "^5.0.2"
   },
   "devDependencies": {
-    "@react-three/drei": "^9.115.0",
-    "@react-three/fiber": "^8.17.10",
+    "@react-three/drei": "^10.7.7",
+    "@react-three/fiber": "^9.5.0",
     "@types/deep-equal": "^1.0.4",
     "@types/lodash": "^4.17.4",
-    "@types/react": "^18.3.1",
+    "@types/react": "^19.2.7",
     "@types/three": "^0.170.0",
     "@size-limit/file": "^11.2.0",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3",
     "size-limit": "^11.1.7",
     "three": "^0.170.0",
     "zustand": "^5.0.2",

--- a/packages/@vizij/render/src/actions/create-new-element.ts
+++ b/packages/@vizij/render/src/actions/create-new-element.ts
@@ -1,10 +1,11 @@
-import { type RefObject, createRef } from "react";
+import { createRef } from "react";
+import type { RefObject } from "react";
 import { mapValues } from "lodash";
-import { Group as ThreeGroup } from "three";
+import type { Group as ThreeGroup } from "three";
 import { createDefaultGroup } from "../functions/create-world-element";
-import { World } from "../types/world";
-import { VizijData } from "../store-types";
-import { Group as RenderGroup } from "../types/group";
+import type { World } from "../types/world";
+import type { VizijData } from "../store-types";
+import type { Group as RenderGroup } from "../types/group";
 import type { Selection } from "../types/selection";
 
 export function createNewElement(

--- a/packages/@vizij/render/src/actions/remove-children.ts
+++ b/packages/@vizij/render/src/actions/remove-children.ts
@@ -1,5 +1,5 @@
-import { VizijData } from "../store-types";
-import { World } from "../types/world";
+import type { VizijData } from "../store-types";
+import type { World } from "../types/world";
 
 export function removeFromTree(
   state: VizijData,

--- a/packages/@vizij/render/src/effects/selection-glow-effect.tsx
+++ b/packages/@vizij/render/src/effects/selection-glow-effect.tsx
@@ -1,20 +1,22 @@
 import { Fragment, useEffect, useMemo, useRef } from "react";
+import type { RefObject } from "react";
 import { useFrame } from "@react-three/fiber";
 import { useShallow } from "zustand/react/shallow";
+import type {
+  BufferGeometry,
+  ColorRepresentation,
+  LineSegments,
+  Object3D,
+} from "three";
 import {
   AdditiveBlending,
-  BufferGeometry,
   Color,
-  ColorRepresentation,
   EdgesGeometry,
   LineBasicMaterial,
-  LineSegments,
   Matrix4,
-  Object3D,
   Quaternion,
   Vector3,
 } from "three";
-import type { RefObject } from "react";
 import type { Selection } from "../types";
 import type { VizijActions, VizijData } from "../store-types";
 import { useVizijStore } from "../hooks/use-vizij-store";

--- a/packages/@vizij/render/src/functions/compare-data.ts
+++ b/packages/@vizij/render/src/functions/compare-data.ts
@@ -1,7 +1,8 @@
+import type { AnimatableValue } from "@vizij/utils";
+import type { World } from "../types/world";
+
 // import { mapValues } from "lodash";
-import { AnimatableValue } from "@vizij/utils";
 // import stringify from "json-stable-stringify";
-import { World } from "../types/world";
 // import { Shape, StoredShape } from "../types/shape";
 // import { Body, StoredBody } from "../types/body";
 // import { Joint, JointType, StoredJoint } from "../types/joint";

--- a/packages/@vizij/render/src/functions/create-animatable.ts
+++ b/packages/@vizij/render/src/functions/create-animatable.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AnimatableValue,
   AnimatableBoolean,
   AnimatableColor,

--- a/packages/@vizij/render/src/functions/create-stored-data.ts
+++ b/packages/@vizij/render/src/functions/create-stored-data.ts
@@ -1,8 +1,8 @@
 import { omit } from "lodash";
-import { AnimatableValue } from "@vizij/utils";
+import type { AnimatableValue } from "@vizij/utils";
 import { type Stored } from "../types/stored";
 import { type RenderableBase } from "../types/renderable-base";
-import { Feature } from "../types/feature";
+import type { Feature } from "../types/feature";
 import { createStoredFeatures } from "./create-stored-features";
 
 export function createStoredRenderable<T extends RenderableBase>(

--- a/packages/@vizij/render/src/functions/create-stored-features.ts
+++ b/packages/@vizij/render/src/functions/create-stored-features.ts
@@ -1,6 +1,6 @@
 import { mapValues } from "lodash";
-import { AnimatableValue } from "@vizij/utils";
-import {
+import type { AnimatableValue } from "@vizij/utils";
+import type {
   Feature,
   StaticFeature,
   StoredAnimatedFeature,

--- a/packages/@vizij/render/src/functions/create-world-element.ts
+++ b/packages/@vizij/render/src/functions/create-world-element.ts
@@ -1,7 +1,7 @@
 import type { RefObject } from "react";
 import type { Group as ThreeGroup } from "three";
-import { Feature } from "../types/feature";
-import { Group } from "../types/group";
+import type { Feature } from "../types/feature";
+import type { Group } from "../types/group";
 
 export function createDefaultGroup(partialBody: Partial<Group>): Group {
   const translation: Feature =

--- a/packages/@vizij/render/src/functions/export.ts
+++ b/packages/@vizij/render/src/functions/export.ts
@@ -1,5 +1,5 @@
 import { GLTFExporter } from "three-stdlib";
-import { AnimationClip, Group } from "three";
+import type { AnimationClip, Group } from "three";
 import * as THREE from "three";
 import type { VizijBundleExtension } from "../types";
 import { applyVizijBundle } from "./vizij-bundle";

--- a/packages/@vizij/render/src/functions/gltf-loading/extract-animations.ts
+++ b/packages/@vizij/render/src/functions/gltf-loading/extract-animations.ts
@@ -34,9 +34,9 @@ const CHANNEL_PATH_TO_TRACK_PROPERTY: Record<string, string> = {
 function isPlainObject(value: unknown): value is PlainObject {
   return Boolean(
     value &&
-      typeof value === "object" &&
-      !Array.isArray(value) &&
-      Object.prototype.toString.call(value) === "[object Object]",
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Object.prototype.toString.call(value) === "[object Object]",
   );
 }
 

--- a/packages/@vizij/render/src/functions/gltf-loading/extract-animations.ts
+++ b/packages/@vizij/render/src/functions/gltf-loading/extract-animations.ts
@@ -1,9 +1,9 @@
 import type { AnimationClip, KeyframeTrack } from "three";
+import { cloneDeepSafe } from "@vizij/utils";
 import type {
   VizijAnimationClipData,
   VizijAnimationTrackData,
 } from "../../types/animations";
-import { cloneDeepSafe } from "@vizij/utils";
 
 type PlainObject = Record<string, unknown>;
 

--- a/packages/@vizij/render/src/functions/gltf-loading/import-geometry.ts
+++ b/packages/@vizij/render/src/functions/gltf-loading/import-geometry.ts
@@ -1,6 +1,6 @@
-import { BufferGeometry, Mesh } from "three";
-import { AnimatableValue, AnimatableNumber } from "@vizij/utils";
-import { Feature } from "../../types";
+import type { BufferGeometry, Mesh } from "three";
+import type { AnimatableValue, AnimatableNumber } from "@vizij/utils";
+import type { Feature } from "../../types";
 
 function sanitizeMorphKey(
   name: string,

--- a/packages/@vizij/render/src/functions/gltf-loading/import-group.ts
+++ b/packages/@vizij/render/src/functions/gltf-loading/import-group.ts
@@ -1,11 +1,12 @@
-import { Object3D, Group, Mesh } from "three";
-import {
+import type { Group, Mesh } from "three";
+import { Object3D } from "three";
+import type {
   AnimatableEuler,
   AnimatableValue,
   AnimatableVector3,
   RawVector2,
 } from "@vizij/utils";
-import { World, Group as VizijGroup } from "../../types";
+import type { World, Group as VizijGroup } from "../../types";
 import { namespaceArrayToRefs } from "../util";
 import { importMesh } from "./import-mesh";
 

--- a/packages/@vizij/render/src/functions/gltf-loading/import-mesh.ts
+++ b/packages/@vizij/render/src/functions/gltf-loading/import-mesh.ts
@@ -1,5 +1,4 @@
-import {
-  Object3D,
+import type {
   Mesh,
   MeshStandardMaterial,
   MeshPhongMaterial,
@@ -8,14 +7,16 @@ import {
   MeshLambertMaterial,
   MeshPhysicalMaterial,
 } from "three";
-import {
+import { Object3D } from "three";
+import type {
   AnimatableEuler,
   AnimatableValue,
   AnimatableVector3,
   AnimatableColor,
   AnimatableNumber,
 } from "@vizij/utils";
-import { World, Shape, ShapeMaterial } from "../../types";
+import type { World, Shape } from "../../types";
+import { ShapeMaterial } from "../../types";
 import { namespaceArrayToRefs } from "../util";
 import { importGeometry } from "./import-geometry";
 

--- a/packages/@vizij/render/src/functions/gltf-loading/import-scene.ts
+++ b/packages/@vizij/render/src/functions/gltf-loading/import-scene.ts
@@ -1,6 +1,7 @@
-import { Object3D, Group } from "three";
-import { AnimatableValue, RawVector2 } from "@vizij/utils";
-import { World } from "../../types";
+import type { Group } from "three";
+import { Object3D } from "three";
+import type { AnimatableValue, RawVector2 } from "@vizij/utils";
+import type { World } from "../../types";
 import { importGroup } from "./import-group";
 
 Object3D.DEFAULT_UP.set(0, 0, 1);

--- a/packages/@vizij/render/src/functions/gltf-loading/map-features.ts
+++ b/packages/@vizij/render/src/functions/gltf-loading/map-features.ts
@@ -1,5 +1,5 @@
 import { type AnimatableValue } from "@vizij/utils";
-import {
+import type {
   AnimatedFeature,
   StaticFeature,
   StoredAnimatedFeature,

--- a/packages/@vizij/render/src/functions/gltf-loading/traverse-three.ts
+++ b/packages/@vizij/render/src/functions/gltf-loading/traverse-three.ts
@@ -1,8 +1,8 @@
 import { createRef } from "react";
 import * as THREE from "three";
-import { Group, Mesh, Material, Object3D } from "three";
-import { AnimatableValue, RawVector2 } from "@vizij/utils";
-import {
+import type { Group, Mesh, Material, Object3D } from "three";
+import type { AnimatableValue, RawVector2 } from "@vizij/utils";
+import type {
   World,
   RenderableBase,
   StoredRenderable,

--- a/packages/@vizij/render/src/functions/load-gltf-blob.ts
+++ b/packages/@vizij/render/src/functions/load-gltf-blob.ts
@@ -1,6 +1,7 @@
-import { DRACOLoader, GLTFLoader, GLTF } from "three-stdlib";
-import { AnimatableValue } from "@vizij/utils";
-import { World } from "../types";
+import type { GLTF } from "three-stdlib";
+import { DRACOLoader, GLTFLoader } from "three-stdlib";
+import type { AnimatableValue } from "@vizij/utils";
+import type { World } from "../types";
 import { traverseThree } from "./gltf-loading/traverse-three";
 
 /**

--- a/packages/@vizij/render/src/functions/load-gltf.ts
+++ b/packages/@vizij/render/src/functions/load-gltf.ts
@@ -1,8 +1,9 @@
 import * as THREE from "three";
-import { AnimationClip, Group } from "three";
-import { GLTFLoader, DRACOLoader, GLTF } from "three-stdlib";
-import { AnimatableValue, RawVector2 } from "@vizij/utils";
-import { World } from "../types/world";
+import type { AnimationClip, Group } from "three";
+import type { GLTF } from "three-stdlib";
+import { GLTFLoader, DRACOLoader } from "three-stdlib";
+import type { AnimatableValue, RawVector2 } from "@vizij/utils";
+import type { World } from "../types/world";
 import type { VizijBundleExtension, VizijAnimationClipData } from "../types";
 import { traverseThree } from "./gltf-loading/traverse-three";
 import { extractVizijBundle } from "./vizij-bundle";

--- a/packages/@vizij/render/src/functions/transforms.ts
+++ b/packages/@vizij/render/src/functions/transforms.ts
@@ -1,4 +1,4 @@
-import { Object3D } from "three";
+import type { Object3D } from "three";
 import * as THREE from "three";
 
 THREE.Object3D.DEFAULT_UP.set(0, 0, 1);

--- a/packages/@vizij/render/src/functions/util.ts
+++ b/packages/@vizij/render/src/functions/util.ts
@@ -1,4 +1,5 @@
-import { createRef, type RefObject } from "react";
+import { createRef } from "react";
+import type { RefObject } from "react";
 
 export function iterateOrExtract(data: any, cb: (data: any) => void): void {
   if (Array.isArray(data)) {

--- a/packages/@vizij/render/src/functions/vizij-bundle.ts
+++ b/packages/@vizij/render/src/functions/vizij-bundle.ts
@@ -1,6 +1,6 @@
-import { Object3D } from "three";
-import type { VizijBundleExtension } from "../types";
+import type { Object3D } from "three";
 import { cloneDeepSafe } from "@vizij/utils";
+import type { VizijBundleExtension } from "../types";
 
 const BUNDLE_KEYS = ["VIZIJ_bundle"];
 

--- a/packages/@vizij/render/src/hooks/use-deep.ts
+++ b/packages/@vizij/render/src/hooks/use-deep.ts
@@ -2,7 +2,7 @@ import { useRef } from "react";
 import deepEqual from "deep-equal";
 
 export function useDeep<S, U>(selector: (state: S) => U): (state: S) => U {
-  const prev = useRef<U>();
+  const prev = useRef<U>(null);
 
   return (state) => {
     const next = selector(state);

--- a/packages/@vizij/render/src/hooks/use-features.ts
+++ b/packages/@vizij/render/src/hooks/use-features.ts
@@ -1,7 +1,7 @@
 import { useEffect, useContext } from "react";
 import { shallow } from "zustand/shallow";
 import { type RawValue, type AnimatableValue, getLookup } from "@vizij/utils";
-import { Feature } from "../types/feature";
+import type { Feature } from "../types/feature";
 import { VizijContext } from "../context";
 
 /**

--- a/packages/@vizij/render/src/renderables/ellipse.tsx
+++ b/packages/@vizij/render/src/renderables/ellipse.tsx
@@ -1,16 +1,8 @@
-import {
-  ReactNode,
-  memo,
-  RefObject,
-  useCallback,
-  useEffect,
-  useRef,
-  useMemo,
-} from "react";
+import { memo, useCallback, useEffect, useRef, useMemo } from "react";
+import type { ReactNode, RefObject } from "react";
 import { useShallow } from "zustand/react/shallow";
+import type { RawValue, AnimatableValue } from "@vizij/utils";
 import {
-  RawValue,
-  AnimatableValue,
   instanceOfRawNumber,
   instanceOfRawVector2,
   instanceOfRawVector3,
@@ -19,13 +11,14 @@ import {
   instanceOfRawHSL,
 } from "@vizij/utils";
 import { Circle, Line } from "@react-three/drei";
-import { Mesh, MeshStandardMaterial } from "three";
-import { Line2 } from "three-stdlib";
-import { ThreeEvent } from "@react-three/fiber";
+import type { Mesh, MeshStandardMaterial } from "three";
+import type { Line2 } from "three-stdlib";
+import type { ThreeEvent } from "@react-three/fiber";
+import type { MouseEvent as ReactMouseEvent } from "react";
 import { useFeatures } from "../hooks/use-features";
 import { useVizijStore } from "../hooks/use-vizij-store";
-import { VizijActions } from "../store-types";
-import { Ellipse } from "../types/ellipse";
+import type { VizijActions } from "../store-types";
+import type { Ellipse } from "../types/ellipse";
 import { createStoredRenderable } from "../functions/create-stored-data";
 
 export interface RenderedEllipseProps {
@@ -311,7 +304,7 @@ function InnerRenderedEllipse({
         args={[1, 100]}
         onPointerOver={handlePointerOver}
         onPointerOut={handlePointerOut}
-        onClick={(e) => {
+        onClick={(e: ThreeEvent<ReactMouseEvent>) => {
           onElementClick({ id, type: "ellipse", namespace }, [...chain, id], e);
         }}
       >

--- a/packages/@vizij/render/src/renderables/ellipse.tsx
+++ b/packages/@vizij/render/src/renderables/ellipse.tsx
@@ -39,10 +39,11 @@ function InnerRenderedEllipse({
   namespace,
   chain,
 }: RenderedEllipseProps): ReactNode {
-  const ellipseRef = useRef<Mesh>() as RefObject<Mesh>;
-  const materialRef =
-    useRef<MeshStandardMaterial>() as RefObject<MeshStandardMaterial>;
-  const lineRef = useRef<Mesh>() as RefObject<Line2>;
+  const ellipseRef = useRef<Mesh>(null) as RefObject<Mesh>;
+  const materialRef = useRef<MeshStandardMaterial>(
+    null,
+  ) as RefObject<MeshStandardMaterial>;
+  const lineRef = useRef<Mesh>(null) as RefObject<Line2>;
   const strokeOffsetRef = useRef<number>(0);
   const strokeWidthRef = useRef<number>(0);
   const onElementClick = useVizijStore(

--- a/packages/@vizij/render/src/renderables/group.tsx
+++ b/packages/@vizij/render/src/renderables/group.tsx
@@ -1,28 +1,20 @@
-import {
-  ReactNode,
-  memo,
-  RefObject,
-  useCallback,
-  useEffect,
-  useRef,
-  useMemo,
-} from "react";
+import { memo, useCallback, useEffect, useRef, useMemo } from "react";
+import type { ReactNode, RefObject } from "react";
 import * as THREE from "three";
 import { useShallow } from "zustand/react/shallow";
-import { ThreeEvent } from "@react-three/fiber";
+import type { ThreeEvent } from "@react-three/fiber";
+import type { RawValue, AnimatableValue } from "@vizij/utils";
 import {
-  RawValue,
-  AnimatableValue,
   instanceOfRawEuler,
   instanceOfRawNumber,
   instanceOfRawVector2,
   instanceOfRawVector3,
 } from "@vizij/utils";
 import { useFeatures } from "../hooks/use-features";
-import { Group } from "../types/group";
+import type { Group } from "../types/group";
 import { useVizijStore } from "../hooks/use-vizij-store";
 import { createStoredRenderable } from "../functions/create-stored-data";
-import { VizijActions } from "../store-types";
+import type { VizijActions } from "../store-types";
 // eslint-disable-next-line import/no-cycle -- circular import will be fixed later
 import { Renderable } from "./renderable";
 

--- a/packages/@vizij/render/src/renderables/group.tsx
+++ b/packages/@vizij/render/src/renderables/group.tsx
@@ -39,7 +39,7 @@ function InnerRenderedGroup({
   namespace,
   chain,
 }: RenderedGroupProps): ReactNode {
-  const ref = useRef<THREE.Group>() as RefObject<THREE.Group>;
+  const ref = useRef<THREE.Group>(null) as RefObject<THREE.Group>;
   const group = useVizijStore(useShallow((state) => state.world[id] as Group));
   const refIsNull = !group.refs[namespace]?.current;
 

--- a/packages/@vizij/render/src/renderables/rectangle.tsx
+++ b/packages/@vizij/render/src/renderables/rectangle.tsx
@@ -1,16 +1,8 @@
-import {
-  ReactNode,
-  memo,
-  RefObject,
-  useCallback,
-  useEffect,
-  useRef,
-  useMemo,
-} from "react";
+import { memo, useCallback, useEffect, useRef, useMemo } from "react";
+import type { ReactNode, RefObject } from "react";
 import { useShallow } from "zustand/react/shallow";
+import type { RawValue, AnimatableValue } from "@vizij/utils";
 import {
-  RawValue,
-  AnimatableValue,
   instanceOfRawNumber,
   instanceOfRawVector2,
   instanceOfRawVector3,
@@ -19,13 +11,14 @@ import {
   instanceOfRawHSL,
 } from "@vizij/utils";
 import { Plane, Line } from "@react-three/drei";
-import { Mesh, MeshStandardMaterial } from "three";
-import { Line2 } from "three-stdlib";
-import { ThreeEvent } from "@react-three/fiber";
+import type { Mesh, MeshStandardMaterial } from "three";
+import type { Line2 } from "three-stdlib";
+import type { ThreeEvent } from "@react-three/fiber";
+import type { MouseEvent as ReactMouseEvent } from "react";
 import { useFeatures } from "../hooks/use-features";
 import { useVizijStore } from "../hooks/use-vizij-store";
-import { VizijActions } from "../store-types";
-import { Rectangle } from "../types/rectangle";
+import type { VizijActions } from "../store-types";
+import type { Rectangle } from "../types/rectangle";
 import { createStoredRenderable } from "../functions/create-stored-data";
 
 export interface RenderedRectangleProps {
@@ -310,7 +303,7 @@ function InnerRenderedRectangle({
         args={[1, 1]}
         onPointerOver={handlePointerOver}
         onPointerOut={handlePointerOut}
-        onClick={(e) => {
+        onClick={(e: ThreeEvent<ReactMouseEvent>) => {
           onElementClick(
             { id, type: "rectangle", namespace },
             [...chain, id],

--- a/packages/@vizij/render/src/renderables/rectangle.tsx
+++ b/packages/@vizij/render/src/renderables/rectangle.tsx
@@ -39,10 +39,11 @@ function InnerRenderedRectangle({
   namespace,
   chain,
 }: RenderedRectangleProps): ReactNode {
-  const rectangleRef = useRef<Mesh>() as RefObject<Mesh>;
-  const materialRef =
-    useRef<MeshStandardMaterial>() as RefObject<MeshStandardMaterial>;
-  const lineRef = useRef<Mesh>() as RefObject<Line2>;
+  const rectangleRef = useRef<Mesh>(null) as RefObject<Mesh>;
+  const materialRef = useRef<MeshStandardMaterial>(
+    null,
+  ) as RefObject<MeshStandardMaterial>;
+  const lineRef = useRef<Mesh>(null) as RefObject<Line2>;
   const strokeOffsetRef = useRef<number>(0);
   const strokeWidthRef = useRef<number>(0);
   const onElementClick = useVizijStore(

--- a/packages/@vizij/render/src/renderables/renderable.tsx
+++ b/packages/@vizij/render/src/renderables/renderable.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-cycle -- circular import will be fixed later*/
-import { ReactNode, memo, useMemo } from "react";
+import { memo, useMemo } from "react";
+import type { ReactNode } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { useVizijStore } from "../hooks/use-vizij-store";
 import { RenderedGroup } from "./group";

--- a/packages/@vizij/render/src/renderables/shape.tsx
+++ b/packages/@vizij/render/src/renderables/shape.tsx
@@ -47,8 +47,8 @@ function InnerRenderedShape({
   namespace,
   chain,
 }: RenderedShapeProps): ReactNode {
-  const refGroup = useRef<THREE.Group>() as RefObject<THREE.Group>;
-  const ref = useRef<THREE.Mesh>() as RefObject<THREE.Mesh>;
+  const refGroup = useRef<THREE.Group>(null) as RefObject<THREE.Group>;
+  const ref = useRef<THREE.Mesh>(null) as RefObject<THREE.Mesh>;
   const shape = useVizijStore(useShallow((state) => state.world[id] as Shape));
 
   const refs = useVizijStore(
@@ -107,7 +107,7 @@ function InnerRenderedShape({
     | MeshPhongMaterial
     | MeshNormalMaterial
     | MeshStandardMaterial
-  >();
+  >(null);
 
   const morphTargetSettings: [
     Record<string, number> | undefined,

--- a/packages/@vizij/render/src/renderables/shape.tsx
+++ b/packages/@vizij/render/src/renderables/shape.tsx
@@ -1,15 +1,7 @@
-import {
-  type Ref,
-  RefObject,
-  ReactNode,
-  memo,
-  useCallback,
-  useRef,
-  useMemo,
-  useEffect,
-} from "react";
+import { memo, useCallback, useRef, useMemo, useEffect } from "react";
+import type { RefObject, ReactNode, Ref } from "react";
 import * as THREE from "three";
-import {
+import type {
   MeshBasicMaterial,
   MeshLambertMaterial,
   MeshNormalMaterial,
@@ -17,20 +9,20 @@ import {
   MeshStandardMaterial,
 } from "three";
 import { useShallow } from "zustand/react/shallow";
+import type { AnimatableValue, RawValue } from "@vizij/utils";
 import {
-  AnimatableValue,
-  RawValue,
   instanceOfRawEuler,
   instanceOfRawHSL,
   instanceOfRawNumber,
   instanceOfRawRGB,
   instanceOfRawVector3,
 } from "@vizij/utils";
-import { Shape } from "../types/shape";
+import type { ThreeEvent } from "@react-three/fiber";
+import type { MouseEvent as ReactMouseEvent } from "react";
+import type { Shape } from "../types/shape";
 import { useVizijStore } from "../hooks/use-vizij-store";
 import { useFeatures } from "../hooks/use-features";
 import { createStoredRenderable } from "../functions/create-stored-data";
-import { ThreeEvent } from "@react-three/fiber";
 // eslint-disable-next-line import/no-cycle -- circular import will be fixed later
 import { Renderable } from "./renderable";
 
@@ -280,7 +272,7 @@ function InnerRenderedShape({
       morphTargetInfluences={morphTargetSettings[1]}
       onPointerOver={handlePointerOver}
       onPointerOut={handlePointerOut}
-      onClick={(e) => {
+      onClick={(e: ThreeEvent<ReactMouseEvent>) => {
         console.log("Clicked element", shape);
         onElementClick({ id, type: "shape", namespace }, [...chain, id], e);
       }}

--- a/packages/@vizij/render/src/store-types.ts
+++ b/packages/@vizij/render/src/store-types.ts
@@ -1,9 +1,10 @@
-import { type RefObject } from "react";
-import * as THREE from "three";
-import { Group, Mesh } from "three";
-import { ThreeEvent } from "@react-three/fiber";
-import { RawValue, AnimatableValue } from "@vizij/utils";
-import { World, Selection, RenderableFeature } from "./types";
+import type { RefObject } from "react";
+import type * as THREE from "three";
+import type { Group, Mesh } from "three";
+import type { ThreeEvent } from "@react-three/fiber";
+import type { MouseEvent as ReactMouseEvent } from "react";
+import type { RawValue, AnimatableValue } from "@vizij/utils";
+import type { World, Selection, RenderableFeature } from "./types";
 
 export interface VizijData {
   world: World;
@@ -57,7 +58,7 @@ export interface VizijActions {
   onElementClick: (
     selection: Selection,
     chain: string[],
-    event: ThreeEvent<MouseEvent>,
+    event: ThreeEvent<ReactMouseEvent>,
   ) => void;
   clearSelection: () => void;
   setOrigin: (

--- a/packages/@vizij/render/src/store.ts
+++ b/packages/@vizij/render/src/store.ts
@@ -1,23 +1,24 @@
-import { MutableRefObject, type RefObject } from "react";
+import type { MutableRefObject, RefObject } from "react";
 import { create } from "zustand";
 import { subscribeWithSelector } from "zustand/middleware";
 import { produce, enableMapSet } from "immer";
 import * as THREE from "three";
-import { ThreeEvent } from "@react-three/fiber";
-import { Group, Mesh } from "three";
+import type { ThreeEvent } from "@react-three/fiber";
+import type { MouseEvent as ReactMouseEvent } from "react";
+import type { Group, Mesh } from "three";
 import { type RawValue, type AnimatableValue, getLookup } from "@vizij/utils";
-import { World } from "./types/world";
+import type { World } from "./types/world";
 import { createNewElement } from "./actions/create-new-element";
 import { removeFromTree } from "./actions/remove-children";
-import {
+import type {
   VizijData,
   VizijActions,
   VizijStoreGetter,
   VizijStoreSetter,
 } from "./store-types";
 import { createAnimatable } from "./functions/create-animatable";
-import { RenderableFeature } from "./types/renderable-feature";
-import { StaticFeature, GroupFeature, Selection } from "./types";
+import type { RenderableFeature } from "./types/renderable-feature";
+import type { StaticFeature, GroupFeature, Selection } from "./types";
 
 THREE.Object3D.DEFAULT_UP.set(0, 0, 1);
 enableMapSet();
@@ -50,7 +51,7 @@ export const VizijSlice = (set: VizijStoreSetter, get: VizijStoreGetter) => ({
   onElementClick: (
     selection: Selection,
     _chain: string[],
-    event: ThreeEvent<MouseEvent>,
+    event: ThreeEvent<ReactMouseEvent>,
   ) => {
     event.stopPropagation();
 

--- a/packages/@vizij/render/src/types/ellipse.ts
+++ b/packages/@vizij/render/src/types/ellipse.ts
@@ -1,8 +1,8 @@
-import { RefObject } from "react";
-import { Mesh } from "three";
-import { Feature } from "./feature";
-import { Stored } from "./stored";
-import { RenderableBase } from "./renderable-base";
+import type { RefObject } from "react";
+import type { Mesh } from "three";
+import type { Feature } from "./feature";
+import type { Stored } from "./stored";
+import type { RenderableBase } from "./renderable-base";
 
 /**
  * An object for creating hierarchies/bodies

--- a/packages/@vizij/render/src/types/group.ts
+++ b/packages/@vizij/render/src/types/group.ts
@@ -1,9 +1,9 @@
-import { RefObject } from "react";
-import { Group as ThreeGroup } from "three";
-import { RawVector2 } from "@vizij/utils";
-import { Feature } from "./feature";
-import { Stored } from "./stored";
-import { RenderableBase } from "./renderable-base";
+import type { RefObject } from "react";
+import type { Group as ThreeGroup } from "three";
+import type { RawVector2 } from "@vizij/utils";
+import type { Feature } from "./feature";
+import type { Stored } from "./stored";
+import type { RenderableBase } from "./renderable-base";
 
 /**
  * An object for creating hierarchies/groups

--- a/packages/@vizij/render/src/types/rectangle.ts
+++ b/packages/@vizij/render/src/types/rectangle.ts
@@ -1,8 +1,8 @@
-import { RefObject } from "react";
-import { Mesh } from "three";
-import { Feature } from "./feature";
-import { Stored } from "./stored";
-import { RenderableBase } from "./renderable-base";
+import type { RefObject } from "react";
+import type { Mesh } from "three";
+import type { Feature } from "./feature";
+import type { Stored } from "./stored";
+import type { RenderableBase } from "./renderable-base";
 
 /**
  * An object for creating rectangles

--- a/packages/@vizij/render/src/types/renderable-base.ts
+++ b/packages/@vizij/render/src/types/renderable-base.ts
@@ -1,4 +1,4 @@
-import { type RefObject } from "react";
+import type { RefObject } from "react";
 import type { Feature } from "./feature";
 
 export interface RenderableBase {

--- a/packages/@vizij/render/src/types/renderable-feature.ts
+++ b/packages/@vizij/render/src/types/renderable-feature.ts
@@ -1,4 +1,4 @@
-import { GroupFeature } from "./group";
-import { EllipseFeature } from "./ellipse";
+import type { GroupFeature } from "./group";
+import type { EllipseFeature } from "./ellipse";
 
 export type RenderableFeature = GroupFeature | EllipseFeature;

--- a/packages/@vizij/render/src/types/shape.ts
+++ b/packages/@vizij/render/src/types/shape.ts
@@ -1,8 +1,9 @@
-import { RefObject } from "react";
-import { type Mesh, BufferGeometry, ShapeGeometry } from "three";
-import { Stored } from "./stored";
-import { Feature } from "./feature";
-import { RenderableBase } from "./renderable-base";
+import type { RefObject } from "react";
+import type { BufferGeometry, ShapeGeometry } from "three";
+import { type Mesh } from "three";
+import type { Stored } from "./stored";
+import type { Feature } from "./feature";
+import type { RenderableBase } from "./renderable-base";
 
 /**
  * Represents a 3D mesh object in the scene that can be rendered.

--- a/packages/@vizij/render/src/types/stored.ts
+++ b/packages/@vizij/render/src/types/stored.ts
@@ -1,5 +1,6 @@
-import { type StaticFeature, StoredAnimatedFeature } from "./feature";
-import { RenderableBase } from "./renderable-base";
+import type { StoredAnimatedFeature } from "./feature";
+import { type StaticFeature } from "./feature";
+import type { RenderableBase } from "./renderable-base";
 
 export type StoredFeatures<T extends RenderableBase["features"]> = {
   [key in keyof T]: StaticFeature | StoredAnimatedFeature;

--- a/packages/@vizij/render/src/types/world.ts
+++ b/packages/@vizij/render/src/types/world.ts
@@ -1,6 +1,6 @@
-import { Ellipse } from "./ellipse";
-import { Rectangle } from "./rectangle";
-import { Group } from "./group";
-import { Shape } from "./shape";
+import type { Ellipse } from "./ellipse";
+import type { Rectangle } from "./rectangle";
+import type { Group } from "./group";
+import type { Shape } from "./shape";
 
 export type World = Record<string, Group | Ellipse | Rectangle | Shape>;

--- a/packages/@vizij/render/src/vizij.tsx
+++ b/packages/@vizij/render/src/vizij.tsx
@@ -1,18 +1,8 @@
-import {
-  type ReactNode,
-  type ComponentProps,
-  Suspense,
-  memo,
-  useContext,
-  useEffect,
-} from "react";
+import { Suspense, memo, useContext, useEffect } from "react";
+import type { ReactNode, ComponentProps, CSSProperties } from "react";
 import { ErrorBoundary } from "react-error-boundary";
-import {
-  Object3D,
-  OrthographicCamera as OrthographicCameraType,
-  SRGBColorSpace,
-  NoToneMapping,
-} from "three";
+import type { OrthographicCamera as OrthographicCameraType } from "three";
+import { Object3D, SRGBColorSpace, NoToneMapping } from "three";
 import { Canvas, useThree } from "@react-three/fiber";
 import { Line, OrthographicCamera, Text } from "@react-three/drei";
 import { useShallow } from "zustand/react/shallow";
@@ -21,7 +11,7 @@ import { VizijContext } from "./context";
 import { useDefaultVizijStore } from "./store";
 import { useVizijStore } from "./hooks/use-vizij-store";
 import type { VizijActions, VizijData } from "./store-types";
-import { Group } from "./types";
+import type { Group } from "./types";
 import { SelectionGlowEffect } from "./effects/selection-glow-effect";
 
 type RootBounds = NonNullable<Group["rootBounds"]>;
@@ -29,7 +19,7 @@ type RootBounds = NonNullable<Group["rootBounds"]>;
 Object3D.DEFAULT_UP.set(0, 0, 1);
 
 export interface VizijProps {
-  style?: React.CSSProperties;
+  style?: CSSProperties;
   className?: string;
   rootId: string;
   namespace?: string;

--- a/packages/@vizij/render/tests/node-ts-loader.mjs
+++ b/packages/@vizij/render/tests/node-ts-loader.mjs
@@ -1,7 +1,8 @@
-import path from "node:path";
+/* eslint-disable import/order */
 import { readFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { URL, fileURLToPath } from "node:url";
+import path from "node:path";
 
 const require = createRequire(import.meta.url);
 const ts = require("typescript");

--- a/packages/@vizij/runtime-react/package.json
+++ b/packages/@vizij/runtime-react/package.json
@@ -49,8 +49,8 @@
     "react-dom": ">=18"
   },
   "devDependencies": {
-    "@types/react": "^18.3.1",
-    "@types/react-dom": "^18.3.1",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
     "prettier": "^3.4.2",
     "tsup": "^8.0.1",
     "typescript": "^5.5.0",

--- a/packages/@vizij/runtime-react/src/VizijRuntimeProvider.tsx
+++ b/packages/@vizij/runtime-react/src/VizijRuntimeProvider.tsx
@@ -5,9 +5,8 @@ import {
   useMemo,
   useRef,
   useState,
-  type PropsWithChildren,
-  type ReactNode,
 } from "react";
+import type { PropsWithChildren, ReactNode } from "react";
 import {
   VizijContext,
   createVizijStore,

--- a/packages/@vizij/runtime-react/src/VizijRuntimeProvider.tsx
+++ b/packages/@vizij/runtime-react/src/VizijRuntimeProvider.tsx
@@ -822,7 +822,7 @@ export function VizijRuntimeProvider({
   onStatusChange,
   orchestratorScope = "auto",
 }: ProviderProps) {
-  const storeRef = useRef<VizijStore>();
+  const storeRef = useRef<VizijStore | null>(null);
   if (!storeRef.current) {
     storeRef.current = createVizijStore();
   }

--- a/packages/@vizij/utils/package.json
+++ b/packages/@vizij/utils/package.json
@@ -45,5 +45,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "dependencies": {}
 }

--- a/packages/@vizij/utils/src/rig/graph-builder.test.ts
+++ b/packages/@vizij/utils/src/rig/graph-builder.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-
 import type { RigDriverGraph } from "./drivers";
 import { buildGraphFromDrivers } from "./graph-builder";
 

--- a/packages/@vizij/utils/src/rig/standard-inputs.ts
+++ b/packages/@vizij/utils/src/rig/standard-inputs.ts
@@ -152,8 +152,10 @@ export function deriveStandardRigInputIdFromPath(path: string): string {
   return path.replace(/\//g, "_").replace(/^_+/, "");
 }
 
-export interface StandardRigInputInit
-  extends Omit<StandardRigInput, "id" | "path"> {
+export interface StandardRigInputInit extends Omit<
+  StandardRigInput,
+  "id" | "path"
+> {
   path: string;
   id?: string;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,22 +15,22 @@ importers:
     devDependencies:
       '@changesets/cli':
         specifier: ^2.27.7
-        version: 2.29.7(@types/node@22.19.1)
+        version: 2.29.8(@types/node@22.19.3)
       '@eslint/js':
         specifier: ^9.19.0
-        version: 9.39.1
+        version: 9.39.2
       eslint:
         specifier: ^9.19.0
-        version: 9.39.1(jiti@2.6.1)
+        version: 9.39.2(jiti@2.6.1)
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))
+        version: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks:
         specifier: ^5.0.0
-        version: 5.2.0(eslint@9.39.1(jiti@2.6.1))
+        version: 5.2.0(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-refresh:
         specifier: ^0.4.18
-        version: 0.4.24(eslint@9.39.1(jiti@2.6.1))
+        version: 0.4.26(eslint@9.39.2(jiti@2.6.1))
       globals:
         specifier: ^15.14.0
         version: 15.15.0
@@ -39,16 +39,16 @@ importers:
         version: 15.5.2
       prettier:
         specifier: ^3.4.2
-        version: 3.6.2
+        version: 3.7.4
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.22.0
-        version: 8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.1)(jiti@2.6.1)(jsdom@24.1.3)(yaml@2.8.1)
+        version: 3.2.4(@types/node@22.19.3)(jiti@2.6.1)(jsdom@24.1.3)(yaml@2.8.2)
 
   apps/demo-animation-studio:
     dependencies:
@@ -82,19 +82,19 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react-swc':
         specifier: ^4.2.2
-        version: 4.2.2(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
+        version: 4.2.2(vite@6.4.1(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2))
       prettier:
         specifier: ^3.4.2
-        version: 3.6.2
+        version: 3.7.4
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
       vite:
         specifier: ^6.3.6
-        version: 6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1)
+        version: 6.4.1(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.1)(jiti@2.6.1)(jsdom@24.1.3)(yaml@2.8.1)
+        version: 3.2.4(@types/node@22.19.3)(jiti@2.6.1)(jsdom@24.1.3)(yaml@2.8.2)
 
   apps/demo-graph-studio:
     dependencies:
@@ -131,22 +131,22 @@ importers:
     devDependencies:
       '@vitejs/plugin-react-swc':
         specifier: ^4.2.2
-        version: 4.2.2(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
+        version: 4.2.2(vite@6.4.1(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2))
       eslint:
         specifier: ^9.19.0
-        version: 9.39.1(jiti@2.6.1)
+        version: 9.39.2(jiti@2.6.1)
       prettier:
         specifier: ^3.4.2
-        version: 3.6.2
+        version: 3.7.4
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
       vite:
         specifier: ^6.3.6
-        version: 6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1)
+        version: 6.4.1(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.1)(jiti@2.6.1)(jsdom@24.1.3)(yaml@2.8.1)
+        version: 3.2.4(@types/node@22.19.3)(jiti@2.6.1)(jsdom@24.1.3)(yaml@2.8.2)
 
   apps/demo-vizij-player:
     dependencies:
@@ -180,19 +180,19 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react-swc':
         specifier: ^4.2.2
-        version: 4.2.2(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
+        version: 4.2.2(vite@6.4.1(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2))
       prettier:
         specifier: ^3.4.2
-        version: 3.6.2
+        version: 3.7.4
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: ^6.3.6
-        version: 6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1)
+        version: 6.4.1(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.1)(jiti@2.6.1)(jsdom@24.1.3)(yaml@2.8.1)
+        version: 3.2.4(@types/node@22.19.3)(jiti@2.6.1)(jsdom@24.1.3)(yaml@2.8.2)
 
   apps/minimal-demo-animation:
     dependencies:
@@ -229,19 +229,19 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react-swc':
         specifier: ^4.2.2
-        version: 4.2.2(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
+        version: 4.2.2(vite@6.4.1(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2))
       prettier:
         specifier: ^3.4.2
-        version: 3.6.2
+        version: 3.7.4
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
       vite:
         specifier: ^6.3.6
-        version: 6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1)
+        version: 6.4.1(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.1)(jiti@2.6.1)(jsdom@24.1.3)(yaml@2.8.1)
+        version: 3.2.4(@types/node@22.19.3)(jiti@2.6.1)(jsdom@24.1.3)(yaml@2.8.2)
 
   apps/minimal-demo-animation-graph:
     dependencies:
@@ -287,19 +287,19 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react-swc':
         specifier: ^4.2.2
-        version: 4.2.2(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
+        version: 4.2.2(vite@6.4.1(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2))
       prettier:
         specifier: ^3.4.2
-        version: 3.6.2
+        version: 3.7.4
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
       vite:
         specifier: ^6.3.6
-        version: 6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1)
+        version: 6.4.1(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.1)(jiti@2.6.1)(jsdom@24.1.3)(yaml@2.8.1)
+        version: 3.2.4(@types/node@22.19.3)(jiti@2.6.1)(jsdom@24.1.3)(yaml@2.8.2)
 
   apps/minimal-demo-graph:
     dependencies:
@@ -333,10 +333,10 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react-swc':
         specifier: ^4.2.2
-        version: 4.2.2(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
+        version: 4.2.2(vite@6.4.1(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2))
       prettier:
         specifier: ^3.4.2
-        version: 3.6.2
+        version: 3.7.4
       reactflow:
         specifier: ^11.11.4
         version: 11.11.4(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
@@ -345,10 +345,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.3.6
-        version: 6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1)
+        version: 6.4.1(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.1)(jiti@2.6.1)(jsdom@24.1.3)(yaml@2.8.1)
+        version: 3.2.4(@types/node@22.19.3)(jiti@2.6.1)(jsdom@24.1.3)(yaml@2.8.2)
 
   apps/minimal-demo-orchestrator:
     dependencies:
@@ -379,25 +379,25 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react-swc':
         specifier: ^4.2.2
-        version: 4.2.2(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
+        version: 4.2.2(vite@6.4.1(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2))
       prettier:
         specifier: ^3.4.2
-        version: 3.6.2
+        version: 3.7.4
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
       vite:
         specifier: ^6.3.6
-        version: 6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1)
+        version: 6.4.1(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.1)(jiti@2.6.1)(jsdom@24.1.3)(yaml@2.8.1)
+        version: 3.2.4(@types/node@22.19.3)(jiti@2.6.1)(jsdom@24.1.3)(yaml@2.8.2)
 
   apps/tutorial-agent-face:
     dependencies:
       '@google/genai':
         specifier: ^1.30.0
-        version: 1.30.0
+        version: 1.34.0
       '@react-three/drei':
         specifier: ^10.7.7
         version: 10.7.7(@react-three/fiber@9.5.0(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(three@0.170.0))(@types/react@19.2.7)(@types/three@0.170.0)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(three@0.170.0)
@@ -428,13 +428,13 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react-swc':
         specifier: ^4.2.2
-        version: 4.2.2(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
+        version: 4.2.2(vite@6.4.1(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: ^6.3.6
-        version: 6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1)
+        version: 6.4.1(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2)
 
   apps/tutorial-fullscreen-face:
     dependencies:
@@ -468,13 +468,13 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react-swc':
         specifier: ^4.2.2
-        version: 4.2.2(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
+        version: 4.2.2(vite@6.4.1(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: ^6.3.6
-        version: 6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1)
+        version: 6.4.1(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2)
 
   apps/vizij-authoring:
     dependencies:
@@ -514,19 +514,19 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react-swc':
         specifier: ^4.2.2
-        version: 4.2.2(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
+        version: 4.2.2(vite@6.4.1(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2))
       prettier:
         specifier: ^3.4.2
-        version: 3.6.2
+        version: 3.7.4
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
       vite:
         specifier: ^6.3.6
-        version: 6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1)
+        version: 6.4.1(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.1)(jiti@2.6.1)(jsdom@24.1.3)(yaml@2.8.1)
+        version: 3.2.4(@types/node@22.19.3)(jiti@2.6.1)(jsdom@24.1.3)(yaml@2.8.2)
 
   apps/vizij-showcase:
     dependencies:
@@ -566,13 +566,13 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react-swc':
         specifier: ^4.2.2
-        version: 4.2.2(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
+        version: 4.2.2(vite@6.4.1(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: ^6.3.6
-        version: 6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1)
+        version: 6.4.1(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2)
 
   packages/@vizij/animation-react:
     dependencies:
@@ -597,7 +597,7 @@ importers:
         version: 24.1.3
       prettier:
         specifier: ^3.4.2
-        version: 3.6.2
+        version: 3.7.4
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -606,32 +606,32 @@ importers:
         version: 19.2.3(react@19.2.3)
       tsup:
         specifier: ^8.0.1
-        version: 8.5.1(@swc/core@1.15.2)(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.1)
+        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.1)(jiti@2.6.1)(jsdom@24.1.3)(yaml@2.8.1)
+        version: 3.2.4(@types/node@22.19.3)(jiti@2.6.1)(jsdom@24.1.3)(yaml@2.8.2)
 
   packages/@vizij/minimal-demo-ui:
     dependencies:
       react:
         specifier: '>=18'
-        version: 18.3.1
+        version: 19.2.3
       react-dom:
         specifier: '>=18'
-        version: 18.3.1(react@18.3.1)
+        version: 19.2.3(react@19.2.3)
     devDependencies:
       '@types/react':
         specifier: ^19.2.7
         version: 19.2.7
       prettier:
         specifier: ^3.4.2
-        version: 3.6.2
+        version: 3.7.4
       tsup:
         specifier: ^8.0.1
-        version: 8.5.1(@swc/core@1.15.2)(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.1)
+        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
@@ -647,19 +647,19 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ^22.10.1
-        version: 22.19.1
+        version: 22.19.3
       prettier:
         specifier: ^3.4.2
-        version: 3.6.2
+        version: 3.7.4
       tsup:
         specifier: ^8.0.1
-        version: 8.5.1(@swc/core@1.15.2)(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.1)
+        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.1)(jiti@2.6.1)(jsdom@24.1.3)(yaml@2.8.1)
+        version: 3.2.4(@types/node@22.19.3)(jiti@2.6.1)(jsdom@24.1.3)(yaml@2.8.2)
 
   packages/@vizij/node-graph-react:
     dependencies:
@@ -684,7 +684,7 @@ importers:
         version: 24.1.3
       prettier:
         specifier: ^3.4.2
-        version: 3.6.2
+        version: 3.7.4
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -693,13 +693,13 @@ importers:
         version: 19.2.3(react@19.2.3)
       tsup:
         specifier: ^8.0.1
-        version: 8.5.1(@swc/core@1.15.2)(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.1)
+        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.1)(jiti@2.6.1)(jsdom@24.1.3)(yaml@2.8.1)
+        version: 3.2.4(@types/node@22.19.3)(jiti@2.6.1)(jsdom@24.1.3)(yaml@2.8.2)
 
   packages/@vizij/orchestrator-react:
     dependencies:
@@ -727,7 +727,7 @@ importers:
         version: 24.1.3
       prettier:
         specifier: ^3.4.2
-        version: 3.6.2
+        version: 3.7.4
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -736,13 +736,13 @@ importers:
         version: 19.2.3(react@19.2.3)
       tsup:
         specifier: ^8.0.1
-        version: 8.5.1(@swc/core@1.15.2)(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.1)
+        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.1)(jiti@2.6.1)(jsdom@24.1.3)(yaml@2.8.1)
+        version: 3.2.4(@types/node@22.19.3)(jiti@2.6.1)(jsdom@24.1.3)(yaml@2.8.2)
 
   packages/@vizij/render:
     dependencies:
@@ -766,7 +766,7 @@ importers:
         version: 4.1.2(react@19.2.3)
       tailwindcss:
         specifier: ^4.1.3
-        version: 4.1.17
+        version: 4.1.18
       three-stdlib:
         specifier: ^2.35.13
         version: 2.36.1(three@0.170.0)
@@ -785,7 +785,7 @@ importers:
         version: 1.0.4
       '@types/lodash':
         specifier: ^4.17.4
-        version: 4.17.20
+        version: 4.17.21
       '@types/react':
         specifier: ^19.2.7
         version: 19.2.7
@@ -794,7 +794,7 @@ importers:
         version: 0.170.0
       prettier:
         specifier: ^3.4.2
-        version: 3.6.2
+        version: 3.7.4
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -809,7 +809,7 @@ importers:
         version: 0.170.0
       tsup:
         specifier: ^8.0.1
-        version: 8.5.1(@swc/core@1.15.2)(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.1)
+        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
@@ -836,10 +836,10 @@ importers:
         version: 0.1.2
       react:
         specifier: '>=18'
-        version: 18.3.1
+        version: 19.2.3
       react-dom:
         specifier: '>=18'
-        version: 18.3.1(react@18.3.1)
+        version: 19.2.3(react@19.2.3)
     devDependencies:
       '@types/react':
         specifier: ^19.2.7
@@ -849,31 +849,31 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       prettier:
         specifier: ^3.4.2
-        version: 3.6.2
+        version: 3.7.4
       tsup:
         specifier: ^8.0.1
-        version: 8.5.1(@swc/core@1.15.2)(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.1)
+        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.1)(jiti@2.6.1)(jsdom@24.1.3)(yaml@2.8.1)
+        version: 3.2.4(@types/node@22.19.3)(jiti@2.6.1)(jsdom@24.1.3)(yaml@2.8.2)
 
   packages/@vizij/utils:
     devDependencies:
       prettier:
         specifier: ^3.4.2
-        version: 3.6.2
+        version: 3.7.4
       tsup:
         specifier: ^8.0.1
-        version: 8.5.1(@swc/core@1.15.2)(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.1)
+        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.1)(jiti@2.6.1)(jsdom@24.1.3)(yaml@2.8.1)
+        version: 3.2.4(@types/node@22.19.3)(jiti@2.6.1)(jsdom@24.1.3)(yaml@2.8.2)
 
 packages:
 
@@ -892,8 +892,8 @@ packages:
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
 
-  '@changesets/apply-release-plan@7.0.13':
-    resolution: {integrity: sha512-BIW7bofD2yAWoE8H4V40FikC+1nNFEKBisMECccS16W1rt6qqhNTBDmIw5HaqmMgtLNz9e7oiALiEUuKrQ4oHg==}
+  '@changesets/apply-release-plan@7.0.14':
+    resolution: {integrity: sha512-ddBvf9PHdy2YY0OUiEl3TV78mH9sckndJR14QAt87KLEbIov81XO0q0QAmvooBxXlqRRP8I9B7XOzZwQG7JkWA==}
 
   '@changesets/assemble-release-plan@6.0.9':
     resolution: {integrity: sha512-tPgeeqCHIwNo8sypKlS3gOPmsS3wP0zHt67JDuL20P4QcXiw/O4Hl7oXiuLnP9yg+rXLQ2sScdV1Kkzde61iSQ==}
@@ -901,12 +901,12 @@ packages:
   '@changesets/changelog-git@0.2.1':
     resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
 
-  '@changesets/cli@2.29.7':
-    resolution: {integrity: sha512-R7RqWoaksyyKXbKXBTbT4REdy22yH81mcFK6sWtqSanxUCbUi9Uf+6aqxZtDQouIqPdem2W56CdxXgsxdq7FLQ==}
+  '@changesets/cli@2.29.8':
+    resolution: {integrity: sha512-1weuGZpP63YWUYjay/E84qqwcnt5yJMM0tep10Up7Q5cS/DGe2IZ0Uj3HNMxGhCINZuR7aO9WBMdKnPit5ZDPA==}
     hasBin: true
 
-  '@changesets/config@3.1.1':
-    resolution: {integrity: sha512-bd+3Ap2TKXxljCggI0mKPfzCQKeV/TU4yO2h2C6vAihIo8tzseAn2e7klSuiyYYXvgu53zMN1OeYMIQkaQoWnA==}
+  '@changesets/config@3.1.2':
+    resolution: {integrity: sha512-CYiRhA4bWKemdYi/uwImjPxqWNpqGPNbEBdX1BdONALFIDK7MCUj6FPkzD+z9gJcvDFUQJn9aDVf4UG7OT6Kog==}
 
   '@changesets/errors@0.2.0':
     resolution: {integrity: sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==}
@@ -914,8 +914,8 @@ packages:
   '@changesets/get-dependents-graph@2.1.3':
     resolution: {integrity: sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==}
 
-  '@changesets/get-release-plan@4.0.13':
-    resolution: {integrity: sha512-DWG1pus72FcNeXkM12tx+xtExyH/c9I1z+2aXlObH3i9YA7+WZEVaiHzHl03thpvAgWTRaH64MpfHxozfF7Dvg==}
+  '@changesets/get-release-plan@4.0.14':
+    resolution: {integrity: sha512-yjZMHpUHgl4Xl5gRlolVuxDkm4HgSJqT93Ri1Uz8kGrQb+5iJ8dkXJ20M2j/Y4iV5QzS2c5SeTxVSKX+2eMI0g==}
 
   '@changesets/get-version-range-type@0.4.0':
     resolution: {integrity: sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==}
@@ -926,14 +926,14 @@ packages:
   '@changesets/logger@0.1.1':
     resolution: {integrity: sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==}
 
-  '@changesets/parse@0.4.1':
-    resolution: {integrity: sha512-iwksMs5Bf/wUItfcg+OXrEpravm5rEd9Bf4oyIPL4kVTmJQ7PNDSd6MDYkpSJR1pn7tz/k8Zf2DhTCqX08Ou+Q==}
+  '@changesets/parse@0.4.2':
+    resolution: {integrity: sha512-Uo5MC5mfg4OM0jU3up66fmSn6/NE9INK+8/Vn/7sMVcdWg46zfbvvUSjD9EMonVqPi9fbrJH9SXHn48Tr1f2yA==}
 
   '@changesets/pre@2.0.2':
     resolution: {integrity: sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug==}
 
-  '@changesets/read@0.6.5':
-    resolution: {integrity: sha512-UPzNGhsSjHD3Veb0xO/MwvasGe8eMyNrR/sT9gR8Q3DhOQZirgKhhXv/8hVsI0QpPjR004Z9iFxoJU6in3uGMg==}
+  '@changesets/read@0.6.6':
+    resolution: {integrity: sha512-P5QaN9hJSQQKJShzzpBT13FzOSPyHbqdoIBUd2DJdgvnECCyO6LmAOWSV+O8se2TaZJVwSXjL+v9yhb+a9JeJg==}
 
   '@changesets/should-skip-package@0.1.2':
     resolution: {integrity: sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==}
@@ -981,8 +981,8 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.27.0':
-    resolution: {integrity: sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==}
+  '@esbuild/aix-ppc64@0.27.2':
+    resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
@@ -993,8 +993,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm64@0.27.0':
-    resolution: {integrity: sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==}
+  '@esbuild/android-arm64@0.27.2':
+    resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -1005,8 +1005,8 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.27.0':
-    resolution: {integrity: sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==}
+  '@esbuild/android-arm@0.27.2':
+    resolution: {integrity: sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
@@ -1017,8 +1017,8 @@ packages:
     cpu: [x64]
     os: [android]
 
-  '@esbuild/android-x64@0.27.0':
-    resolution: {integrity: sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==}
+  '@esbuild/android-x64@0.27.2':
+    resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -1029,8 +1029,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.27.0':
-    resolution: {integrity: sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==}
+  '@esbuild/darwin-arm64@0.27.2':
+    resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
@@ -1041,8 +1041,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.0':
-    resolution: {integrity: sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==}
+  '@esbuild/darwin-x64@0.27.2':
+    resolution: {integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -1053,8 +1053,8 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.27.0':
-    resolution: {integrity: sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==}
+  '@esbuild/freebsd-arm64@0.27.2':
+    resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
@@ -1065,8 +1065,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.0':
-    resolution: {integrity: sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==}
+  '@esbuild/freebsd-x64@0.27.2':
+    resolution: {integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -1077,8 +1077,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.27.0':
-    resolution: {integrity: sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==}
+  '@esbuild/linux-arm64@0.27.2':
+    resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
@@ -1089,8 +1089,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.0':
-    resolution: {integrity: sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==}
+  '@esbuild/linux-arm@0.27.2':
+    resolution: {integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -1101,8 +1101,8 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.0':
-    resolution: {integrity: sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==}
+  '@esbuild/linux-ia32@0.27.2':
+    resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
@@ -1113,8 +1113,8 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.0':
-    resolution: {integrity: sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==}
+  '@esbuild/linux-loong64@0.27.2':
+    resolution: {integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -1125,8 +1125,8 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.0':
-    resolution: {integrity: sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==}
+  '@esbuild/linux-mips64el@0.27.2':
+    resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
@@ -1137,8 +1137,8 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.0':
-    resolution: {integrity: sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==}
+  '@esbuild/linux-ppc64@0.27.2':
+    resolution: {integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -1149,8 +1149,8 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.0':
-    resolution: {integrity: sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==}
+  '@esbuild/linux-riscv64@0.27.2':
+    resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
@@ -1161,8 +1161,8 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.0':
-    resolution: {integrity: sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==}
+  '@esbuild/linux-s390x@0.27.2':
+    resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -1173,8 +1173,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.0':
-    resolution: {integrity: sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==}
+  '@esbuild/linux-x64@0.27.2':
+    resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
@@ -1185,8 +1185,8 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-arm64@0.27.0':
-    resolution: {integrity: sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==}
+  '@esbuild/netbsd-arm64@0.27.2':
+    resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -1197,8 +1197,8 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.0':
-    resolution: {integrity: sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==}
+  '@esbuild/netbsd-x64@0.27.2':
+    resolution: {integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
@@ -1209,8 +1209,8 @@ packages:
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-arm64@0.27.0':
-    resolution: {integrity: sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==}
+  '@esbuild/openbsd-arm64@0.27.2':
+    resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -1221,8 +1221,8 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.0':
-    resolution: {integrity: sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==}
+  '@esbuild/openbsd-x64@0.27.2':
+    resolution: {integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
@@ -1233,8 +1233,8 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/openharmony-arm64@0.27.0':
-    resolution: {integrity: sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==}
+  '@esbuild/openharmony-arm64@0.27.2':
+    resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -1245,8 +1245,8 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.27.0':
-    resolution: {integrity: sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==}
+  '@esbuild/sunos-x64@0.27.2':
+    resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
@@ -1257,8 +1257,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-arm64@0.27.0':
-    resolution: {integrity: sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==}
+  '@esbuild/win32-arm64@0.27.2':
+    resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -1269,8 +1269,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.0':
-    resolution: {integrity: sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==}
+  '@esbuild/win32-ia32@0.27.2':
+    resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
@@ -1281,14 +1281,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.0':
-    resolution: {integrity: sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==}
+  '@esbuild/win32-x64@0.27.2':
+    resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
-  '@eslint-community/eslint-utils@4.9.0':
-    resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
@@ -1313,12 +1313,12 @@ packages:
     resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/eslintrc@3.3.1':
-    resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
+  '@eslint/eslintrc@3.3.3':
+    resolution: {integrity: sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/js@9.39.1':
-    resolution: {integrity: sha512-S26Stp4zCy88tH94QbBv3XCuzRQiZ9yXofEILmglYTh/Ug/a9/umqvgFtYBAo3Lp0nsI/5/qH1CCrbdK3AP1Tw==}
+  '@eslint/js@9.39.2':
+    resolution: {integrity: sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/object-schema@2.1.7':
@@ -1333,11 +1333,11 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@google/genai@1.30.0':
-    resolution: {integrity: sha512-3MRcgczBFbUat1wIlZoLJ0vCCfXgm7Qxjh59cZi2X08RgWLtm9hKOspzp7TOg1TV2e26/MLxR2GR5yD5GmBV2w==}
+  '@google/genai@1.34.0':
+    resolution: {integrity: sha512-vu53UMPvjmb7PGzlYu6Tzxso8Dfhn+a7eQFaS2uNemVtDZKwzSpJ5+ikqBbXplF7RGB1STcVDqCkPvquiwb2sw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
-      '@modelcontextprotocol/sdk': ^1.20.1
+      '@modelcontextprotocol/sdk': ^1.24.0
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
         optional: true
@@ -1393,8 +1393,8 @@ packages:
   '@mediapipe/tasks-vision@0.10.17':
     resolution: {integrity: sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==}
 
-  '@monogrid/gainmap-js@3.2.0':
-    resolution: {integrity: sha512-E/DVmj5tbVEXUlnUWJ+k4BK/dEtimZC4RhxnIDkyJgJsrHkaXSSb9FKtEuvCciTY6Rr8weaCS/Suv3UVa2mFAA==}
+  '@monogrid/gainmap-js@3.4.0':
+    resolution: {integrity: sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==}
     peerDependencies:
       three: '>= 0.159.0'
 
@@ -1489,113 +1489,113 @@ packages:
   '@rolldown/pluginutils@1.0.0-beta.47':
     resolution: {integrity: sha512-8QagwMH3kNCuzD8EWL8R2YPW5e4OrHNSAHRFDdmFqEwEaD/KcNKjVoumo+gP2vW5eKB2UPbM6vTYiGZX0ixLnw==}
 
-  '@rollup/rollup-android-arm-eabi@4.53.2':
-    resolution: {integrity: sha512-yDPzwsgiFO26RJA4nZo8I+xqzh7sJTZIWQOxn+/XOdPE31lAvLIYCKqjV+lNH/vxE2L2iH3plKxDCRK6i+CwhA==}
+  '@rollup/rollup-android-arm-eabi@4.54.0':
+    resolution: {integrity: sha512-OywsdRHrFvCdvsewAInDKCNyR3laPA2mc9bRYJ6LBp5IyvF3fvXbbNR0bSzHlZVFtn6E0xw2oZlyjg4rKCVcng==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.53.2':
-    resolution: {integrity: sha512-k8FontTxIE7b0/OGKeSN5B6j25EuppBcWM33Z19JoVT7UTXFSo3D9CdU39wGTeb29NO3XxpMNauh09B+Ibw+9g==}
+  '@rollup/rollup-android-arm64@4.54.0':
+    resolution: {integrity: sha512-Skx39Uv+u7H224Af+bDgNinitlmHyQX1K/atIA32JP3JQw6hVODX5tkbi2zof/E69M1qH2UoN3Xdxgs90mmNYw==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.53.2':
-    resolution: {integrity: sha512-A6s4gJpomNBtJ2yioj8bflM2oogDwzUiMl2yNJ2v9E7++sHrSrsQ29fOfn5DM/iCzpWcebNYEdXpaK4tr2RhfQ==}
+  '@rollup/rollup-darwin-arm64@4.54.0':
+    resolution: {integrity: sha512-k43D4qta/+6Fq+nCDhhv9yP2HdeKeP56QrUUTW7E6PhZP1US6NDqpJj4MY0jBHlJivVJD5P8NxrjuobZBJTCRw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.53.2':
-    resolution: {integrity: sha512-e6XqVmXlHrBlG56obu9gDRPW3O3hLxpwHpLsBJvuI8qqnsrtSZ9ERoWUXtPOkY8c78WghyPHZdmPhHLWNdAGEw==}
+  '@rollup/rollup-darwin-x64@4.54.0':
+    resolution: {integrity: sha512-cOo7biqwkpawslEfox5Vs8/qj83M/aZCSSNIWpVzfU2CYHa2G3P1UN5WF01RdTHSgCkri7XOlTdtk17BezlV3A==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.53.2':
-    resolution: {integrity: sha512-v0E9lJW8VsrwPux5Qe5CwmH/CF/2mQs6xU1MF3nmUxmZUCHazCjLgYvToOk+YuuUqLQBio1qkkREhxhc656ViA==}
+  '@rollup/rollup-freebsd-arm64@4.54.0':
+    resolution: {integrity: sha512-miSvuFkmvFbgJ1BevMa4CPCFt5MPGw094knM64W9I0giUIMMmRYcGW/JWZDriaw/k1kOBtsWh1z6nIFV1vPNtA==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.53.2':
-    resolution: {integrity: sha512-ClAmAPx3ZCHtp6ysl4XEhWU69GUB1D+s7G9YjHGhIGCSrsg00nEGRRZHmINYxkdoJehde8VIsDC5t9C0gb6yqA==}
+  '@rollup/rollup-freebsd-x64@4.54.0':
+    resolution: {integrity: sha512-KGXIs55+b/ZfZsq9aR026tmr/+7tq6VG6MsnrvF4H8VhwflTIuYh+LFUlIsRdQSgrgmtM3fVATzEAj4hBQlaqQ==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.53.2':
-    resolution: {integrity: sha512-EPlb95nUsz6Dd9Qy13fI5kUPXNSljaG9FiJ4YUGU1O/Q77i5DYFW5KR8g1OzTcdZUqQQ1KdDqsTohdFVwCwjqg==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.54.0':
+    resolution: {integrity: sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.53.2':
-    resolution: {integrity: sha512-BOmnVW+khAUX+YZvNfa0tGTEMVVEerOxN0pDk2E6N6DsEIa2Ctj48FOMfNDdrwinocKaC7YXUZ1pHlKpnkja/Q==}
+  '@rollup/rollup-linux-arm-musleabihf@4.54.0':
+    resolution: {integrity: sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.53.2':
-    resolution: {integrity: sha512-Xt2byDZ+6OVNuREgBXr4+CZDJtrVso5woFtpKdGPhpTPHcNG7D8YXeQzpNbFRxzTVqJf7kvPMCub/pcGUWgBjA==}
+  '@rollup/rollup-linux-arm64-gnu@4.54.0':
+    resolution: {integrity: sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.53.2':
-    resolution: {integrity: sha512-+LdZSldy/I9N8+klim/Y1HsKbJ3BbInHav5qE9Iy77dtHC/pibw1SR/fXlWyAk0ThnpRKoODwnAuSjqxFRDHUQ==}
+  '@rollup/rollup-linux-arm64-musl@4.54.0':
+    resolution: {integrity: sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loong64-gnu@4.53.2':
-    resolution: {integrity: sha512-8ms8sjmyc1jWJS6WdNSA23rEfdjWB30LH8Wqj0Cqvv7qSHnvw6kgMMXRdop6hkmGPlyYBdRPkjJnj3KCUHV/uQ==}
+  '@rollup/rollup-linux-loong64-gnu@4.54.0':
+    resolution: {integrity: sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.53.2':
-    resolution: {integrity: sha512-3HRQLUQbpBDMmzoxPJYd3W6vrVHOo2cVW8RUo87Xz0JPJcBLBr5kZ1pGcQAhdZgX9VV7NbGNipah1omKKe23/g==}
+  '@rollup/rollup-linux-ppc64-gnu@4.54.0':
+    resolution: {integrity: sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.53.2':
-    resolution: {integrity: sha512-fMjKi+ojnmIvhk34gZP94vjogXNNUKMEYs+EDaB/5TG/wUkoeua7p7VCHnE6T2Tx+iaghAqQX8teQzcvrYpaQA==}
+  '@rollup/rollup-linux-riscv64-gnu@4.54.0':
+    resolution: {integrity: sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-musl@4.53.2':
-    resolution: {integrity: sha512-XuGFGU+VwUUV5kLvoAdi0Wz5Xbh2SrjIxCtZj6Wq8MDp4bflb/+ThZsVxokM7n0pcbkEr2h5/pzqzDYI7cCgLQ==}
+  '@rollup/rollup-linux-riscv64-musl@4.54.0':
+    resolution: {integrity: sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.53.2':
-    resolution: {integrity: sha512-w6yjZF0P+NGzWR3AXWX9zc0DNEGdtvykB03uhonSHMRa+oWA6novflo2WaJr6JZakG2ucsyb+rvhrKac6NIy+w==}
+  '@rollup/rollup-linux-s390x-gnu@4.54.0':
+    resolution: {integrity: sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.53.2':
-    resolution: {integrity: sha512-yo8d6tdfdeBArzC7T/PnHd7OypfI9cbuZzPnzLJIyKYFhAQ8SvlkKtKBMbXDxe1h03Rcr7u++nFS7tqXz87Gtw==}
+  '@rollup/rollup-linux-x64-gnu@4.54.0':
+    resolution: {integrity: sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.53.2':
-    resolution: {integrity: sha512-ah59c1YkCxKExPP8O9PwOvs+XRLKwh/mV+3YdKqQ5AMQ0r4M4ZDuOrpWkUaqO7fzAHdINzV9tEVu8vNw48z0lA==}
+  '@rollup/rollup-linux-x64-musl@4.54.0':
+    resolution: {integrity: sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-openharmony-arm64@4.53.2':
-    resolution: {integrity: sha512-4VEd19Wmhr+Zy7hbUsFZ6YXEiP48hE//KPLCSVNY5RMGX2/7HZ+QkN55a3atM1C/BZCGIgqN+xrVgtdak2S9+A==}
+  '@rollup/rollup-openharmony-arm64@4.54.0':
+    resolution: {integrity: sha512-huT3fd0iC7jigGh7n3q/+lfPcXxBi+om/Rs3yiFxjvSxbSB6aohDFXbWvlspaqjeOh+hx7DDHS+5Es5qRkWkZg==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.53.2':
-    resolution: {integrity: sha512-IlbHFYc/pQCgew/d5fslcy1KEaYVCJ44G8pajugd8VoOEI8ODhtb/j8XMhLpwHCMB3yk2J07ctup10gpw2nyMA==}
+  '@rollup/rollup-win32-arm64-msvc@4.54.0':
+    resolution: {integrity: sha512-c2V0W1bsKIKfbLMBu/WGBz6Yci8nJ/ZJdheE0EwB73N3MvHYKiKGs3mVilX4Gs70eGeDaMqEob25Tw2Gb9Nqyw==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.53.2':
-    resolution: {integrity: sha512-lNlPEGgdUfSzdCWU176ku/dQRnA7W+Gp8d+cWv73jYrb8uT7HTVVxq62DUYxjbaByuf1Yk0RIIAbDzp+CnOTFg==}
+  '@rollup/rollup-win32-ia32-msvc@4.54.0':
+    resolution: {integrity: sha512-woEHgqQqDCkAzrDhvDipnSirm5vxUXtSKDYTVpZG3nUdW/VVB5VdCYA2iReSj/u3yCZzXID4kuKG7OynPnB3WQ==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.53.2':
-    resolution: {integrity: sha512-S6YojNVrHybQis2lYov1sd+uj7K0Q05NxHcGktuMMdIQ2VixGwAfbJ23NnlvvVV1bdpR2m5MsNBViHJKcA4ADw==}
+  '@rollup/rollup-win32-x64-gnu@4.54.0':
+    resolution: {integrity: sha512-dzAc53LOuFvHwbCEOS0rPbXp6SIhAf2txMP5p6mGyOXXw5mWY8NGGbPMPrs4P1WItkfApDathBj/NzMLUZ9rtQ==}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.53.2':
-    resolution: {integrity: sha512-k+/Rkcyx//P6fetPoLMb8pBeqJBNGx81uuf7iljX9++yNBVRDQgD04L+SVXmXmh5ZP4/WOp4mWF0kmi06PW2tA==}
+  '@rollup/rollup-win32-x64-msvc@4.54.0':
+    resolution: {integrity: sha512-hYT5d3YNdSh3mbCU1gwQyPgQd3T2ne0A3KG8KSBdav5TiBg6eInVmV+TeR5uHufiIgSFg0XsOWGW5/RhNcSvPg==}
     cpu: [x64]
     os: [win32]
 
@@ -1608,68 +1608,68 @@ packages:
     peerDependencies:
       size-limit: 11.2.0
 
-  '@swc/core-darwin-arm64@1.15.2':
-    resolution: {integrity: sha512-Ghyz4RJv4zyXzrUC1B2MLQBbppIB5c4jMZJybX2ebdEQAvryEKp3gq1kBksCNsatKGmEgXul88SETU19sMWcrw==}
+  '@swc/core-darwin-arm64@1.15.8':
+    resolution: {integrity: sha512-M9cK5GwyWWRkRGwwCbREuj6r8jKdES/haCZ3Xckgkl8MUQJZA3XB7IXXK1IXRNeLjg6m7cnoMICpXv1v1hlJOg==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@swc/core-darwin-x64@1.15.2':
-    resolution: {integrity: sha512-7n/PGJOcL2QoptzL42L5xFFfXY5rFxLHnuz1foU+4ruUTG8x2IebGhtwVTpaDN8ShEv2UZObBlT1rrXTba15Zw==}
+  '@swc/core-darwin-x64@1.15.8':
+    resolution: {integrity: sha512-j47DasuOvXl80sKJHSi2X25l44CMc3VDhlJwA7oewC1nV1VsSzwX+KOwE5tLnfORvVJJyeiXgJORNYg4jeIjYQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [darwin]
 
-  '@swc/core-linux-arm-gnueabihf@1.15.2':
-    resolution: {integrity: sha512-ZUQVCfRJ9wimuxkStRSlLwqX4TEDmv6/J+E6FicGkQ6ssLMWoKDy0cAo93HiWt/TWEee5vFhFaSQYzCuBEGO6A==}
+  '@swc/core-linux-arm-gnueabihf@1.15.8':
+    resolution: {integrity: sha512-siAzDENu2rUbwr9+fayWa26r5A9fol1iORG53HWxQL1J8ym4k7xt9eME0dMPXlYZDytK5r9sW8zEA10F2U3Xwg==}
     engines: {node: '>=10'}
     cpu: [arm]
     os: [linux]
 
-  '@swc/core-linux-arm64-gnu@1.15.2':
-    resolution: {integrity: sha512-GZh3pYBmfnpQ+JIg+TqLuz+pM+Mjsk5VOzi8nwKn/m+GvQBsxD5ectRtxuWUxMGNG8h0lMy4SnHRqdK3/iJl7A==}
+  '@swc/core-linux-arm64-gnu@1.15.8':
+    resolution: {integrity: sha512-o+1y5u6k2FfPYbTRUPvurwzNt5qd0NTumCTFscCNuBksycloXY16J8L+SMW5QRX59n4Hp9EmFa3vpvNHRVv1+Q==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
 
-  '@swc/core-linux-arm64-musl@1.15.2':
-    resolution: {integrity: sha512-5av6VYZZeneiYIodwzGMlnyVakpuYZryGzFIbgu1XP8wVylZxduEzup4eP8atiMDFmIm+s4wn8GySJmYqeJC0A==}
+  '@swc/core-linux-arm64-musl@1.15.8':
+    resolution: {integrity: sha512-koiCqL09EwOP1S2RShCI7NbsQuG6r2brTqUYE7pV7kZm9O17wZ0LSz22m6gVibpwEnw8jI3IE1yYsQTVpluALw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
 
-  '@swc/core-linux-x64-gnu@1.15.2':
-    resolution: {integrity: sha512-1nO/UfdCLuT/uE/7oB3EZgTeZDCIa6nL72cFEpdegnqpJVNDI6Qb8U4g/4lfVPkmHq2lvxQ0L+n+JdgaZLhrRA==}
+  '@swc/core-linux-x64-gnu@1.15.8':
+    resolution: {integrity: sha512-4p6lOMU3bC+Vd5ARtKJ/FxpIC5G8v3XLoPEZ5s7mLR8h7411HWC/LmTXDHcrSXRC55zvAVia1eldy6zDLz8iFQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
 
-  '@swc/core-linux-x64-musl@1.15.2':
-    resolution: {integrity: sha512-Ksfrb0Tx310kr+TLiUOvB/I80lyZ3lSOp6cM18zmNRT/92NB4mW8oX2Jo7K4eVEI2JWyaQUAFubDSha2Q+439A==}
+  '@swc/core-linux-x64-musl@1.15.8':
+    resolution: {integrity: sha512-z3XBnbrZAL+6xDGAhJoN4lOueIxC/8rGrJ9tg+fEaeqLEuAtHSW2QHDHxDwkxZMjuF/pZ6MUTjHjbp8wLbuRLA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
 
-  '@swc/core-win32-arm64-msvc@1.15.2':
-    resolution: {integrity: sha512-IzUb5RlMUY0r1A9IuJrQ7Tbts1wWb73/zXVXT8VhewbHGoNlBKE0qUhKMED6Tv4wDF+pmbtUJmKXDthytAvLmg==}
+  '@swc/core-win32-arm64-msvc@1.15.8':
+    resolution: {integrity: sha512-djQPJ9Rh9vP8GTS/Df3hcc6XP6xnG5c8qsngWId/BLA9oX6C7UzCPAn74BG/wGb9a6j4w3RINuoaieJB3t+7iQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
 
-  '@swc/core-win32-ia32-msvc@1.15.2':
-    resolution: {integrity: sha512-kCATEzuY2LP9AlbU2uScjcVhgnCAkRdu62vbce17Ro5kxEHxYWcugkveyBRS3AqZGtwAKYbMAuNloer9LS/hpw==}
+  '@swc/core-win32-ia32-msvc@1.15.8':
+    resolution: {integrity: sha512-/wfAgxORg2VBaUoFdytcVBVCgf1isWZIEXB9MZEUty4wwK93M/PxAkjifOho9RN3WrM3inPLabICRCEgdHpKKQ==}
     engines: {node: '>=10'}
     cpu: [ia32]
     os: [win32]
 
-  '@swc/core-win32-x64-msvc@1.15.2':
-    resolution: {integrity: sha512-iJaHeYCF4jTn7OEKSa3KRiuVFIVYts8jYjNmCdyz1u5g8HRyTDISD76r8+ljEOgm36oviRQvcXaw6LFp1m0yyA==}
+  '@swc/core-win32-x64-msvc@1.15.8':
+    resolution: {integrity: sha512-GpMePrh9Sl4d61o4KAHOOv5is5+zt6BEXCOCgs/H0FLGeii7j9bWDE8ExvKFy2GRRZVNR1ugsnzaGWHKM6kuzA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
 
-  '@swc/core@1.15.2':
-    resolution: {integrity: sha512-OQm+yJdXxvSjqGeaWhP6Ia264ogifwAO7Q12uTDVYj/Ks4jBTI4JknlcjDRAXtRhqbWsfbZyK/5RtuIPyptk3w==}
+  '@swc/core@1.15.8':
+    resolution: {integrity: sha512-T8keoJjXaSUoVBCIjgL6wAnhADIb09GOELzKg10CjNg+vLX48P93SME6jTfte9MZIm5m+Il57H3rTSk/0kzDUw==}
     engines: {node: '>=10'}
     peerDependencies:
       '@swc/helpers': '>=0.5.17'
@@ -1825,14 +1825,14 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
-  '@types/lodash@4.17.20':
-    resolution: {integrity: sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==}
+  '@types/lodash@4.17.21':
+    resolution: {integrity: sha512-FOvQ0YPD5NOfPgMzJihoT+Za5pdkDJWcbpuj1DjaKZIr/gxodQjY/uWEFlTNqW2ugXHUiL8lRQgw63dzKHZdeQ==}
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@22.19.1':
-    resolution: {integrity: sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==}
+  '@types/node@22.19.3':
+    resolution: {integrity: sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==}
 
   '@types/offscreencanvas@2019.7.3':
     resolution: {integrity: sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==}
@@ -1859,63 +1859,63 @@ packages:
   '@types/webxr@0.5.24':
     resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
-  '@typescript-eslint/eslint-plugin@8.47.0':
-    resolution: {integrity: sha512-fe0rz9WJQ5t2iaLfdbDc9T80GJy0AeO453q8C3YCilnGozvOyCG5t+EZtg7j7D88+c3FipfP/x+wzGnh1xp8ZA==}
+  '@typescript-eslint/eslint-plugin@8.51.0':
+    resolution: {integrity: sha512-XtssGWJvypyM2ytBnSnKtHYOGT+4ZwTnBVl36TA4nRO2f4PRNGz5/1OszHzcZCvcBMh+qb7I06uoCmLTRdR9og==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.47.0
+      '@typescript-eslint/parser': ^8.51.0
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/parser@8.47.0':
-    resolution: {integrity: sha512-lJi3PfxVmo0AkEY93ecfN+r8SofEqZNGByvHAI3GBLrvt1Cw6H5k1IM02nSzu0RfUafr2EvFSw0wAsZgubNplQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/project-service@8.47.0':
-    resolution: {integrity: sha512-2X4BX8hUeB5JcA1TQJ7GjcgulXQ+5UkNb0DL8gHsHUHdFoiCTJoYLTpib3LtSDPZsRET5ygN4qqIWrHyYIKERA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/scope-manager@8.47.0':
-    resolution: {integrity: sha512-a0TTJk4HXMkfpFkL9/WaGTNuv7JWfFTQFJd6zS9dVAjKsojmv9HT55xzbEpnZoY+VUb+YXLMp+ihMLz/UlZfDg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.47.0':
-    resolution: {integrity: sha512-ybUAvjy4ZCL11uryalkKxuT3w3sXJAuWhOoGS3T/Wu+iUu1tGJmk5ytSY8gbdACNARmcYEB0COksD2j6hfGK2g==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/type-utils@8.47.0':
-    resolution: {integrity: sha512-QC9RiCmZ2HmIdCEvhd1aJELBlD93ErziOXXlHEZyuBo3tBiAZieya0HLIxp+DoDWlsQqDawyKuNEhORyku+P8A==}
+  '@typescript-eslint/parser@8.51.0':
+    resolution: {integrity: sha512-3xP4XzzDNQOIqBMWogftkwxhg5oMKApqY0BAflmLZiFYHqyhSOxv/cd/zPQLTcCXr4AkaKb25joocY0BD1WC6A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/types@8.47.0':
-    resolution: {integrity: sha512-nHAE6bMKsizhA2uuYZbEbmp5z2UpffNrPEqiKIeN7VsV6UY/roxanWfoRrf6x/k9+Obf+GQdkm0nPU+vnMXo9A==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.47.0':
-    resolution: {integrity: sha512-k6ti9UepJf5NpzCjH31hQNLHQWupTRPhZ+KFF8WtTuTpy7uHPfeg2NM7cP27aCGajoEplxJDFVCEm9TGPYyiVg==}
+  '@typescript-eslint/project-service@8.51.0':
+    resolution: {integrity: sha512-Luv/GafO07Z7HpiI7qeEW5NW8HUtZI/fo/kE0YbtQEFpJRUuR0ajcWfCE5bnMvL7QQFrmT/odMe8QZww8X2nfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/utils@8.47.0':
-    resolution: {integrity: sha512-g7XrNf25iL4TJOiPqatNuaChyqt49a/onq5YsJ9+hXeugK+41LVg7AxikMfM02PC6jbNtZLCJj6AUcQXJS/jGQ==}
+  '@typescript-eslint/scope-manager@8.51.0':
+    resolution: {integrity: sha512-JhhJDVwsSx4hiOEQPeajGhCWgBMBwVkxC/Pet53EpBVs7zHHtayKefw1jtPaNRXpI9RA2uocdmpdfE7T+NrizA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.51.0':
+    resolution: {integrity: sha512-Qi5bSy/vuHeWyir2C8u/uqGMIlIDu8fuiYWv48ZGlZ/k+PRPHtaAu7erpc7p5bzw2WNNSniuxoMSO4Ar6V9OXw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/type-utils@8.51.0':
+    resolution: {integrity: sha512-0XVtYzxnobc9K0VU7wRWg1yiUrw4oQzexCG2V2IDxxCxhqBMSMbjB+6o91A+Uc0GWtgjCa3Y8bi7hwI0Tu4n5Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/visitor-keys@8.47.0':
-    resolution: {integrity: sha512-SIV3/6eftCy1bNzCQoPmbWsRLujS8t5iDIZ4spZOBHqrM+yfX2ogg8Tt3PDTAVKw3sSCiUgg30uOAvK2r9zGjQ==}
+  '@typescript-eslint/types@8.51.0':
+    resolution: {integrity: sha512-TizAvWYFM6sSscmEakjY3sPqGwxZRSywSsPEiuZF6d5GmGD9Gvlsv0f6N8FvAAA0CD06l3rIcWNbsN1e5F/9Ag==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.51.0':
+    resolution: {integrity: sha512-1qNjGqFRmlq0VW5iVlcyHBbCjPB7y6SxpBkrbhNWMy/65ZoncXCEPJxkRZL8McrseNH6lFhaxCIaX+vBuFnRng==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/utils@8.51.0':
+    resolution: {integrity: sha512-11rZYxSe0zabiKaCP2QAwRf/dnmgFgvTmeDTtZvUvXG3UuAdg/GU02NExmmIXzz3vLGgMdtrIosI84jITQOxUA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/visitor-keys@8.51.0':
+    resolution: {integrity: sha512-mM/JRQOzhVN1ykejrvwnBRV3+7yTKK8tVANVN3o1O0t0v7o+jqdVu9crPy5Y9dov15TJk/FTIgoUGHrTOVL3Zg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@use-gesture/core@10.3.1':
@@ -1976,8 +1976,8 @@ packages:
   '@vizij/wasm-loader@0.1.4':
     resolution: {integrity: sha512-BAq4dQshOB4ICSWVvGUVGob0qowLwyq4VI77qmzpeq93l7MA15gNJWwXZ3ED54MNdkSZU/4rej5y2e2BiCA7Kw==}
 
-  '@webgpu/types@0.1.66':
-    resolution: {integrity: sha512-YA2hLrwLpDsRueNDXIMqN9NTzD6bCDkuXbOSe0heS+f8YE8usA6Gbv1prj81pzVHrbaAma7zObnIC+I6/sXJgA==}
+  '@webgpu/types@0.1.68':
+    resolution: {integrity: sha512-3ab1B59Ojb6RwjOspYLsTpCzbNB3ZaamIAxBMmvnNkiDoLTZUOBXZ9p5nAYVEkQlDdf6qAZWi1pqj9+ypiqznA==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -2394,8 +2394,8 @@ packages:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
 
-  es-abstract@1.24.0:
-    resolution: {integrity: sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==}
+  es-abstract@1.24.1:
+    resolution: {integrity: sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==}
     engines: {node: '>= 0.4'}
 
   es-define-property@1.0.1:
@@ -2433,8 +2433,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  esbuild@0.27.0:
-    resolution: {integrity: sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==}
+  esbuild@0.27.2:
+    resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2482,8 +2482,8 @@ packages:
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
 
-  eslint-plugin-react-refresh@0.4.24:
-    resolution: {integrity: sha512-nLHIW7TEq3aLrEYWpVaJ1dRgFR+wLDPN8e8FpYAql/bMV2oBEfC37K0gLEGgv9fy66juNShSMV8OkTqzltcG/w==}
+  eslint-plugin-react-refresh@0.4.26:
+    resolution: {integrity: sha512-1RETEylht2O6FM/MvgnyvT+8K21wLqDNg4qD51Zj3guhjt433XbnnkVttHMyaVyAFD03QSV4LPS5iE3VQmO7XQ==}
     peerDependencies:
       eslint: '>=8.40'
 
@@ -2499,8 +2499,8 @@ packages:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  eslint@9.39.1:
-    resolution: {integrity: sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==}
+  eslint@9.39.2:
+    resolution: {integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
     peerDependencies:
@@ -2518,8 +2518,8 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  esquery@1.6.0:
-    resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
 
   esrecurse@4.3.0:
@@ -2544,8 +2544,8 @@ packages:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
 
-  expect-type@1.2.2:
-    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
   extend@3.0.2:
@@ -2567,8 +2567,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fastq@1.19.1:
-    resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2694,8 +2694,8 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
-  glob@10.4.5:
-    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
     hasBin: true
 
   globals@14.0.0:
@@ -2732,9 +2732,6 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  graphemer@1.4.0:
-    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
-
   gtoken@8.0.0:
     resolution: {integrity: sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==}
     engines: {node: '>=18'}
@@ -2766,8 +2763,8 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  hls.js@1.6.14:
-    resolution: {integrity: sha512-CSpT2aXsv71HST8C5ETeVo+6YybqCpHBiYrCRQSn3U5QUZuLTSsvtq/bj+zuvjLVADeKxoebzo16OkH8m1+65Q==}
+  hls.js@1.6.15:
+    resolution: {integrity: sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA==}
 
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
@@ -2781,8 +2778,8 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
-  human-id@4.1.2:
-    resolution: {integrity: sha512-v/J+4Z/1eIJovEBdlV5TYj1IR+ZiohcYGRY+qN/oC9dAfKzVT023N/Bgw37hrKCoVRBvk3bqyzpr2PP5YeTMSg==}
+  human-id@4.1.3:
+    resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
     hasBin: true
 
   human-signals@5.0.0:
@@ -2793,8 +2790,8 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
-  iconv-lite@0.7.0:
-    resolution: {integrity: sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==}
+  iconv-lite@0.7.1:
+    resolution: {integrity: sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw==}
     engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
@@ -3027,8 +3024,8 @@ packages:
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
 
-  jws@4.0.0:
-    resolution: {integrity: sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==}
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -3080,10 +3077,6 @@ packages:
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
-
-  loose-envify@1.4.0:
-    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
-    hasBin: true
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
@@ -3194,8 +3187,8 @@ packages:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  nwsapi@2.2.22:
-    resolution: {integrity: sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==}
+  nwsapi@2.2.23:
+    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -3384,8 +3377,8 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  prettier@3.6.2:
-    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
+  prettier@3.7.4:
+    resolution: {integrity: sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -3412,11 +3405,6 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  react-dom@18.3.1:
-    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
-    peerDependencies:
-      react: ^18.3.1
-
   react-dom@19.2.3:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
     peerDependencies:
@@ -3438,10 +3426,6 @@ packages:
     peerDependenciesMeta:
       react-dom:
         optional: true
-
-  react@18.3.1:
-    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
-    engines: {node: '>=0.10.0'}
 
   react@19.2.3:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
@@ -3504,8 +3488,8 @@ packages:
     resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
     hasBin: true
 
-  rollup@4.53.2:
-    resolution: {integrity: sha512-MHngMYwGJVi6Fmnk6ISmnk7JAHRNF0UkuucA0CUW3N3a4KnONPEZz+vUanQP/ZC/iY1Qkf3bwPWzyY84wEks1g==}
+  rollup@4.54.0:
+    resolution: {integrity: sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -3539,9 +3523,6 @@ packages:
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
-
-  scheduler@0.23.2:
-    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -3699,8 +3680,8 @@ packages:
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
-  sucrase@3.35.0:
-    resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
 
@@ -3720,8 +3701,8 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
-  tailwindcss@4.1.17:
-    resolution: {integrity: sha512-j9Ee2YjuQqYT9bbRTfTZht9W/ytp5H+jJpZKiYdP/bpnXARAuELt9ofP0lPnmHjbga7SNQIxdTAXCmtKVYjN+Q==}
+  tailwindcss@4.1.18:
+    resolution: {integrity: sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==}
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -3798,8 +3779,8 @@ packages:
   troika-worker-utils@0.52.0:
     resolution: {integrity: sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==}
 
-  ts-api-utils@2.1.0:
-    resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
+  ts-api-utils@2.3.0:
+    resolution: {integrity: sha512-6eg3Y9SF7SsAvGzRHQvvc1skDAhwI4YQ32ui1scxD1Ccr0G5qIIbUBT3pFTKX8kmWIQClHobtUdNuaBgwdfdWg==}
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
@@ -3852,8 +3833,8 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
-  typescript-eslint@8.47.0:
-    resolution: {integrity: sha512-Lwe8i2XQ3WoMjua/r1PHrCTpkubPYJCAfOurtn+mtTzqB6jNd+14n9UN1bJ4s3F49x9ixAm0FLflB/JzQ57M8Q==}
+  typescript-eslint@8.51.0:
+    resolution: {integrity: sha512-jh8ZuM5oEh2PSdyQG9YAEM1TCGuWenLSuSUhf/irbVUNW9O5FhbFVONviN2TgMTBnUmyHv7E56rYnfLZK6TkiA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -3991,6 +3972,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -4061,8 +4043,8 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
-  yaml@2.8.1:
-    resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
+  yaml@2.8.2:
+    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -4108,9 +4090,9 @@ snapshots:
 
   '@babel/runtime@7.28.4': {}
 
-  '@changesets/apply-release-plan@7.0.13':
+  '@changesets/apply-release-plan@7.0.14':
     dependencies:
-      '@changesets/config': 3.1.1
+      '@changesets/config': 3.1.2
       '@changesets/get-version-range-type': 0.4.0
       '@changesets/git': 3.0.4
       '@changesets/should-skip-package': 0.1.2
@@ -4137,23 +4119,23 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/cli@2.29.7(@types/node@22.19.1)':
+  '@changesets/cli@2.29.8(@types/node@22.19.3)':
     dependencies:
-      '@changesets/apply-release-plan': 7.0.13
+      '@changesets/apply-release-plan': 7.0.14
       '@changesets/assemble-release-plan': 6.0.9
       '@changesets/changelog-git': 0.2.1
-      '@changesets/config': 3.1.1
+      '@changesets/config': 3.1.2
       '@changesets/errors': 0.2.0
       '@changesets/get-dependents-graph': 2.1.3
-      '@changesets/get-release-plan': 4.0.13
+      '@changesets/get-release-plan': 4.0.14
       '@changesets/git': 3.0.4
       '@changesets/logger': 0.1.1
       '@changesets/pre': 2.0.2
-      '@changesets/read': 0.6.5
+      '@changesets/read': 0.6.6
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3(@types/node@22.19.1)
+      '@inquirer/external-editor': 1.0.3(@types/node@22.19.3)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       ci-info: 3.9.0
@@ -4170,7 +4152,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@changesets/config@3.1.1':
+  '@changesets/config@3.1.2':
     dependencies:
       '@changesets/errors': 0.2.0
       '@changesets/get-dependents-graph': 2.1.3
@@ -4191,12 +4173,12 @@ snapshots:
       picocolors: 1.1.1
       semver: 7.7.3
 
-  '@changesets/get-release-plan@4.0.13':
+  '@changesets/get-release-plan@4.0.14':
     dependencies:
       '@changesets/assemble-release-plan': 6.0.9
-      '@changesets/config': 3.1.1
+      '@changesets/config': 3.1.2
       '@changesets/pre': 2.0.2
-      '@changesets/read': 0.6.5
+      '@changesets/read': 0.6.6
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
 
@@ -4214,10 +4196,10 @@ snapshots:
     dependencies:
       picocolors: 1.1.1
 
-  '@changesets/parse@0.4.1':
+  '@changesets/parse@0.4.2':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 3.14.2
+      js-yaml: 4.1.1
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -4226,11 +4208,11 @@ snapshots:
       '@manypkg/get-packages': 1.1.3
       fs-extra: 7.0.1
 
-  '@changesets/read@0.6.5':
+  '@changesets/read@0.6.6':
     dependencies:
       '@changesets/git': 3.0.4
       '@changesets/logger': 0.1.1
-      '@changesets/parse': 0.4.1
+      '@changesets/parse': 0.4.2
       '@changesets/types': 6.1.0
       fs-extra: 7.0.1
       p-filter: 2.1.0
@@ -4249,7 +4231,7 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
       fs-extra: 7.0.1
-      human-id: 4.1.2
+      human-id: 4.1.3
       prettier: 2.8.8
 
   '@csstools/color-helpers@5.1.0': {}
@@ -4275,162 +4257,162 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.0':
+  '@esbuild/aix-ppc64@0.27.2':
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
     optional: true
 
-  '@esbuild/android-arm64@0.27.0':
+  '@esbuild/android-arm64@0.27.2':
     optional: true
 
   '@esbuild/android-arm@0.25.12':
     optional: true
 
-  '@esbuild/android-arm@0.27.0':
+  '@esbuild/android-arm@0.27.2':
     optional: true
 
   '@esbuild/android-x64@0.25.12':
     optional: true
 
-  '@esbuild/android-x64@0.27.0':
+  '@esbuild/android-x64@0.27.2':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.0':
+  '@esbuild/darwin-arm64@0.27.2':
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.0':
+  '@esbuild/darwin-x64@0.27.2':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.0':
+  '@esbuild/freebsd-arm64@0.27.2':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.0':
+  '@esbuild/freebsd-x64@0.27.2':
     optional: true
 
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.0':
+  '@esbuild/linux-arm64@0.27.2':
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
     optional: true
 
-  '@esbuild/linux-arm@0.27.0':
+  '@esbuild/linux-arm@0.27.2':
     optional: true
 
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.0':
+  '@esbuild/linux-ia32@0.27.2':
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.0':
+  '@esbuild/linux-loong64@0.27.2':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.0':
+  '@esbuild/linux-mips64el@0.27.2':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.0':
+  '@esbuild/linux-ppc64@0.27.2':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.0':
+  '@esbuild/linux-riscv64@0.27.2':
     optional: true
 
   '@esbuild/linux-s390x@0.25.12':
     optional: true
 
-  '@esbuild/linux-s390x@0.27.0':
+  '@esbuild/linux-s390x@0.27.2':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
     optional: true
 
-  '@esbuild/linux-x64@0.27.0':
+  '@esbuild/linux-x64@0.27.2':
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.0':
+  '@esbuild/netbsd-arm64@0.27.2':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.0':
+  '@esbuild/netbsd-x64@0.27.2':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.0':
+  '@esbuild/openbsd-arm64@0.27.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.0':
+  '@esbuild/openbsd-x64@0.27.2':
     optional: true
 
   '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.0':
+  '@esbuild/openharmony-arm64@0.27.2':
     optional: true
 
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.0':
+  '@esbuild/sunos-x64@0.27.2':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.0':
+  '@esbuild/win32-arm64@0.27.2':
     optional: true
 
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.0':
+  '@esbuild/win32-ia32@0.27.2':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
     optional: true
 
-  '@esbuild/win32-x64@0.27.0':
+  '@esbuild/win32-x64@0.27.2':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.0(eslint@9.39.1(jiti@2.6.1))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.6.1))':
     dependencies:
-      eslint: 9.39.1(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -4455,7 +4437,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.1':
+  '@eslint/eslintrc@3.3.3':
     dependencies:
       ajv: 6.12.6
       debug: 4.4.3
@@ -4469,7 +4451,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/js@9.39.1': {}
+  '@eslint/js@9.39.2': {}
 
   '@eslint/object-schema@2.1.7': {}
 
@@ -4483,7 +4465,7 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@google/genai@1.30.0':
+  '@google/genai@1.34.0':
     dependencies:
       google-auth-library: 10.5.0
       ws: 8.18.3
@@ -4503,12 +4485,12 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@inquirer/external-editor@1.0.3(@types/node@22.19.1)':
+  '@inquirer/external-editor@1.0.3(@types/node@22.19.3)':
     dependencies:
       chardet: 2.1.1
-      iconv-lite: 0.7.0
+      iconv-lite: 0.7.1
     optionalDependencies:
-      '@types/node': 22.19.1
+      '@types/node': 22.19.3
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -4551,7 +4533,7 @@ snapshots:
 
   '@mediapipe/tasks-vision@0.10.17': {}
 
-  '@monogrid/gainmap-js@3.2.0(three@0.170.0)':
+  '@monogrid/gainmap-js@3.4.0(three@0.170.0)':
     dependencies:
       promise-worker-transferable: 1.0.4
       three: 0.170.0
@@ -4566,7 +4548,7 @@ snapshots:
   '@nodelib/fs.walk@1.2.8':
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.19.1
+      fastq: 1.20.1
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -4575,14 +4557,14 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.4
       '@mediapipe/tasks-vision': 0.10.17
-      '@monogrid/gainmap-js': 3.2.0(three@0.170.0)
+      '@monogrid/gainmap-js': 3.4.0(three@0.170.0)
       '@react-three/fiber': 9.5.0(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(three@0.170.0)
       '@use-gesture/react': 10.3.1(react@19.2.3)
       camera-controls: 3.1.2(three@0.170.0)
       cross-env: 7.0.3
       detect-gpu: 5.0.70
       glsl-noise: 0.0.0
-      hls.js: 1.6.14
+      hls.js: 1.6.15
       maath: 0.10.8(@types/three@0.170.0)(three@0.170.0)
       meshline: 3.3.1(three@0.170.0)
       react: 19.2.3
@@ -4710,70 +4692,70 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-beta.47': {}
 
-  '@rollup/rollup-android-arm-eabi@4.53.2':
+  '@rollup/rollup-android-arm-eabi@4.54.0':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.53.2':
+  '@rollup/rollup-android-arm64@4.54.0':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.53.2':
+  '@rollup/rollup-darwin-arm64@4.54.0':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.53.2':
+  '@rollup/rollup-darwin-x64@4.54.0':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.53.2':
+  '@rollup/rollup-freebsd-arm64@4.54.0':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.53.2':
+  '@rollup/rollup-freebsd-x64@4.54.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.53.2':
+  '@rollup/rollup-linux-arm-gnueabihf@4.54.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.53.2':
+  '@rollup/rollup-linux-arm-musleabihf@4.54.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.53.2':
+  '@rollup/rollup-linux-arm64-gnu@4.54.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.53.2':
+  '@rollup/rollup-linux-arm64-musl@4.54.0':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.53.2':
+  '@rollup/rollup-linux-loong64-gnu@4.54.0':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.53.2':
+  '@rollup/rollup-linux-ppc64-gnu@4.54.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.53.2':
+  '@rollup/rollup-linux-riscv64-gnu@4.54.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.53.2':
+  '@rollup/rollup-linux-riscv64-musl@4.54.0':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.53.2':
+  '@rollup/rollup-linux-s390x-gnu@4.54.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.53.2':
+  '@rollup/rollup-linux-x64-gnu@4.54.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.53.2':
+  '@rollup/rollup-linux-x64-musl@4.54.0':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.53.2':
+  '@rollup/rollup-openharmony-arm64@4.54.0':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.53.2':
+  '@rollup/rollup-win32-arm64-msvc@4.54.0':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.53.2':
+  '@rollup/rollup-win32-ia32-msvc@4.54.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.53.2':
+  '@rollup/rollup-win32-x64-gnu@4.54.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.53.2':
+  '@rollup/rollup-win32-x64-msvc@4.54.0':
     optional: true
 
   '@rtsao/scc@1.1.0': {}
@@ -4782,51 +4764,51 @@ snapshots:
     dependencies:
       size-limit: 11.2.0
 
-  '@swc/core-darwin-arm64@1.15.2':
+  '@swc/core-darwin-arm64@1.15.8':
     optional: true
 
-  '@swc/core-darwin-x64@1.15.2':
+  '@swc/core-darwin-x64@1.15.8':
     optional: true
 
-  '@swc/core-linux-arm-gnueabihf@1.15.2':
+  '@swc/core-linux-arm-gnueabihf@1.15.8':
     optional: true
 
-  '@swc/core-linux-arm64-gnu@1.15.2':
+  '@swc/core-linux-arm64-gnu@1.15.8':
     optional: true
 
-  '@swc/core-linux-arm64-musl@1.15.2':
+  '@swc/core-linux-arm64-musl@1.15.8':
     optional: true
 
-  '@swc/core-linux-x64-gnu@1.15.2':
+  '@swc/core-linux-x64-gnu@1.15.8':
     optional: true
 
-  '@swc/core-linux-x64-musl@1.15.2':
+  '@swc/core-linux-x64-musl@1.15.8':
     optional: true
 
-  '@swc/core-win32-arm64-msvc@1.15.2':
+  '@swc/core-win32-arm64-msvc@1.15.8':
     optional: true
 
-  '@swc/core-win32-ia32-msvc@1.15.2':
+  '@swc/core-win32-ia32-msvc@1.15.8':
     optional: true
 
-  '@swc/core-win32-x64-msvc@1.15.2':
+  '@swc/core-win32-x64-msvc@1.15.8':
     optional: true
 
-  '@swc/core@1.15.2':
+  '@swc/core@1.15.8':
     dependencies:
       '@swc/counter': 0.1.3
       '@swc/types': 0.1.25
     optionalDependencies:
-      '@swc/core-darwin-arm64': 1.15.2
-      '@swc/core-darwin-x64': 1.15.2
-      '@swc/core-linux-arm-gnueabihf': 1.15.2
-      '@swc/core-linux-arm64-gnu': 1.15.2
-      '@swc/core-linux-arm64-musl': 1.15.2
-      '@swc/core-linux-x64-gnu': 1.15.2
-      '@swc/core-linux-x64-musl': 1.15.2
-      '@swc/core-win32-arm64-msvc': 1.15.2
-      '@swc/core-win32-ia32-msvc': 1.15.2
-      '@swc/core-win32-x64-msvc': 1.15.2
+      '@swc/core-darwin-arm64': 1.15.8
+      '@swc/core-darwin-x64': 1.15.8
+      '@swc/core-linux-arm-gnueabihf': 1.15.8
+      '@swc/core-linux-arm64-gnu': 1.15.8
+      '@swc/core-linux-arm64-musl': 1.15.8
+      '@swc/core-linux-x64-gnu': 1.15.8
+      '@swc/core-linux-x64-musl': 1.15.8
+      '@swc/core-win32-arm64-msvc': 1.15.8
+      '@swc/core-win32-ia32-msvc': 1.15.8
+      '@swc/core-win32-x64-msvc': 1.15.8
 
   '@swc/counter@0.1.3': {}
 
@@ -4995,11 +4977,11 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
-  '@types/lodash@4.17.20': {}
+  '@types/lodash@4.17.21': {}
 
   '@types/node@12.20.55': {}
 
-  '@types/node@22.19.1':
+  '@types/node@22.19.3':
     dependencies:
       undici-types: 6.21.0
 
@@ -5024,103 +5006,101 @@ snapshots:
       '@tweenjs/tween.js': 23.1.3
       '@types/stats.js': 0.17.4
       '@types/webxr': 0.5.24
-      '@webgpu/types': 0.1.66
+      '@webgpu/types': 0.1.68
       fflate: 0.8.2
       meshoptimizer: 0.18.1
 
   '@types/webxr@0.5.24': {}
 
-  '@typescript-eslint/eslint-plugin@8.47.0(@typescript-eslint/parser@8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.51.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.47.0
-      '@typescript-eslint/type-utils': 8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.47.0
-      eslint: 9.39.1(jiti@2.6.1)
-      graphemer: 1.4.0
+      '@typescript-eslint/parser': 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.51.0
+      '@typescript-eslint/type-utils': 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.51.0
+      eslint: 9.39.2(jiti@2.6.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.1.0(typescript@5.9.3)
+      ts-api-utils: 2.3.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.47.0
-      '@typescript-eslint/types': 8.47.0
-      '@typescript-eslint/typescript-estree': 8.47.0(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.47.0
+      '@typescript-eslint/scope-manager': 8.51.0
+      '@typescript-eslint/types': 8.51.0
+      '@typescript-eslint/typescript-estree': 8.51.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.51.0
       debug: 4.4.3
-      eslint: 9.39.1(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.47.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.51.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.47.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.47.0
+      '@typescript-eslint/tsconfig-utils': 8.51.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.51.0
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.47.0':
+  '@typescript-eslint/scope-manager@8.51.0':
     dependencies:
-      '@typescript-eslint/types': 8.47.0
-      '@typescript-eslint/visitor-keys': 8.47.0
+      '@typescript-eslint/types': 8.51.0
+      '@typescript-eslint/visitor-keys': 8.51.0
 
-  '@typescript-eslint/tsconfig-utils@8.47.0(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.51.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/types': 8.47.0
-      '@typescript-eslint/typescript-estree': 8.47.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/types': 8.51.0
+      '@typescript-eslint/typescript-estree': 8.51.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       debug: 4.4.3
-      eslint: 9.39.1(jiti@2.6.1)
-      ts-api-utils: 2.1.0(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.6.1)
+      ts-api-utils: 2.3.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.47.0': {}
+  '@typescript-eslint/types@8.51.0': {}
 
-  '@typescript-eslint/typescript-estree@8.47.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.51.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.47.0(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.47.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.47.0
-      '@typescript-eslint/visitor-keys': 8.47.0
+      '@typescript-eslint/project-service': 8.51.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.51.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.51.0
+      '@typescript-eslint/visitor-keys': 8.51.0
       debug: 4.4.3
-      fast-glob: 3.3.3
-      is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.7.3
-      ts-api-utils: 2.1.0(typescript@5.9.3)
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.3.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1(jiti@2.6.1))
-      '@typescript-eslint/scope-manager': 8.47.0
-      '@typescript-eslint/types': 8.47.0
-      '@typescript-eslint/typescript-estree': 8.47.0(typescript@5.9.3)
-      eslint: 9.39.1(jiti@2.6.1)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
+      '@typescript-eslint/scope-manager': 8.51.0
+      '@typescript-eslint/types': 8.51.0
+      '@typescript-eslint/typescript-estree': 8.51.0(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.47.0':
+  '@typescript-eslint/visitor-keys@8.51.0':
     dependencies:
-      '@typescript-eslint/types': 8.47.0
+      '@typescript-eslint/types': 8.51.0
       eslint-visitor-keys: 4.2.1
 
   '@use-gesture/core@10.3.1': {}
@@ -5130,11 +5110,11 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 19.2.3
 
-  '@vitejs/plugin-react-swc@4.2.2(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))':
+  '@vitejs/plugin-react-swc@4.2.2(vite@6.4.1(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.47
-      '@swc/core': 1.15.2
-      vite: 6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1)
+      '@swc/core': 1.15.8
+      vite: 6.4.1(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -5146,13 +5126,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))':
+  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1)
+      vite: 6.4.1(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -5199,7 +5179,7 @@ snapshots:
 
   '@vizij/wasm-loader@0.1.4': {}
 
-  '@webgpu/types@0.1.66': {}
+  '@webgpu/types@0.1.68': {}
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -5256,7 +5236,7 @@ snapshots:
       call-bind: 1.0.8
       call-bound: 1.0.4
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.1
       es-object-atoms: 1.1.1
       get-intrinsic: 1.3.0
       is-string: 1.1.1
@@ -5269,7 +5249,7 @@ snapshots:
       call-bind: 1.0.8
       call-bound: 1.0.4
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
       es-shim-unscopables: 1.1.0
@@ -5278,14 +5258,14 @@ snapshots:
     dependencies:
       call-bind: 1.0.8
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.1
       es-shim-unscopables: 1.1.0
 
   array.prototype.flatmap@1.3.3:
     dependencies:
       call-bind: 1.0.8
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.1
       es-shim-unscopables: 1.1.0
 
   arraybuffer.prototype.slice@1.0.4:
@@ -5293,7 +5273,7 @@ snapshots:
       array-buffer-byte-length: 1.0.2
       call-bind: 1.0.8
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.1
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
@@ -5342,9 +5322,9 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  bundle-require@5.1.0(esbuild@0.27.0):
+  bundle-require@5.1.0(esbuild@0.27.2):
     dependencies:
-      esbuild: 0.27.0
+      esbuild: 0.27.2
       load-tsconfig: 0.2.5
 
   bytes-iec@3.1.1: {}
@@ -5608,7 +5588,7 @@ snapshots:
 
   environment@1.1.0: {}
 
-  es-abstract@1.24.0:
+  es-abstract@1.24.1:
     dependencies:
       array-buffer-byte-length: 1.0.2
       arraybuffer.prototype.slice: 1.0.4
@@ -5733,34 +5713,34 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
 
-  esbuild@0.27.0:
+  esbuild@0.27.2:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.0
-      '@esbuild/android-arm': 0.27.0
-      '@esbuild/android-arm64': 0.27.0
-      '@esbuild/android-x64': 0.27.0
-      '@esbuild/darwin-arm64': 0.27.0
-      '@esbuild/darwin-x64': 0.27.0
-      '@esbuild/freebsd-arm64': 0.27.0
-      '@esbuild/freebsd-x64': 0.27.0
-      '@esbuild/linux-arm': 0.27.0
-      '@esbuild/linux-arm64': 0.27.0
-      '@esbuild/linux-ia32': 0.27.0
-      '@esbuild/linux-loong64': 0.27.0
-      '@esbuild/linux-mips64el': 0.27.0
-      '@esbuild/linux-ppc64': 0.27.0
-      '@esbuild/linux-riscv64': 0.27.0
-      '@esbuild/linux-s390x': 0.27.0
-      '@esbuild/linux-x64': 0.27.0
-      '@esbuild/netbsd-arm64': 0.27.0
-      '@esbuild/netbsd-x64': 0.27.0
-      '@esbuild/openbsd-arm64': 0.27.0
-      '@esbuild/openbsd-x64': 0.27.0
-      '@esbuild/openharmony-arm64': 0.27.0
-      '@esbuild/sunos-x64': 0.27.0
-      '@esbuild/win32-arm64': 0.27.0
-      '@esbuild/win32-ia32': 0.27.0
-      '@esbuild/win32-x64': 0.27.0
+      '@esbuild/aix-ppc64': 0.27.2
+      '@esbuild/android-arm': 0.27.2
+      '@esbuild/android-arm64': 0.27.2
+      '@esbuild/android-x64': 0.27.2
+      '@esbuild/darwin-arm64': 0.27.2
+      '@esbuild/darwin-x64': 0.27.2
+      '@esbuild/freebsd-arm64': 0.27.2
+      '@esbuild/freebsd-x64': 0.27.2
+      '@esbuild/linux-arm': 0.27.2
+      '@esbuild/linux-arm64': 0.27.2
+      '@esbuild/linux-ia32': 0.27.2
+      '@esbuild/linux-loong64': 0.27.2
+      '@esbuild/linux-mips64el': 0.27.2
+      '@esbuild/linux-ppc64': 0.27.2
+      '@esbuild/linux-riscv64': 0.27.2
+      '@esbuild/linux-s390x': 0.27.2
+      '@esbuild/linux-x64': 0.27.2
+      '@esbuild/netbsd-arm64': 0.27.2
+      '@esbuild/netbsd-x64': 0.27.2
+      '@esbuild/openbsd-arm64': 0.27.2
+      '@esbuild/openbsd-x64': 0.27.2
+      '@esbuild/openharmony-arm64': 0.27.2
+      '@esbuild/sunos-x64': 0.27.2
+      '@esbuild/win32-arm64': 0.27.2
+      '@esbuild/win32-ia32': 0.27.2
+      '@esbuild/win32-x64': 0.27.2
 
   escape-string-regexp@4.0.0: {}
 
@@ -5772,17 +5752,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 9.39.1(jiti@2.6.1)
+      '@typescript-eslint/parser': 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -5791,9 +5771,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.1(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -5805,19 +5785,19 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-react-hooks@5.2.0(eslint@9.39.1(jiti@2.6.1)):
+  eslint-plugin-react-hooks@5.2.0(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
-      eslint: 9.39.1(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)
 
-  eslint-plugin-react-refresh@0.4.24(eslint@9.39.1(jiti@2.6.1)):
+  eslint-plugin-react-refresh@0.4.26(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
-      eslint: 9.39.1(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)
 
   eslint-scope@8.4.0:
     dependencies:
@@ -5828,15 +5808,15 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.39.1(jiti@2.6.1):
+  eslint@9.39.2(jiti@2.6.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.21.1
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.1
-      '@eslint/js': 9.39.1
+      '@eslint/eslintrc': 3.3.3
+      '@eslint/js': 9.39.2
       '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.7
       '@humanwhocodes/module-importer': 1.0.1
@@ -5850,7 +5830,7 @@ snapshots:
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
-      esquery: 1.6.0
+      esquery: 1.7.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
       file-entry-cache: 8.0.0
@@ -5877,7 +5857,7 @@ snapshots:
 
   esprima@4.0.1: {}
 
-  esquery@1.6.0:
+  esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
 
@@ -5907,7 +5887,7 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
-  expect-type@1.2.2: {}
+  expect-type@1.3.0: {}
 
   extend@3.0.2: {}
 
@@ -5927,7 +5907,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fastq@1.19.1:
+  fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
 
@@ -5966,7 +5946,7 @@ snapshots:
     dependencies:
       magic-string: 0.30.21
       mlly: 1.8.0
-      rollup: 4.53.2
+      rollup: 4.54.0
 
   flat-cache@4.0.1:
     dependencies:
@@ -6079,7 +6059,7 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  glob@10.4.5:
+  glob@10.5.0:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
@@ -6116,7 +6096,7 @@ snapshots:
       gcp-metadata: 8.1.2
       google-logging-utils: 1.1.3
       gtoken: 8.0.0
-      jws: 4.0.0
+      jws: 4.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -6126,12 +6106,10 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  graphemer@1.4.0: {}
-
   gtoken@8.0.0:
     dependencies:
       gaxios: 7.1.3
-      jws: 4.0.0
+      jws: 4.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -6157,7 +6135,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hls.js@1.6.14: {}
+  hls.js@1.6.15: {}
 
   html-encoding-sniffer@4.0.0:
     dependencies:
@@ -6177,7 +6155,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  human-id@4.1.2: {}
+  human-id@4.1.3: {}
 
   human-signals@5.0.0: {}
 
@@ -6185,7 +6163,7 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  iconv-lite@0.7.0:
+  iconv-lite@0.7.1:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -6389,7 +6367,7 @@ snapshots:
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       is-potential-custom-element-name: 1.0.1
-      nwsapi: 2.2.22
+      nwsapi: 2.2.23
       parse5: 7.3.0
       rrweb-cssom: 0.7.1
       saxes: 6.0.0
@@ -6431,7 +6409,7 @@ snapshots:
       ecdsa-sig-formatter: 1.0.11
       safe-buffer: 5.2.1
 
-  jws@4.0.0:
+  jws@4.0.1:
     dependencies:
       jwa: 2.0.1
       safe-buffer: 5.2.1
@@ -6464,7 +6442,7 @@ snapshots:
       micromatch: 4.0.8
       pidtree: 0.6.0
       string-argv: 0.3.2
-      yaml: 2.8.1
+      yaml: 2.8.2
     transitivePeerDependencies:
       - supports-color
 
@@ -6500,10 +6478,6 @@ snapshots:
       slice-ansi: 7.1.2
       strip-ansi: 7.1.2
       wrap-ansi: 9.0.2
-
-  loose-envify@1.4.0:
-    dependencies:
-      js-tokens: 4.0.0
 
   loupe@3.2.1: {}
 
@@ -6596,7 +6570,7 @@ snapshots:
     dependencies:
       path-key: 4.0.0
 
-  nwsapi@2.2.22: {}
+  nwsapi@2.2.23: {}
 
   object-assign@4.1.1: {}
 
@@ -6622,14 +6596,14 @@ snapshots:
     dependencies:
       call-bind: 1.0.8
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.1
       es-object-atoms: 1.1.1
 
   object.groupby@1.0.3:
     dependencies:
       call-bind: 1.0.8
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.1
 
   object.values@1.2.1:
     dependencies:
@@ -6740,13 +6714,13 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.6)(yaml@2.8.1):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.6)(yaml@2.8.2):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.6.1
       postcss: 8.5.6
-      yaml: 2.8.1
+      yaml: 2.8.2
 
   postcss@8.5.6:
     dependencies:
@@ -6760,7 +6734,7 @@ snapshots:
 
   prettier@2.8.8: {}
 
-  prettier@3.6.2: {}
+  prettier@3.7.4: {}
 
   pretty-format@27.5.1:
     dependencies:
@@ -6785,12 +6759,6 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  react-dom@18.3.1(react@18.3.1):
-    dependencies:
-      loose-envify: 1.4.0
-      react: 18.3.1
-      scheduler: 0.23.2
-
   react-dom@19.2.3(react@19.2.3):
     dependencies:
       react: 19.2.3
@@ -6808,10 +6776,6 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       react-dom: 19.2.3(react@19.2.3)
-
-  react@18.3.1:
-    dependencies:
-      loose-envify: 1.4.0
 
   react@19.2.3: {}
 
@@ -6843,7 +6807,7 @@ snapshots:
     dependencies:
       call-bind: 1.0.8
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
       get-intrinsic: 1.3.0
@@ -6884,34 +6848,34 @@ snapshots:
 
   rimraf@5.0.10:
     dependencies:
-      glob: 10.4.5
+      glob: 10.5.0
 
-  rollup@4.53.2:
+  rollup@4.54.0:
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.53.2
-      '@rollup/rollup-android-arm64': 4.53.2
-      '@rollup/rollup-darwin-arm64': 4.53.2
-      '@rollup/rollup-darwin-x64': 4.53.2
-      '@rollup/rollup-freebsd-arm64': 4.53.2
-      '@rollup/rollup-freebsd-x64': 4.53.2
-      '@rollup/rollup-linux-arm-gnueabihf': 4.53.2
-      '@rollup/rollup-linux-arm-musleabihf': 4.53.2
-      '@rollup/rollup-linux-arm64-gnu': 4.53.2
-      '@rollup/rollup-linux-arm64-musl': 4.53.2
-      '@rollup/rollup-linux-loong64-gnu': 4.53.2
-      '@rollup/rollup-linux-ppc64-gnu': 4.53.2
-      '@rollup/rollup-linux-riscv64-gnu': 4.53.2
-      '@rollup/rollup-linux-riscv64-musl': 4.53.2
-      '@rollup/rollup-linux-s390x-gnu': 4.53.2
-      '@rollup/rollup-linux-x64-gnu': 4.53.2
-      '@rollup/rollup-linux-x64-musl': 4.53.2
-      '@rollup/rollup-openharmony-arm64': 4.53.2
-      '@rollup/rollup-win32-arm64-msvc': 4.53.2
-      '@rollup/rollup-win32-ia32-msvc': 4.53.2
-      '@rollup/rollup-win32-x64-gnu': 4.53.2
-      '@rollup/rollup-win32-x64-msvc': 4.53.2
+      '@rollup/rollup-android-arm-eabi': 4.54.0
+      '@rollup/rollup-android-arm64': 4.54.0
+      '@rollup/rollup-darwin-arm64': 4.54.0
+      '@rollup/rollup-darwin-x64': 4.54.0
+      '@rollup/rollup-freebsd-arm64': 4.54.0
+      '@rollup/rollup-freebsd-x64': 4.54.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.54.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.54.0
+      '@rollup/rollup-linux-arm64-gnu': 4.54.0
+      '@rollup/rollup-linux-arm64-musl': 4.54.0
+      '@rollup/rollup-linux-loong64-gnu': 4.54.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.54.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.54.0
+      '@rollup/rollup-linux-riscv64-musl': 4.54.0
+      '@rollup/rollup-linux-s390x-gnu': 4.54.0
+      '@rollup/rollup-linux-x64-gnu': 4.54.0
+      '@rollup/rollup-linux-x64-musl': 4.54.0
+      '@rollup/rollup-openharmony-arm64': 4.54.0
+      '@rollup/rollup-win32-arm64-msvc': 4.54.0
+      '@rollup/rollup-win32-ia32-msvc': 4.54.0
+      '@rollup/rollup-win32-x64-gnu': 4.54.0
+      '@rollup/rollup-win32-x64-msvc': 4.54.0
       fsevents: 2.3.3
 
   rrweb-cssom@0.7.1: {}
@@ -6948,10 +6912,6 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
-
-  scheduler@0.23.2:
-    dependencies:
-      loose-envify: 1.4.0
 
   scheduler@0.27.0: {}
 
@@ -7094,7 +7054,7 @@ snapshots:
       call-bound: 1.0.4
       define-data-property: 1.1.4
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.1
       es-object-atoms: 1.1.1
       has-property-descriptors: 1.0.2
 
@@ -7129,14 +7089,14 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
-  sucrase@3.35.0:
+  sucrase@3.35.1:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       commander: 4.1.1
-      glob: 10.4.5
       lines-and-columns: 1.2.4
       mz: 2.7.0
       pirates: 4.0.7
+      tinyglobby: 0.2.15
       ts-interface-checker: 0.1.13
 
   supports-color@7.2.0:
@@ -7151,7 +7111,7 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
-  tailwindcss@4.1.17: {}
+  tailwindcss@4.1.18: {}
 
   term-size@2.2.1: {}
 
@@ -7225,7 +7185,7 @@ snapshots:
 
   troika-worker-utils@0.52.0: {}
 
-  ts-api-utils@2.1.0(typescript@5.9.3):
+  ts-api-utils@2.3.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
 
@@ -7238,27 +7198,27 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tsup@8.5.1(@swc/core@1.15.2)(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.1):
+  tsup@8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.2):
     dependencies:
-      bundle-require: 5.1.0(esbuild@0.27.0)
+      bundle-require: 5.1.0(esbuild@0.27.2)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
       debug: 4.4.3
-      esbuild: 0.27.0
+      esbuild: 0.27.2
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.6)(yaml@2.8.1)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.6)(yaml@2.8.2)
       resolve-from: 5.0.0
-      rollup: 4.53.2
+      rollup: 4.54.0
       source-map: 0.7.4
-      sucrase: 3.35.0
+      sucrase: 3.35.1
       tinyexec: 0.3.2
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
     optionalDependencies:
-      '@swc/core': 1.15.2
+      '@swc/core': 1.15.8
       postcss: 8.5.6
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -7313,13 +7273,13 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript-eslint@8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3):
+  typescript-eslint@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.47.0(@typescript-eslint/parser@8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.47.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 9.39.1(jiti@2.6.1)
+      '@typescript-eslint/eslint-plugin': 8.51.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.51.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -7356,13 +7316,13 @@ snapshots:
 
   utility-types@3.11.0: {}
 
-  vite-node@3.2.4(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1):
+  vite-node@3.2.4(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1)
+      vite: 6.4.1(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -7377,25 +7337,25 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1):
+  vite@6.4.1(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
-      rollup: 4.53.2
+      rollup: 4.54.0
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 22.19.1
+      '@types/node': 22.19.3
       fsevents: 2.3.3
       jiti: 2.6.1
-      yaml: 2.8.1
+      yaml: 2.8.2
 
-  vitest@3.2.4(@types/node@22.19.1)(jiti@2.6.1)(jsdom@24.1.3)(yaml@2.8.1):
+  vitest@3.2.4(@types/node@22.19.3)(jiti@2.6.1)(jsdom@24.1.3)(yaml@2.8.2):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -7403,7 +7363,7 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.3.3
       debug: 4.4.3
-      expect-type: 1.2.2
+      expect-type: 1.3.0
       magic-string: 0.30.21
       pathe: 2.0.3
       picomatch: 4.0.3
@@ -7413,11 +7373,11 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1)
-      vite-node: 3.2.4(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1)
+      vite: 6.4.1(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2)
+      vite-node: 3.2.4(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.19.1
+      '@types/node': 22.19.3
       jsdom: 24.1.3
     transitivePeerDependencies:
       - jiti
@@ -7532,7 +7492,7 @@ snapshots:
 
   xmlchars@2.2.0: {}
 
-  yaml@2.8.1: {}
+  yaml@2.8.2: {}
 
   yocto-queue@0.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,8 @@ settings:
 
 overrides:
   source-map: 0.7.4
+  zustand: 5.0.9
+  use-sync-external-store: 1.6.0
 
 importers:
 
@@ -66,21 +68,21 @@ importers:
         specifier: ^0.1.2
         version: 0.1.2
       react:
-        specifier: ^18.2.0
-        version: 18.3.1
+        specifier: ^19.2.3
+        version: 19.2.3
       react-dom:
-        specifier: ^18.2.0
-        version: 18.3.1(react@18.3.1)
+        specifier: ^19.2.3
+        version: 19.2.3(react@19.2.3)
     devDependencies:
       '@types/react':
-        specifier: ^18.3.26
-        version: 18.3.26
+        specifier: ^19.2.7
+        version: 19.2.7
       '@types/react-dom':
-        specifier: ^18.3.7
-        version: 18.3.7(@types/react@18.3.26)
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react-swc':
-        specifier: ^3.7.0
-        version: 3.11.0(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
+        specifier: ^4.2.2
+        version: 4.2.2(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
       prettier:
         specifier: ^3.4.2
         version: 3.6.2
@@ -115,21 +117,21 @@ importers:
         specifier: ^0.1.2
         version: 0.1.2
       react:
-        specifier: 18.x
-        version: 18.3.1
+        specifier: ^19.2.3
+        version: 19.2.3
       react-dom:
-        specifier: 18.x
-        version: 18.3.1(react@18.3.1)
+        specifier: ^19.2.3
+        version: 19.2.3(react@19.2.3)
       reactflow:
         specifier: 11.x
-        version: 11.11.4(@types/react@18.3.26)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 11.11.4(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
       zustand:
-        specifier: ^4.4.0
-        version: 4.5.7(@types/react@18.3.26)(immer@10.2.0)(react@18.3.1)
+        specifier: 5.0.9
+        version: 5.0.9(@types/react@19.2.7)(immer@10.2.0)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
     devDependencies:
-      '@vitejs/plugin-react':
-        specifier: ^4.0.0
-        version: 4.7.0(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
+      '@vitejs/plugin-react-swc':
+        specifier: ^4.2.2
+        version: 4.2.2(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
       eslint:
         specifier: ^9.19.0
         version: 9.39.1(jiti@2.6.1)
@@ -164,21 +166,21 @@ importers:
         specifier: ^0.1.2
         version: 0.1.2
       react:
-        specifier: ^18.2.0
-        version: 18.3.1
+        specifier: ^19.2.3
+        version: 19.2.3
       react-dom:
-        specifier: ^18.2.0
-        version: 18.3.1(react@18.3.1)
+        specifier: ^19.2.3
+        version: 19.2.3(react@19.2.3)
     devDependencies:
       '@types/react':
-        specifier: ^18.3.26
-        version: 18.3.26
+        specifier: ^19.2.7
+        version: 19.2.7
       '@types/react-dom':
-        specifier: ^18.3.7
-        version: 18.3.7(@types/react@18.3.26)
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react-swc':
-        specifier: ^3.7.0
-        version: 3.11.0(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
+        specifier: ^4.2.2
+        version: 4.2.2(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
       prettier:
         specifier: ^3.4.2
         version: 3.6.2
@@ -207,24 +209,27 @@ importers:
         specifier: workspace:*
         version: link:../../packages/@vizij/utils
       react:
-        specifier: ^18.2.0
-        version: 18.3.1
+        specifier: ^19.2.3
+        version: 19.2.3
       react-dom:
-        specifier: ^18.2.0
-        version: 18.3.1(react@18.3.1)
+        specifier: ^19.2.3
+        version: 19.2.3(react@19.2.3)
     devDependencies:
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
       '@testing-library/react':
-        specifier: ^14.3.1
-        version: 14.3.1(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^16.3.1
+        version: 16.3.1(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@types/react':
-        specifier: ^18.3.26
-        version: 18.3.26
+        specifier: ^19.2.7
+        version: 19.2.7
       '@types/react-dom':
-        specifier: ^18.3.7
-        version: 18.3.7(@types/react@18.3.26)
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react-swc':
-        specifier: ^3.7.0
-        version: 3.11.0(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
+        specifier: ^4.2.2
+        version: 4.2.2(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
       prettier:
         specifier: ^3.4.2
         version: 3.6.2
@@ -262,24 +267,27 @@ importers:
         specifier: ^0.1.2
         version: 0.1.2
       react:
-        specifier: ^18.2.0
-        version: 18.3.1
+        specifier: ^19.2.3
+        version: 19.2.3
       react-dom:
-        specifier: ^18.2.0
-        version: 18.3.1(react@18.3.1)
+        specifier: ^19.2.3
+        version: 19.2.3(react@19.2.3)
     devDependencies:
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
       '@testing-library/react':
-        specifier: ^14.3.1
-        version: 14.3.1(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^16.3.1
+        version: 16.3.1(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@types/react':
-        specifier: ^18.3.26
-        version: 18.3.26
+        specifier: ^19.2.7
+        version: 19.2.7
       '@types/react-dom':
-        specifier: ^18.3.7
-        version: 18.3.7(@types/react@18.3.26)
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react-swc':
-        specifier: ^3.7.0
-        version: 3.11.0(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
+        specifier: ^4.2.2
+        version: 4.2.2(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
       prettier:
         specifier: ^3.4.2
         version: 3.6.2
@@ -311,27 +319,27 @@ importers:
         specifier: workspace:*
         version: link:../../packages/@vizij/utils
       react:
-        specifier: ^18.2.0
-        version: 18.3.1
+        specifier: ^19.2.3
+        version: 19.2.3
       react-dom:
-        specifier: ^18.2.0
-        version: 18.3.1(react@18.3.1)
+        specifier: ^19.2.3
+        version: 19.2.3(react@19.2.3)
     devDependencies:
       '@types/react':
-        specifier: ^18.3.26
-        version: 18.3.26
+        specifier: ^19.2.7
+        version: 19.2.7
       '@types/react-dom':
-        specifier: ^18.3.7
-        version: 18.3.7(@types/react@18.3.26)
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react-swc':
-        specifier: ^3.7.0
-        version: 3.11.0(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
+        specifier: ^4.2.2
+        version: 4.2.2(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
       prettier:
         specifier: ^3.4.2
         version: 3.6.2
       reactflow:
         specifier: ^11.11.4
-        version: 11.11.4(@types/react@18.3.26)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 11.11.4(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
@@ -357,21 +365,21 @@ importers:
         specifier: workspace:*
         version: link:../../packages/@vizij/utils
       react:
-        specifier: ^18.2.0
-        version: 18.3.1
+        specifier: ^19.2.3
+        version: 19.2.3
       react-dom:
-        specifier: ^18.2.0
-        version: 18.3.1(react@18.3.1)
+        specifier: ^19.2.3
+        version: 19.2.3(react@19.2.3)
     devDependencies:
       '@types/react':
-        specifier: ^18.3.26
-        version: 18.3.26
+        specifier: ^19.2.7
+        version: 19.2.7
       '@types/react-dom':
-        specifier: ^18.3.7
-        version: 18.3.7(@types/react@18.3.26)
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react-swc':
-        specifier: ^3.7.0
-        version: 3.11.0(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
+        specifier: ^4.2.2
+        version: 4.2.2(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
       prettier:
         specifier: ^3.4.2
         version: 3.6.2
@@ -391,36 +399,36 @@ importers:
         specifier: ^1.30.0
         version: 1.30.0
       '@react-three/drei':
-        specifier: ^9.115.0
-        version: 9.122.0(@react-three/fiber@8.18.0(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.170.0))(@types/react@18.3.26)(@types/three@0.170.0)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.170.0)(use-sync-external-store@1.6.0(react@18.3.1))
+        specifier: ^10.7.7
+        version: 10.7.7(@react-three/fiber@9.5.0(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(three@0.170.0))(@types/react@19.2.7)(@types/three@0.170.0)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(three@0.170.0)
       '@react-three/fiber':
-        specifier: ^8.17.10
-        version: 8.18.0(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.170.0)
+        specifier: ^9.5.0
+        version: 9.5.0(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(three@0.170.0)
       '@vizij/runtime-react':
         specifier: workspace:*
         version: link:../../packages/@vizij/runtime-react
       react:
-        specifier: ^18.2.0
-        version: 18.3.1
+        specifier: ^19.2.3
+        version: 19.2.3
       react-dom:
-        specifier: ^18.2.0
-        version: 18.3.1(react@18.3.1)
+        specifier: ^19.2.3
+        version: 19.2.3(react@19.2.3)
       three:
         specifier: ^0.170.0
         version: 0.170.0
       zustand:
-        specifier: ^5.0.2
-        version: 5.0.8(@types/react@18.3.26)(immer@10.2.0)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
+        specifier: 5.0.9
+        version: 5.0.9(@types/react@19.2.7)(immer@10.2.0)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
     devDependencies:
       '@types/react':
-        specifier: ^18.3.26
-        version: 18.3.26
+        specifier: ^19.2.7
+        version: 19.2.7
       '@types/react-dom':
-        specifier: ^18.3.7
-        version: 18.3.7(@types/react@18.3.26)
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react-swc':
-        specifier: ^3.7.0
-        version: 3.11.0(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
+        specifier: ^4.2.2
+        version: 4.2.2(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -431,36 +439,36 @@ importers:
   apps/tutorial-fullscreen-face:
     dependencies:
       '@react-three/drei':
-        specifier: ^9.115.0
-        version: 9.122.0(@react-three/fiber@8.18.0(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.170.0))(@types/react@18.3.26)(@types/three@0.170.0)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.170.0)(use-sync-external-store@1.6.0(react@18.3.1))
+        specifier: ^10.7.7
+        version: 10.7.7(@react-three/fiber@9.5.0(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(three@0.170.0))(@types/react@19.2.7)(@types/three@0.170.0)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(three@0.170.0)
       '@react-three/fiber':
-        specifier: ^8.17.10
-        version: 8.18.0(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.170.0)
+        specifier: ^9.5.0
+        version: 9.5.0(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(three@0.170.0)
       '@vizij/runtime-react':
         specifier: workspace:*
         version: link:../../packages/@vizij/runtime-react
       react:
-        specifier: ^18.2.0
-        version: 18.3.1
+        specifier: ^19.2.3
+        version: 19.2.3
       react-dom:
-        specifier: ^18.2.0
-        version: 18.3.1(react@18.3.1)
+        specifier: ^19.2.3
+        version: 19.2.3(react@19.2.3)
       three:
         specifier: ^0.170.0
         version: 0.170.0
       zustand:
-        specifier: ^5.0.2
-        version: 5.0.8(@types/react@18.3.26)(immer@10.2.0)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
+        specifier: 5.0.9
+        version: 5.0.9(@types/react@19.2.7)(immer@10.2.0)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
     devDependencies:
       '@types/react':
-        specifier: ^18.3.26
-        version: 18.3.26
+        specifier: ^19.2.7
+        version: 19.2.7
       '@types/react-dom':
-        specifier: ^18.3.7
-        version: 18.3.7(@types/react@18.3.26)
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react-swc':
-        specifier: ^3.7.0
-        version: 3.11.0(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
+        specifier: ^4.2.2
+        version: 4.2.2(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -489,24 +497,24 @@ importers:
         specifier: workspace:*
         version: link:../../packages/@vizij/utils
       react:
-        specifier: ^18.2.0
-        version: 18.3.1
+        specifier: ^19.2.3
+        version: 19.2.3
       react-dom:
-        specifier: ^18.2.0
-        version: 18.3.1(react@18.3.1)
+        specifier: ^19.2.3
+        version: 19.2.3(react@19.2.3)
       three:
         specifier: ^0.170.0
         version: 0.170.0
     devDependencies:
       '@types/react':
-        specifier: ^18.3.26
-        version: 18.3.26
+        specifier: ^19.2.7
+        version: 19.2.7
       '@types/react-dom':
-        specifier: ^18.3.7
-        version: 18.3.7(@types/react@18.3.26)
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react-swc':
-        specifier: ^3.7.0
-        version: 3.11.0(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
+        specifier: ^4.2.2
+        version: 4.2.2(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
       prettier:
         specifier: ^3.4.2
         version: 3.6.2
@@ -523,11 +531,11 @@ importers:
   apps/vizij-showcase:
     dependencies:
       '@react-three/drei':
-        specifier: ^9.115.0
-        version: 9.122.0(@react-three/fiber@8.18.0(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.170.0))(@types/react@18.3.26)(@types/three@0.170.0)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.170.0)(use-sync-external-store@1.6.0(react@18.3.1))
+        specifier: ^10.7.7
+        version: 10.7.7(@react-three/fiber@9.5.0(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(three@0.170.0))(@types/react@19.2.7)(@types/three@0.170.0)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(three@0.170.0)
       '@react-three/fiber':
-        specifier: ^8.17.10
-        version: 8.18.0(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.170.0)
+        specifier: ^9.5.0
+        version: 9.5.0(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(three@0.170.0)
       '@vizij/orchestrator-react':
         specifier: workspace:*
         version: link:../../packages/@vizij/orchestrator-react
@@ -538,27 +546,27 @@ importers:
         specifier: workspace:*
         version: link:../../packages/@vizij/runtime-react
       react:
-        specifier: ^18.2.0
-        version: 18.3.1
+        specifier: ^19.2.3
+        version: 19.2.3
       react-dom:
-        specifier: ^18.2.0
-        version: 18.3.1(react@18.3.1)
+        specifier: ^19.2.3
+        version: 19.2.3(react@19.2.3)
       three:
         specifier: ^0.170.0
         version: 0.170.0
       zustand:
-        specifier: ^5.0.2
-        version: 5.0.8(@types/react@18.3.26)(immer@10.2.0)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
+        specifier: 5.0.9
+        version: 5.0.9(@types/react@19.2.7)(immer@10.2.0)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
     devDependencies:
       '@types/react':
-        specifier: ^18.3.26
-        version: 18.3.26
+        specifier: ^19.2.7
+        version: 19.2.7
       '@types/react-dom':
-        specifier: ^18.3.7
-        version: 18.3.7(@types/react@18.3.26)
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react-swc':
-        specifier: ^3.7.0
-        version: 3.11.0(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
+        specifier: ^4.2.2
+        version: 4.2.2(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -574,25 +582,28 @@ importers:
       '@vizij/value-json':
         specifier: ^0.1.2
         version: 0.1.2
-      react:
-        specifier: '>=18'
-        version: 18.3.1
     devDependencies:
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
       '@testing-library/react':
-        specifier: ^14.3.1
-        version: 14.3.1(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^16.3.1
+        version: 16.3.1(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@types/react':
-        specifier: ^18.2.0
-        version: 18.3.26
+        specifier: ^19.2.7
+        version: 19.2.7
       jsdom:
         specifier: ^24.1.3
         version: 24.1.3
       prettier:
         specifier: ^3.4.2
         version: 3.6.2
+      react:
+        specifier: ^19.2.3
+        version: 19.2.3
       react-dom:
-        specifier: ^18.2.0
-        version: 18.3.1(react@18.3.1)
+        specifier: ^19.2.3
+        version: 19.2.3(react@19.2.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(@swc/core@1.15.2)(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -613,8 +624,8 @@ importers:
         version: 18.3.1(react@18.3.1)
     devDependencies:
       '@types/react':
-        specifier: ^18.3.26
-        version: 18.3.26
+        specifier: ^19.2.7
+        version: 19.2.7
       prettier:
         specifier: ^3.4.2
         version: 3.6.2
@@ -658,25 +669,28 @@ importers:
       '@vizij/value-json':
         specifier: ^0.1.2
         version: 0.1.2
-      react:
-        specifier: '>=18'
-        version: 18.3.1
     devDependencies:
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
       '@testing-library/react':
-        specifier: ^14.3.1
-        version: 14.3.1(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^16.3.1
+        version: 16.3.1(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@types/react':
-        specifier: ^18.2.0
-        version: 18.3.26
+        specifier: ^19.2.7
+        version: 19.2.7
       jsdom:
         specifier: ^24.1.3
         version: 24.1.3
       prettier:
         specifier: ^3.4.2
         version: 3.6.2
+      react:
+        specifier: ^19.2.3
+        version: 19.2.3
       react-dom:
-        specifier: ^18.2.0
-        version: 18.3.1(react@18.3.1)
+        specifier: ^19.2.3
+        version: 19.2.3(react@19.2.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(@swc/core@1.15.2)(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -698,25 +712,28 @@ importers:
       '@vizij/value-json':
         specifier: ^0.1.2
         version: 0.1.2
-      react:
-        specifier: '>=18'
-        version: 18.3.1
     devDependencies:
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
       '@testing-library/react':
-        specifier: ^14.3.1
-        version: 14.3.1(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^16.3.1
+        version: 16.3.1(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@types/react':
-        specifier: ^18.2.0
-        version: 18.3.26
+        specifier: ^19.2.7
+        version: 19.2.7
       jsdom:
         specifier: ^24.1.3
         version: 24.1.3
       prettier:
         specifier: ^3.4.2
         version: 3.6.2
+      react:
+        specifier: ^19.2.3
+        version: 19.2.3
       react-dom:
-        specifier: ^18.2.0
-        version: 18.3.1(react@18.3.1)
+        specifier: ^19.2.3
+        version: 19.2.3(react@19.2.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(@swc/core@1.15.2)(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -746,7 +763,7 @@ importers:
         version: 4.17.21
       react-error-boundary:
         specifier: ^4.0.13
-        version: 4.1.2(react@18.3.1)
+        version: 4.1.2(react@19.2.3)
       tailwindcss:
         specifier: ^4.1.3
         version: 4.1.17
@@ -755,11 +772,11 @@ importers:
         version: 2.36.1(three@0.170.0)
     devDependencies:
       '@react-three/drei':
-        specifier: ^9.115.0
-        version: 9.122.0(@react-three/fiber@8.18.0(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.170.0))(@types/react@18.3.26)(@types/three@0.170.0)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.170.0)(use-sync-external-store@1.6.0(react@18.3.1))
+        specifier: ^10.7.7
+        version: 10.7.7(@react-three/fiber@9.5.0(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(three@0.170.0))(@types/react@19.2.7)(@types/three@0.170.0)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(three@0.170.0)
       '@react-three/fiber':
-        specifier: ^8.17.10
-        version: 8.18.0(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.170.0)
+        specifier: ^9.5.0
+        version: 9.5.0(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(three@0.170.0)
       '@size-limit/file':
         specifier: ^11.2.0
         version: 11.2.0(size-limit@11.2.0)
@@ -770,8 +787,8 @@ importers:
         specifier: ^4.17.4
         version: 4.17.20
       '@types/react':
-        specifier: ^18.3.1
-        version: 18.3.26
+        specifier: ^19.2.7
+        version: 19.2.7
       '@types/three':
         specifier: ^0.170.0
         version: 0.170.0
@@ -779,11 +796,11 @@ importers:
         specifier: ^3.4.2
         version: 3.6.2
       react:
-        specifier: ^18.3.1
-        version: 18.3.1
+        specifier: ^19.2.3
+        version: 19.2.3
       react-dom:
-        specifier: ^18.3.1
-        version: 18.3.1(react@18.3.1)
+        specifier: ^19.2.3
+        version: 19.2.3(react@19.2.3)
       size-limit:
         specifier: ^11.1.7
         version: 11.2.0
@@ -797,8 +814,8 @@ importers:
         specifier: ^5.5.0
         version: 5.9.3
       zustand:
-        specifier: ^5.0.2
-        version: 5.0.8(@types/react@18.3.26)(immer@10.2.0)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
+        specifier: 5.0.9
+        version: 5.0.9(@types/react@19.2.7)(immer@10.2.0)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
 
   packages/@vizij/runtime-react:
     dependencies:
@@ -825,11 +842,11 @@ importers:
         version: 18.3.1(react@18.3.1)
     devDependencies:
       '@types/react':
-        specifier: ^18.3.1
-        version: 18.3.26
+        specifier: ^19.2.7
+        version: 19.2.7
       '@types/react-dom':
-        specifier: ^18.3.1
-        version: 18.3.7(@types/react@18.3.26)
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.7)
       prettier:
         specifier: ^3.4.2
         version: 3.6.2
@@ -867,87 +884,12 @@ packages:
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.28.5':
-    resolution: {integrity: sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/core@7.28.5':
-    resolution: {integrity: sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/generator@7.28.5':
-    resolution: {integrity: sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-compilation-targets@7.27.2':
-    resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-globals@7.28.0':
-    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-imports@7.27.1':
-    resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-transforms@7.28.3':
-    resolution: {integrity: sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/helper-plugin-utils@7.27.1':
-    resolution: {integrity: sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-option@7.27.1':
-    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helpers@7.28.4':
-    resolution: {integrity: sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.28.5':
-    resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/plugin-transform-react-jsx-self@7.27.1':
-    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-jsx-source@7.27.1':
-    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/runtime@7.28.4':
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/template@7.27.2':
-    resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/traverse@7.28.5':
-    resolution: {integrity: sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.28.5':
-    resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
   '@changesets/apply-release-plan@7.0.13':
@@ -1432,9 +1374,6 @@ packages:
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
-  '@jridgewell/remapping@2.3.5':
-    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
-
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
@@ -1475,56 +1414,28 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@react-spring/animated@9.7.5':
-    resolution: {integrity: sha512-Tqrwz7pIlsSDITzxoLS3n/v/YCUHQdOIKtOJf4yL6kYVSDTSmVK1LI1Q3M/uu2Sx4X3pIWF3xLUhlsA6SPNTNg==}
+  '@react-three/drei@10.7.7':
+    resolution: {integrity: sha512-ff+J5iloR0k4tC++QtD/j9u3w5fzfgFAWDtAGQah9pF2B1YgOq/5JxqY0/aVoQG5r3xSZz0cv5tk2YuBob4xEQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-
-  '@react-spring/core@9.7.5':
-    resolution: {integrity: sha512-rmEqcxRcu7dWh7MnCcMXLvrf6/SDlSokLaLTxiPlAYi11nN3B5oiCUAblO72o+9z/87j2uzxa2Inm8UbLjXA+w==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-
-  '@react-spring/rafz@9.7.5':
-    resolution: {integrity: sha512-5ZenDQMC48wjUzPAm1EtwQ5Ot3bLIAwwqP2w2owG5KoNdNHpEJV263nGhCeKKmuA3vG2zLLOdu3or6kuDjA6Aw==}
-
-  '@react-spring/shared@9.7.5':
-    resolution: {integrity: sha512-wdtoJrhUeeyD/PP/zo+np2s1Z820Ohr/BbuVYv+3dVLW7WctoiN7std8rISoYoHpUXtbkpesSKuPIw/6U1w1Pw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-
-  '@react-spring/three@9.7.5':
-    resolution: {integrity: sha512-RxIsCoQfUqOS3POmhVHa1wdWS0wyHAUway73uRLp3GAL5U2iYVNdnzQsep6M2NZ994BlW8TcKuMtQHUqOsy6WA==}
-    peerDependencies:
-      '@react-three/fiber': '>=6.0'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      three: '>=0.126'
-
-  '@react-spring/types@9.7.5':
-    resolution: {integrity: sha512-HVj7LrZ4ReHWBimBvu2SKND3cDVUPWKLqRTmWe/fNY6o1owGOX0cAHbdPDTMelgBlVbrTKrre6lFkhqGZErK/g==}
-
-  '@react-three/drei@9.122.0':
-    resolution: {integrity: sha512-SEO/F/rBCTjlLez7WAlpys+iGe9hty4rNgjZvgkQeXFSiwqD4Hbk/wNHMAbdd8vprO2Aj81mihv4dF5bC7D0CA==}
-    peerDependencies:
-      '@react-three/fiber': ^8
-      react: ^18
-      react-dom: ^18
-      three: '>=0.137'
+      '@react-three/fiber': ^9.0.0
+      react: ^19
+      react-dom: ^19
+      three: '>=0.159'
     peerDependenciesMeta:
       react-dom:
         optional: true
 
-  '@react-three/fiber@8.18.0':
-    resolution: {integrity: sha512-FYZZqD0UUHUswKz3LQl2Z7H24AhD14XGTsIRw3SJaXUxyfVMi+1yiZGmqTcPt/CkPpdU7rrxqcyQ1zJE5DjvIQ==}
+  '@react-three/fiber@9.5.0':
+    resolution: {integrity: sha512-FiUzfYW4wB1+PpmsE47UM+mCads7j2+giRBltfwH7SNhah95rqJs3ltEs9V3pP8rYdS0QlNne+9Aj8dS/SiaIA==}
     peerDependencies:
       expo: '>=43.0'
       expo-asset: '>=8.4'
       expo-file-system: '>=11.0'
       expo-gl: '>=11.0'
-      react: '>=18 <19'
-      react-dom: '>=18 <19'
-      react-native: '>=0.64'
-      three: '>=0.133'
+      react: '>=19 <19.3'
+      react-dom: '>=19 <19.3'
+      react-native: '>=0.78'
+      three: '>=0.156'
     peerDependenciesMeta:
       expo:
         optional: true
@@ -1575,8 +1486,8 @@ packages:
       react: '>=17'
       react-dom: '>=17'
 
-  '@rolldown/pluginutils@1.0.0-beta.27':
-    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+  '@rolldown/pluginutils@1.0.0-beta.47':
+    resolution: {integrity: sha512-8QagwMH3kNCuzD8EWL8R2YPW5e4OrHNSAHRFDdmFqEwEaD/KcNKjVoumo+gP2vW5eKB2UPbM6vTYiGZX0ixLnw==}
 
   '@rollup/rollup-android-arm-eabi@4.53.2':
     resolution: {integrity: sha512-yDPzwsgiFO26RJA4nZo8I+xqzh7sJTZIWQOxn+/XOdPE31lAvLIYCKqjV+lNH/vxE2L2iH3plKxDCRK6i+CwhA==}
@@ -1772,34 +1683,30 @@ packages:
   '@swc/types@0.1.25':
     resolution: {integrity: sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==}
 
-  '@testing-library/dom@9.3.4':
-    resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}
-    engines: {node: '>=14'}
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
 
-  '@testing-library/react@14.3.1':
-    resolution: {integrity: sha512-H99XjUhWQw0lTgyMN05W3xQG1Nh4lq574D8keFf1dDoNTJgp66VbJozRaczoF+wsiaPJNt/TcnfpLGufGxSrZQ==}
-    engines: {node: '>=14'}
+  '@testing-library/react@16.3.1':
+    resolution: {integrity: sha512-gr4KtAWqIOQoucWYD/f6ki+j5chXfcPc74Col/6poTyqTmn7zRmodWahWRCp8tYd+GMqBonw6hstNzqjbs6gjw==}
+    engines: {node: '>=18'}
     peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   '@tweenjs/tween.js@23.1.3':
     resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
-
-  '@types/babel__core@7.20.5':
-    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
-
-  '@types/babel__generator@7.27.0':
-    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
-
-  '@types/babel__template@7.4.4':
-    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
-
-  '@types/babel__traverse@7.28.0':
-    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -1930,24 +1837,18 @@ packages:
   '@types/offscreencanvas@2019.7.3':
     resolution: {integrity: sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==}
 
-  '@types/prop-types@15.7.15':
-    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
-
-  '@types/react-dom@18.3.7':
-    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
-      '@types/react': ^18.0.0
-
-  '@types/react-reconciler@0.26.7':
-    resolution: {integrity: sha512-mBDYl8x+oyPX/VBb3E638N0B7xG+SPk/EAMcVPeexqus/5aTpTphQi0curhhshOqRrc9t6OPoJfEUkbymse/lQ==}
+      '@types/react': ^19.2.0
 
   '@types/react-reconciler@0.28.9':
     resolution: {integrity: sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==}
     peerDependencies:
       '@types/react': '*'
 
-  '@types/react@18.3.26':
-    resolution: {integrity: sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==}
+  '@types/react@19.2.7':
+    resolution: {integrity: sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==}
 
   '@types/stats.js@0.17.4':
     resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
@@ -2025,16 +1926,11 @@ packages:
     peerDependencies:
       react: '>= 16.8.0'
 
-  '@vitejs/plugin-react-swc@3.11.0':
-    resolution: {integrity: sha512-YTJCGFdNMHCMfjODYtxRNVAYmTWQ1Lb8PulP/2/f/oEEtglw8oKxKIZmmRkyXrVrHfsKOaVkAc3NT9/dMutO5w==}
+  '@vitejs/plugin-react-swc@4.2.2':
+    resolution: {integrity: sha512-x+rE6tsxq/gxrEJN3Nv3dIV60lFflPj94c90b+NNo6n1QV1QQUTLoL0MpaOVasUZ0zqVBn7ead1B5ecx1JAGfA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^4 || ^5 || ^6 || ^7
-
-  '@vitejs/plugin-react@4.7.0':
-    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    peerDependencies:
-      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
@@ -2137,8 +2033,8 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
-  aria-query@5.1.3:
-    resolution: {integrity: sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==}
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
@@ -2189,10 +2085,6 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.8.29:
-    resolution: {integrity: sha512-sXdt2elaVnhpDNRDz+1BDx1JQoJRuNk7oVlAlbGiFkLikHCAQiccexF/9e91zVi6RCgqspl04aP+6Cnl9zRLrA==}
-    hasBin: true
-
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
@@ -2212,11 +2104,6 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
-
-  browserslist@4.28.0:
-    resolution: {integrity: sha512-tbydkR/CxfMwelN0vwdP/pLkDwyAASZ+VfWm4EOwlB6SWhx1sYnWLqo8N5j0rAzPfzfRaxt0mM/4wPU/Su84RQ==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
@@ -2254,13 +2141,11 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  camera-controls@2.10.1:
-    resolution: {integrity: sha512-KnaKdcvkBJ1Irbrzl8XD6WtZltkRjp869Jx8c0ujs9K+9WD+1D7ryBsCiVqJYUqt6i/HR5FxT7RLASieUD+Q5w==}
+  camera-controls@3.1.2:
+    resolution: {integrity: sha512-xkxfpG2ECZ6Ww5/9+kf4mfg1VEYAoe9aDSY+IwF0UEs7qEzwy0aVRfs2grImIECs/PoBtWFrh7RXsQkwG922JA==}
+    engines: {node: '>=22.0.0', npm: '>=10.5.1'}
     peerDependencies:
       three: '>=0.126.1'
-
-  caniuse-lite@1.0.30001755:
-    resolution: {integrity: sha512-44V+Jm6ctPj7R52Na4TLi3Zri4dWUljJd+RDm+j8LtNCc/ihLCT+X1TzoOAkRETEWqjuLnh9581Tl80FvK7jVA==}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -2335,9 +2220,6 @@ packages:
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
-
-  convert-source-map@2.0.0:
-    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cross-env@7.0.3:
     resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
@@ -2456,6 +2338,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-gpu@5.0.70:
     resolution: {integrity: sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==}
 
@@ -2486,9 +2372,6 @@ packages:
 
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
-
-  electron-to-chromium@1.5.255:
-    resolution: {integrity: sha512-Z9oIp4HrFF/cZkDPMpz2XSuVpc1THDpT4dlmATFlJUIBVCy9Vap5/rIXsASP1CscBacBqhabwh8vLctqBwEerQ==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -2554,10 +2437,6 @@ packages:
     resolution: {integrity: sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==}
     engines: {node: '>=18'}
     hasBin: true
-
-  escalade@3.2.0:
-    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
-    engines: {node: '>=6'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -2786,10 +2665,6 @@ packages:
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
-
-  gensync@1.0.0-beta.2:
-    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
-    engines: {node: '>=6.9.0'}
 
   get-east-asian-width@1.4.0:
     resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
@@ -3091,10 +2966,10 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  its-fine@1.2.5:
-    resolution: {integrity: sha512-fXtDA0X0t0eBYAGLVM5YsgJGsJ5jEmqZEPrGbzdf5awjv0xE7nqv3TVnvtUF060Tkes15DbDAKW/I48vsb6SyA==}
+  its-fine@2.0.0:
+    resolution: {integrity: sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==}
     peerDependencies:
-      react: '>=18.0'
+      react: ^19.0.0
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
@@ -3130,11 +3005,6 @@ packages:
       canvas:
         optional: true
 
-  jsesc@3.1.0:
-    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
-    engines: {node: '>=6'}
-    hasBin: true
-
   json-bigint@1.0.0:
     resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
 
@@ -3149,11 +3019,6 @@ packages:
 
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
-    hasBin: true
-
-  json5@2.2.3:
-    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
-    engines: {node: '>=6'}
     hasBin: true
 
   jsonfile@4.0.0:
@@ -3225,9 +3090,6 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
-
-  lru-cache@5.1.1:
-    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -3327,9 +3189,6 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  node-releases@2.0.27:
-    resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
@@ -3537,9 +3396,6 @@ packages:
   promise-worker-transferable@1.0.4:
     resolution: {integrity: sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==}
 
-  prop-types@15.8.1:
-    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
-
   psl@1.15.0:
     resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
 
@@ -3556,36 +3412,23 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  react-composer@5.0.3:
-    resolution: {integrity: sha512-1uWd07EME6XZvMfapwZmc7NgCZqDemcvicRi3wMJzXsQLvZ3L7fTHVyPy1bZdnWXM4iPjYuNE+uJ41MLKeTtnA==}
-    peerDependencies:
-      react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
-
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
+
+  react-dom@19.2.3:
+    resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
+    peerDependencies:
+      react: ^19.2.3
 
   react-error-boundary@4.1.2:
     resolution: {integrity: sha512-GQDxZ5Jd+Aq/qUxbCm1UtzmL/s++V7zKgE8yMktJiCQXCCFZnMZh9ng+6/Ne6PjNSXH0L9CjeOEREfRnq6Duag==}
     peerDependencies:
       react: '>=16.13.1'
 
-  react-is@16.13.1:
-    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
-
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
-
-  react-reconciler@0.27.0:
-    resolution: {integrity: sha512-HmMDKciQjYmBRGuuhIaKA1ba/7a+UsM5FzOZsMO2JYHt9Jh8reCb7j1eDC95NOyUlKM9KRyvdx0flBuDvYSBoA==}
-    engines: {node: '>=0.10.0'}
-    peerDependencies:
-      react: ^18.0.0
-
-  react-refresh@0.17.0:
-    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
-    engines: {node: '>=0.10.0'}
 
   react-use-measure@2.1.7:
     resolution: {integrity: sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==}
@@ -3598,6 +3441,10 @@ packages:
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.3:
+    resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
 
   reactflow@11.11.4:
@@ -3693,11 +3540,11 @@ packages:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
 
-  scheduler@0.21.0:
-    resolution: {integrity: sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==}
-
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -3887,11 +3734,10 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
-  three-mesh-bvh@0.7.8:
-    resolution: {integrity: sha512-BGEZTOIC14U0XIRw3tO4jY7IjP7n7v24nv9JXS1CyeVRWOCkcOMhRnmENUjuV39gktAw4Ofhr0OvIAiTspQrrw==}
-    deprecated: Deprecated due to three.js version incompatibility. Please use v0.8.0, instead.
+  three-mesh-bvh@0.8.3:
+    resolution: {integrity: sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg==}
     peerDependencies:
-      three: '>= 0.151.0'
+      three: '>= 0.159.0'
 
   three-stdlib@2.36.1:
     resolution: {integrity: sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==}
@@ -4035,12 +3881,6 @@ packages:
   universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
     engines: {node: '>= 4.0.0'}
-
-  update-browserslist-db@1.1.4:
-    resolution: {integrity: sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -4221,9 +4061,6 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
-  yallist@3.1.1:
-    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-
   yaml@2.8.1:
     resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
     engines: {node: '>= 14.6'}
@@ -4233,38 +4070,14 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zustand@3.7.2:
-    resolution: {integrity: sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==}
-    engines: {node: '>=12.7.0'}
-    peerDependencies:
-      react: '>=16.8'
-    peerDependenciesMeta:
-      react:
-        optional: true
-
-  zustand@4.5.7:
-    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
-    engines: {node: '>=12.7.0'}
-    peerDependencies:
-      '@types/react': '>=16.8'
-      immer: '>=9.0.6'
-      react: '>=16.8'
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      immer:
-        optional: true
-      react:
-        optional: true
-
-  zustand@5.0.8:
-    resolution: {integrity: sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==}
+  zustand@5.0.9:
+    resolution: {integrity: sha512-ALBtUj0AfjJt3uNRQoL1tL2tMvj6Gp/6e39dnfT6uzpelGru8v1tPOGBzayOWbPJvujM8JojDk3E1LxeFisBNg==}
     engines: {node: '>=12.20.0'}
     peerDependencies:
       '@types/react': '>=18.0.0'
       immer: '>=9.0.6'
       react: '>=18.0.0'
-      use-sync-external-store: '>=1.2.0'
+      use-sync-external-store: 1.6.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -4291,113 +4104,9 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.28.5': {}
-
-  '@babel/core@7.28.5':
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
-      '@babel/helpers': 7.28.4
-      '@babel/parser': 7.28.5
-      '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
-      '@jridgewell/remapping': 2.3.5
-      convert-source-map: 2.0.0
-      debug: 4.4.3
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/generator@7.28.5':
-    dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-      jsesc: 3.1.0
-
-  '@babel/helper-compilation-targets@7.27.2':
-    dependencies:
-      '@babel/compat-data': 7.28.5
-      '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.28.0
-      lru-cache: 5.1.1
-      semver: 6.3.1
-
-  '@babel/helper-globals@7.28.0': {}
-
-  '@babel/helper-module-imports@7.27.1':
-    dependencies:
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-plugin-utils@7.27.1': {}
-
-  '@babel/helper-string-parser@7.27.1': {}
-
   '@babel/helper-validator-identifier@7.28.5': {}
 
-  '@babel/helper-validator-option@7.27.1': {}
-
-  '@babel/helpers@7.28.4':
-    dependencies:
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
-
-  '@babel/parser@7.28.5':
-    dependencies:
-      '@babel/types': 7.28.5
-
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-
   '@babel/runtime@7.28.4': {}
-
-  '@babel/template@7.27.2':
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
-
-  '@babel/traverse@7.28.5':
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
-      '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.5
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/types@7.28.5':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
 
   '@changesets/apply-release-plan@7.0.13':
     dependencies:
@@ -4815,11 +4524,6 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@jridgewell/remapping@2.3.5':
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
@@ -4867,117 +4571,84 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@react-spring/animated@9.7.5(react@18.3.1)':
-    dependencies:
-      '@react-spring/shared': 9.7.5(react@18.3.1)
-      '@react-spring/types': 9.7.5
-      react: 18.3.1
-
-  '@react-spring/core@9.7.5(react@18.3.1)':
-    dependencies:
-      '@react-spring/animated': 9.7.5(react@18.3.1)
-      '@react-spring/shared': 9.7.5(react@18.3.1)
-      '@react-spring/types': 9.7.5
-      react: 18.3.1
-
-  '@react-spring/rafz@9.7.5': {}
-
-  '@react-spring/shared@9.7.5(react@18.3.1)':
-    dependencies:
-      '@react-spring/rafz': 9.7.5
-      '@react-spring/types': 9.7.5
-      react: 18.3.1
-
-  '@react-spring/three@9.7.5(@react-three/fiber@8.18.0(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.170.0))(react@18.3.1)(three@0.170.0)':
-    dependencies:
-      '@react-spring/animated': 9.7.5(react@18.3.1)
-      '@react-spring/core': 9.7.5(react@18.3.1)
-      '@react-spring/shared': 9.7.5(react@18.3.1)
-      '@react-spring/types': 9.7.5
-      '@react-three/fiber': 8.18.0(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.170.0)
-      react: 18.3.1
-      three: 0.170.0
-
-  '@react-spring/types@9.7.5': {}
-
-  '@react-three/drei@9.122.0(@react-three/fiber@8.18.0(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.170.0))(@types/react@18.3.26)(@types/three@0.170.0)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.170.0)(use-sync-external-store@1.6.0(react@18.3.1))':
+  '@react-three/drei@10.7.7(@react-three/fiber@9.5.0(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(three@0.170.0))(@types/react@19.2.7)(@types/three@0.170.0)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(three@0.170.0)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@mediapipe/tasks-vision': 0.10.17
       '@monogrid/gainmap-js': 3.2.0(three@0.170.0)
-      '@react-spring/three': 9.7.5(@react-three/fiber@8.18.0(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.170.0))(react@18.3.1)(three@0.170.0)
-      '@react-three/fiber': 8.18.0(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.170.0)
-      '@use-gesture/react': 10.3.1(react@18.3.1)
-      camera-controls: 2.10.1(three@0.170.0)
+      '@react-three/fiber': 9.5.0(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(three@0.170.0)
+      '@use-gesture/react': 10.3.1(react@19.2.3)
+      camera-controls: 3.1.2(three@0.170.0)
       cross-env: 7.0.3
       detect-gpu: 5.0.70
       glsl-noise: 0.0.0
       hls.js: 1.6.14
       maath: 0.10.8(@types/three@0.170.0)(three@0.170.0)
       meshline: 3.3.1(three@0.170.0)
-      react: 18.3.1
-      react-composer: 5.0.3(react@18.3.1)
+      react: 19.2.3
       stats-gl: 2.4.2(@types/three@0.170.0)(three@0.170.0)
       stats.js: 0.17.0
-      suspend-react: 0.1.3(react@18.3.1)
+      suspend-react: 0.1.3(react@19.2.3)
       three: 0.170.0
-      three-mesh-bvh: 0.7.8(three@0.170.0)
+      three-mesh-bvh: 0.8.3(three@0.170.0)
       three-stdlib: 2.36.1(three@0.170.0)
       troika-three-text: 0.52.4(three@0.170.0)
-      tunnel-rat: 0.1.2(@types/react@18.3.26)(immer@10.2.0)(react@18.3.1)
+      tunnel-rat: 0.1.2(@types/react@19.2.7)(immer@10.2.0)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
+      use-sync-external-store: 1.6.0(react@19.2.3)
       utility-types: 3.11.0
-      zustand: 5.0.8(@types/react@18.3.26)(immer@10.2.0)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
+      zustand: 5.0.9(@types/react@19.2.7)(immer@10.2.0)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
     optionalDependencies:
-      react-dom: 18.3.1(react@18.3.1)
+      react-dom: 19.2.3(react@19.2.3)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/three'
       - immer
-      - use-sync-external-store
 
-  '@react-three/fiber@8.18.0(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.170.0)':
+  '@react-three/fiber@9.5.0(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(three@0.170.0)':
     dependencies:
       '@babel/runtime': 7.28.4
-      '@types/react-reconciler': 0.26.7
       '@types/webxr': 0.5.24
       base64-js: 1.5.1
       buffer: 6.0.3
-      its-fine: 1.2.5(@types/react@18.3.26)(react@18.3.1)
-      react: 18.3.1
-      react-reconciler: 0.27.0(react@18.3.1)
-      react-use-measure: 2.1.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      scheduler: 0.21.0
-      suspend-react: 0.1.3(react@18.3.1)
+      its-fine: 2.0.0(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+      react-use-measure: 2.1.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      scheduler: 0.27.0
+      suspend-react: 0.1.3(react@19.2.3)
       three: 0.170.0
-      zustand: 3.7.2(react@18.3.1)
+      use-sync-external-store: 1.6.0(react@19.2.3)
+      zustand: 5.0.9(@types/react@19.2.7)(immer@10.2.0)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
     optionalDependencies:
-      react-dom: 18.3.1(react@18.3.1)
-    transitivePeerDependencies:
-      - '@types/react'
-
-  '@reactflow/background@11.3.14(@types/react@18.3.26)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@reactflow/core': 11.11.4(@types/react@18.3.26)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      classcat: 5.0.5
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      zustand: 4.5.7(@types/react@18.3.26)(immer@10.2.0)(react@18.3.1)
+      react-dom: 19.2.3(react@19.2.3)
     transitivePeerDependencies:
       - '@types/react'
       - immer
 
-  '@reactflow/controls@11.2.14(@types/react@18.3.26)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@reactflow/background@11.3.14(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))':
     dependencies:
-      '@reactflow/core': 11.11.4(@types/react@18.3.26)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@reactflow/core': 11.11.4(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
       classcat: 5.0.5
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      zustand: 4.5.7(@types/react@18.3.26)(immer@10.2.0)(react@18.3.1)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      zustand: 5.0.9(@types/react@19.2.7)(immer@10.2.0)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
     transitivePeerDependencies:
       - '@types/react'
       - immer
+      - use-sync-external-store
 
-  '@reactflow/core@11.11.4(@types/react@18.3.26)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@reactflow/controls@11.2.14(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))':
+    dependencies:
+      '@reactflow/core': 11.11.4(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
+      classcat: 5.0.5
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      zustand: 5.0.9(@types/react@19.2.7)(immer@10.2.0)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - use-sync-external-store
+
+  '@reactflow/core@11.11.4(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))':
     dependencies:
       '@types/d3': 7.4.3
       '@types/d3-drag': 3.0.7
@@ -4987,53 +4658,57 @@ snapshots:
       d3-drag: 3.0.0
       d3-selection: 3.0.0
       d3-zoom: 3.0.0
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      zustand: 4.5.7(@types/react@18.3.26)(immer@10.2.0)(react@18.3.1)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      zustand: 5.0.9(@types/react@19.2.7)(immer@10.2.0)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
     transitivePeerDependencies:
       - '@types/react'
       - immer
+      - use-sync-external-store
 
-  '@reactflow/minimap@11.7.14(@types/react@18.3.26)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@reactflow/minimap@11.7.14(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))':
     dependencies:
-      '@reactflow/core': 11.11.4(@types/react@18.3.26)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@reactflow/core': 11.11.4(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
       '@types/d3-selection': 3.0.11
       '@types/d3-zoom': 3.0.8
       classcat: 5.0.5
       d3-selection: 3.0.0
       d3-zoom: 3.0.0
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      zustand: 4.5.7(@types/react@18.3.26)(immer@10.2.0)(react@18.3.1)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      zustand: 5.0.9(@types/react@19.2.7)(immer@10.2.0)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
     transitivePeerDependencies:
       - '@types/react'
       - immer
+      - use-sync-external-store
 
-  '@reactflow/node-resizer@2.2.14(@types/react@18.3.26)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@reactflow/node-resizer@2.2.14(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))':
     dependencies:
-      '@reactflow/core': 11.11.4(@types/react@18.3.26)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@reactflow/core': 11.11.4(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
       classcat: 5.0.5
       d3-drag: 3.0.0
       d3-selection: 3.0.0
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      zustand: 4.5.7(@types/react@18.3.26)(immer@10.2.0)(react@18.3.1)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      zustand: 5.0.9(@types/react@19.2.7)(immer@10.2.0)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
     transitivePeerDependencies:
       - '@types/react'
       - immer
+      - use-sync-external-store
 
-  '@reactflow/node-toolbar@1.3.14(@types/react@18.3.26)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@reactflow/node-toolbar@1.3.14(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))':
     dependencies:
-      '@reactflow/core': 11.11.4(@types/react@18.3.26)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@reactflow/core': 11.11.4(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
       classcat: 5.0.5
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      zustand: 4.5.7(@types/react@18.3.26)(immer@10.2.0)(react@18.3.1)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      zustand: 5.0.9(@types/react@19.2.7)(immer@10.2.0)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
     transitivePeerDependencies:
       - '@types/react'
       - immer
+      - use-sync-external-store
 
-  '@rolldown/pluginutils@1.0.0-beta.27': {}
+  '@rolldown/pluginutils@1.0.0-beta.47': {}
 
   '@rollup/rollup-android-arm-eabi@4.53.2':
     optional: true
@@ -5159,51 +4834,30 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@testing-library/dom@9.3.4':
+  '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/runtime': 7.28.4
       '@types/aria-query': 5.0.4
-      aria-query: 5.1.3
-      chalk: 4.1.2
+      aria-query: 5.3.0
       dom-accessibility-api: 0.5.16
       lz-string: 1.5.0
+      picocolors: 1.1.1
       pretty-format: 27.5.1
 
-  '@testing-library/react@14.3.1(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@testing-library/react@16.3.1(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.28.4
-      '@testing-library/dom': 9.3.4
-      '@types/react-dom': 18.3.7(@types/react@18.3.26)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    transitivePeerDependencies:
-      - '@types/react'
+      '@testing-library/dom': 10.4.1
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
   '@tweenjs/tween.js@23.1.3': {}
 
   '@types/aria-query@5.0.4': {}
-
-  '@types/babel__core@7.20.5':
-    dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
-      '@types/babel__generator': 7.27.0
-      '@types/babel__template': 7.4.4
-      '@types/babel__traverse': 7.28.0
-
-  '@types/babel__generator@7.27.0':
-    dependencies:
-      '@babel/types': 7.28.5
-
-  '@types/babel__template@7.4.4':
-    dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
-
-  '@types/babel__traverse@7.28.0':
-    dependencies:
-      '@babel/types': 7.28.5
 
   '@types/chai@5.2.3':
     dependencies:
@@ -5351,23 +5005,16 @@ snapshots:
 
   '@types/offscreencanvas@2019.7.3': {}
 
-  '@types/prop-types@15.7.15': {}
-
-  '@types/react-dom@18.3.7(@types/react@18.3.26)':
+  '@types/react-dom@19.2.3(@types/react@19.2.7)':
     dependencies:
-      '@types/react': 18.3.26
+      '@types/react': 19.2.7
 
-  '@types/react-reconciler@0.26.7':
+  '@types/react-reconciler@0.28.9(@types/react@19.2.7)':
     dependencies:
-      '@types/react': 18.3.26
+      '@types/react': 19.2.7
 
-  '@types/react-reconciler@0.28.9(@types/react@18.3.26)':
+  '@types/react@19.2.7':
     dependencies:
-      '@types/react': 18.3.26
-
-  '@types/react@18.3.26':
-    dependencies:
-      '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
   '@types/stats.js@0.17.4': {}
@@ -5478,30 +5125,18 @@ snapshots:
 
   '@use-gesture/core@10.3.1': {}
 
-  '@use-gesture/react@10.3.1(react@18.3.1)':
+  '@use-gesture/react@10.3.1(react@19.2.3)':
     dependencies:
       '@use-gesture/core': 10.3.1
-      react: 18.3.1
+      react: 19.2.3
 
-  '@vitejs/plugin-react-swc@3.11.0(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))':
+  '@vitejs/plugin-react-swc@4.2.2(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))':
     dependencies:
-      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@rolldown/pluginutils': 1.0.0-beta.47
       '@swc/core': 1.15.2
       vite: 6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@swc/helpers'
-
-  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1))':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.5)
-      '@rolldown/pluginutils': 1.0.0-beta.27
-      '@types/babel__core': 7.20.5
-      react-refresh: 0.17.0
-      vite: 6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.1)
-    transitivePeerDependencies:
-      - supports-color
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -5607,9 +5242,9 @@ snapshots:
 
   argparse@2.0.1: {}
 
-  aria-query@5.1.3:
+  aria-query@5.3.0:
     dependencies:
-      deep-equal: 2.2.3
+      dequal: 2.0.3
 
   array-buffer-byte-length@1.0.2:
     dependencies:
@@ -5677,8 +5312,6 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.8.29: {}
-
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
@@ -5701,14 +5334,6 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
-
-  browserslist@4.28.0:
-    dependencies:
-      baseline-browser-mapping: 2.8.29
-      caniuse-lite: 1.0.30001755
-      electron-to-chromium: 1.5.255
-      node-releases: 2.0.27
-      update-browserslist-db: 1.1.4(browserslist@4.28.0)
 
   buffer-equal-constant-time@1.0.1: {}
 
@@ -5745,11 +5370,9 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  camera-controls@2.10.1(three@0.170.0):
+  camera-controls@3.1.2(three@0.170.0):
     dependencies:
       three: 0.170.0
-
-  caniuse-lite@1.0.30001755: {}
 
   chai@5.3.3:
     dependencies:
@@ -5810,8 +5433,6 @@ snapshots:
   confbox@0.1.8: {}
 
   consola@3.4.2: {}
-
-  convert-source-map@2.0.0: {}
 
   cross-env@7.0.3:
     dependencies:
@@ -5940,6 +5561,8 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  dequal@2.0.3: {}
+
   detect-gpu@5.0.70:
     dependencies:
       webgl-constants: 1.1.1
@@ -5969,8 +5592,6 @@ snapshots:
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
-
-  electron-to-chromium@1.5.255: {}
 
   emoji-regex@10.6.0: {}
 
@@ -6140,8 +5761,6 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.0
       '@esbuild/win32-ia32': 0.27.0
       '@esbuild/win32-x64': 0.27.0
-
-  escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -6423,8 +6042,6 @@ snapshots:
       - supports-color
 
   generator-function@2.0.1: {}
-
-  gensync@1.0.0-beta.2: {}
 
   get-east-asian-width@1.4.0: {}
 
@@ -6732,10 +6349,10 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  its-fine@1.2.5(@types/react@18.3.26)(react@18.3.1):
+  its-fine@2.0.0(@types/react@19.2.7)(react@19.2.3):
     dependencies:
-      '@types/react-reconciler': 0.28.9(@types/react@18.3.26)
-      react: 18.3.1
+      '@types/react-reconciler': 0.28.9(@types/react@19.2.7)
+      react: 19.2.3
     transitivePeerDependencies:
       - '@types/react'
 
@@ -6790,8 +6407,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  jsesc@3.1.0: {}
-
   json-bigint@1.0.0:
     dependencies:
       bignumber.js: 9.3.1
@@ -6805,8 +6420,6 @@ snapshots:
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
-
-  json5@2.2.3: {}
 
   jsonfile@4.0.0:
     optionalDependencies:
@@ -6896,10 +6509,6 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lru-cache@5.1.1:
-    dependencies:
-      yallist: 3.1.1
-
   lz-string@1.5.0: {}
 
   maath@0.10.8(@types/three@0.170.0)(three@0.170.0):
@@ -6982,8 +6591,6 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
-
-  node-releases@2.0.27: {}
 
   npm-run-path@5.3.0:
     dependencies:
@@ -7166,12 +6773,6 @@ snapshots:
       is-promise: 2.2.2
       lie: 3.3.0
 
-  prop-types@15.8.1:
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
-      react-is: 16.13.1
-
   psl@1.15.0:
     dependencies:
       punycode: 2.3.1
@@ -7184,57 +6785,50 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  react-composer@5.0.3(react@18.3.1):
-    dependencies:
-      prop-types: 15.8.1
-      react: 18.3.1
-
   react-dom@18.3.1(react@18.3.1):
     dependencies:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
 
-  react-error-boundary@4.1.2(react@18.3.1):
+  react-dom@19.2.3(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      scheduler: 0.27.0
+
+  react-error-boundary@4.1.2(react@19.2.3):
     dependencies:
       '@babel/runtime': 7.28.4
-      react: 18.3.1
-
-  react-is@16.13.1: {}
+      react: 19.2.3
 
   react-is@17.0.2: {}
 
-  react-reconciler@0.27.0(react@18.3.1):
+  react-use-measure@2.1.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
-      loose-envify: 1.4.0
-      react: 18.3.1
-      scheduler: 0.21.0
-
-  react-refresh@0.17.0: {}
-
-  react-use-measure@2.1.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      react: 18.3.1
+      react: 19.2.3
     optionalDependencies:
-      react-dom: 18.3.1(react@18.3.1)
+      react-dom: 19.2.3(react@19.2.3)
 
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
 
-  reactflow@11.11.4(@types/react@18.3.26)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react@19.2.3: {}
+
+  reactflow@11.11.4(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3)):
     dependencies:
-      '@reactflow/background': 11.3.14(@types/react@18.3.26)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@reactflow/controls': 11.2.14(@types/react@18.3.26)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@reactflow/core': 11.11.4(@types/react@18.3.26)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@reactflow/minimap': 11.7.14(@types/react@18.3.26)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@reactflow/node-resizer': 2.2.14(@types/react@18.3.26)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@reactflow/node-toolbar': 1.3.14(@types/react@18.3.26)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      '@reactflow/background': 11.3.14(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
+      '@reactflow/controls': 11.2.14(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
+      '@reactflow/core': 11.11.4(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
+      '@reactflow/minimap': 11.7.14(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
+      '@reactflow/node-resizer': 2.2.14(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
+      '@reactflow/node-toolbar': 1.3.14(@types/react@19.2.7)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
     transitivePeerDependencies:
       - '@types/react'
       - immer
+      - use-sync-external-store
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -7355,13 +6949,11 @@ snapshots:
     dependencies:
       xmlchars: 2.2.0
 
-  scheduler@0.21.0:
-    dependencies:
-      loose-envify: 1.4.0
-
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
+
+  scheduler@0.27.0: {}
 
   semver@6.3.1: {}
 
@@ -7553,9 +7145,9 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  suspend-react@0.1.3(react@18.3.1):
+  suspend-react@0.1.3(react@19.2.3):
     dependencies:
-      react: 18.3.1
+      react: 19.2.3
 
   symbol-tree@3.2.4: {}
 
@@ -7571,7 +7163,7 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
-  three-mesh-bvh@0.7.8(three@0.170.0):
+  three-mesh-bvh@0.8.3(three@0.170.0):
     dependencies:
       three: 0.170.0
 
@@ -7675,13 +7267,14 @@ snapshots:
       - tsx
       - yaml
 
-  tunnel-rat@0.1.2(@types/react@18.3.26)(immer@10.2.0)(react@18.3.1):
+  tunnel-rat@0.1.2(@types/react@19.2.7)(immer@10.2.0)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3)):
     dependencies:
-      zustand: 4.5.7(@types/react@18.3.26)(immer@10.2.0)(react@18.3.1)
+      zustand: 5.0.9(@types/react@19.2.7)(immer@10.2.0)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
     transitivePeerDependencies:
       - '@types/react'
       - immer
       - react
+      - use-sync-external-store
 
   type-check@0.4.0:
     dependencies:
@@ -7748,12 +7341,6 @@ snapshots:
 
   universalify@0.2.0: {}
 
-  update-browserslist-db@1.1.4(browserslist@4.28.0):
-    dependencies:
-      browserslist: 4.28.0
-      escalade: 3.2.0
-      picocolors: 1.1.1
-
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
@@ -7763,9 +7350,9 @@ snapshots:
       querystringify: 2.2.0
       requires-port: 1.0.0
 
-  use-sync-external-store@1.6.0(react@18.3.1):
+  use-sync-external-store@1.6.0(react@19.2.3):
     dependencies:
-      react: 18.3.1
+      react: 19.2.3
 
   utility-types@3.11.0: {}
 
@@ -7945,27 +7532,13 @@ snapshots:
 
   xmlchars@2.2.0: {}
 
-  yallist@3.1.1: {}
-
   yaml@2.8.1: {}
 
   yocto-queue@0.1.0: {}
 
-  zustand@3.7.2(react@18.3.1):
+  zustand@5.0.9(@types/react@19.2.7)(immer@10.2.0)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3)):
     optionalDependencies:
-      react: 18.3.1
-
-  zustand@4.5.7(@types/react@18.3.26)(immer@10.2.0)(react@18.3.1):
-    dependencies:
-      use-sync-external-store: 1.6.0(react@18.3.1)
-    optionalDependencies:
-      '@types/react': 18.3.26
+      '@types/react': 19.2.7
       immer: 10.2.0
-      react: 18.3.1
-
-  zustand@5.0.8(@types/react@18.3.26)(immer@10.2.0)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1)):
-    optionalDependencies:
-      '@types/react': 18.3.26
-      immer: 10.2.0
-      react: 18.3.1
-      use-sync-external-store: 1.6.0(react@18.3.1)
+      react: 19.2.3
+      use-sync-external-store: 1.6.0(react@19.2.3)


### PR DESCRIPTION
## Summary
Upgrade vizij-web to React 19 across apps and packages, align type usage, and tighten provider/test behavior for StrictMode readiness.

## Key changes
- Bump React/ReactDOM and related deps across apps/packages; update R3F/Drei and Zustand where needed.
- Move demo-graph-studio to @vitejs/plugin-react-swc.
- Update JSX return types and ref typings for React 19.
- Harden @vizij/node-graph-react + @vizij/orchestrator-react tests for readiness/unmount scenarios.

## Testing
- pnpm run prep:push
- Full build completed
- Smoke tests run across apps and packages

## Notes
- Peer deps remain react >=18 / react-dom >=18 (React 19 validated in workspace).
- Updated npm packages will published after PR is approved
