### PR TITLE
Feature matrix and driver chain refinements

### DIFF
--- a/apps/vizij-authoring/src/components/inspector/BindingConnections.tsx
+++ b/apps/vizij-authoring/src/components/inspector/BindingConnections.tsx
@@ -1,5 +1,12 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { Link as LinkIcon, Box, Sparkles, Route, ChevronDown, ChevronRight } from "lucide-react";
+import {
+  Link as LinkIcon,
+  Box,
+  Sparkles,
+  Route,
+  ChevronDown,
+  ChevronRight,
+} from "lucide-react";
 import type { SceneObjectNode } from "../../scene/sceneGraph";
 import {
   useBindingAuthoring,
@@ -468,8 +475,8 @@ export function BindingConnections({
                         const constraints = anim?.constraints as any;
                         const range =
                           constraints &&
-                            typeof constraints.min === "number" &&
-                            typeof constraints.max === "number"
+                          typeof constraints.min === "number" &&
+                          typeof constraints.max === "number"
                             ? `${constraints.min.toFixed(2)} - ${constraints.max.toFixed(2)}`
                             : null;
 
@@ -560,8 +567,8 @@ export function BindingConnections({
                         const constraints = anim?.constraints as any;
                         const range =
                           constraints &&
-                            typeof constraints.min === "number" &&
-                            typeof constraints.max === "number"
+                          typeof constraints.min === "number" &&
+                          typeof constraints.max === "number"
                             ? `${constraints.min.toFixed(2)} - ${constraints.max.toFixed(2)}`
                             : null;
 

--- a/apps/vizij-authoring/src/components/inspector/BindingConnections.tsx
+++ b/apps/vizij-authoring/src/components/inspector/BindingConnections.tsx
@@ -1,9 +1,10 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { Link as LinkIcon, Box, Sparkles, Route } from "lucide-react";
+import { Link as LinkIcon, Box, Sparkles, Route, ChevronDown, ChevronRight } from "lucide-react";
 import type { SceneObjectNode } from "../../scene/sceneGraph";
 import {
   useBindingAuthoring,
   useSelectionStore,
+  useGraphRuntime,
 } from "../../state/RigControllerProvider";
 import { usePoseRig } from "../../state/PoseRigProvider";
 import { usePoseRigStore } from "../../poseRig/store";
@@ -35,6 +36,8 @@ export function BindingConnections({
   );
   const handleSelectRig = useBindingAuthoring((state) => state.handleSelectRig);
   const inputBindings = useBindingAuthoring((state) => state.inputBindings);
+  const inputValues = useBindingAuthoring((state) => state.inputValues);
+  const animatables = useGraphRuntime((state) => state.animatables);
   const handleCreateParentDriverBinding = useBindingAuthoring(
     (state) => state.handleCreateParentDriverBinding,
   );
@@ -91,6 +94,31 @@ export function BindingConnections({
     rollback: () => void;
   } | null>(null);
   const [traceFeedback, setTraceFeedback] = useState<string | null>(null);
+
+  const [expandedPoseIds, setExpandedPoseIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [expandedRigIds, setExpandedRigIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+
+  const togglePoseExpansion = useCallback((id: string) => {
+    setExpandedPoseIds((current) => {
+      const next = new Set(current);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const toggleRigExpansion = useCallback((id: string) => {
+    setExpandedRigIds((current) => {
+      const next = new Set(current);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
 
   const applyTraceSuggestion = useCallback(
     (suggestion: PoseRigTraceSuggestion) => {
@@ -385,33 +413,93 @@ export function BindingConnections({
             <span className="text-[9px] text-slate-600 font-medium px-1">
               POSES
             </span>
-            {connections.poses.map((pose) => (
-              <Button
-                key={pose.id}
-                variant="secondary"
-                size="sm"
-                className="h-auto py-1 text-[10px] px-2 bg-purple-900/10 hover:bg-purple-600/20 hover:text-purple-300 border-purple-500/20 hover:border-purple-500/40 transition-colors justify-start"
-                onClick={() => {
-                  if (onSelectPose) {
-                    onSelectPose(pose.id);
-                    return;
-                  }
-                  selectPose(pose.id);
-                  handleClearSelection();
-                }}
-              >
-                <div className="flex flex-col items-start gap-0.5">
-                  <div className="flex items-center gap-1.5 font-semibold">
-                    <Sparkles size={10} className="text-purple-400" />
-                    {pose.label}
+            {connections.poses.map((pose) => {
+              const isExpanded = expandedPoseIds.has(pose.id);
+              const affectedTargets = trace.targets.filter((t) =>
+                t.matchedPoseOutputs.some((o) => o.poseId === pose.id),
+              );
+
+              return (
+                <div key={pose.id} className="flex flex-col gap-0.5">
+                  <div className="flex items-center gap-1 group/pose">
+                    <button
+                      onClick={() => togglePoseExpansion(pose.id)}
+                      className="p-0.5 hover:bg-purple-500/10 rounded transition-colors text-purple-400 cursor-pointer"
+                    >
+                      {isExpanded ? (
+                        <ChevronDown size={12} />
+                      ) : (
+                        <ChevronRight size={12} />
+                      )}
+                    </button>
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      className="h-auto py-1 text-[10px] px-2 bg-purple-900/10 hover:bg-purple-600/20 hover:text-purple-300 border-purple-500/20 hover:border-purple-500/40 transition-colors justify-start flex-1"
+                      onClick={() => {
+                        if (onSelectPose) {
+                          onSelectPose(pose.id);
+                          return;
+                        }
+                        selectPose(pose.id);
+                        handleClearSelection();
+                      }}
+                    >
+                      <div className="flex flex-col items-start gap-0.5 w-full">
+                        <div className="flex items-center gap-1.5 font-semibold">
+                          <Sparkles size={10} className="text-purple-400" />
+                          {pose.label}
+                        </div>
+                        <span className="text-[9px] opacity-50 truncate max-w-[160px]">
+                          affects: {pose.features.slice(0, 3).join(", ")}
+                          {pose.features.length > 3 ? "..." : ""}
+                        </span>
+                      </div>
+                    </Button>
                   </div>
-                  <span className="text-[9px] opacity-50 truncate max-w-[160px]">
-                    affects: {pose.features.slice(0, 3).join(", ")}
-                    {pose.features.length > 3 ? "..." : ""}
-                  </span>
+                  {isExpanded && affectedTargets.length > 0 && (
+                    <div className="flex flex-col gap-1 ml-4 mt-0.5 pb-1 last:pb-0">
+                      {affectedTargets.map((target) => {
+                        const output = target.matchedPoseOutputs.find(
+                          (o) => o.poseId === pose.id,
+                        );
+                        if (!output) return null;
+                        const anim = animatables[target.targetId];
+                        const constraints = anim?.constraints as any;
+                        const range =
+                          constraints &&
+                            typeof constraints.min === "number" &&
+                            typeof constraints.max === "number"
+                            ? `${constraints.min.toFixed(2)} - ${constraints.max.toFixed(2)}`
+                            : null;
+
+                        return (
+                          <div
+                            key={target.targetId}
+                            className="flex items-baseline gap-2 text-[9px] text-purple-200/70 cursor-pointer group/item hover:text-purple-300 transition-colors"
+                            onClick={() => onSelectTarget?.(target.targetId)}
+                          >
+                            <span className="truncate font-medium flex-1">
+                              {target.targetLabel}
+                            </span>
+                            <div className="flex gap-1.5 items-center shrink-0">
+                              <span className="font-mono text-purple-400">
+                                {output.value.toFixed(3)}
+                              </span>
+                              {range && (
+                                <span className="opacity-50 text-[8px] italic">
+                                  ({range})
+                                </span>
+                              )}
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
                 </div>
-              </Button>
-            ))}
+              );
+            })}
           </div>
         )}
 
@@ -421,32 +509,89 @@ export function BindingConnections({
             <span className="text-[9px] text-text-muted font-medium px-1">
               RIGS
             </span>
-            {connections.rigs.map((rig) => (
-              <Button
-                key={rig.id}
-                variant="secondary"
-                size="sm"
-                className="h-auto py-1 text-[10px] px-2 bg-bg-panel/30 hover:bg-accent-subtle hover:text-accent border-border-default/50 hover:border-accent/30 transition-colors justify-start"
-                onClick={() => {
-                  if (onSelectRig) {
-                    onSelectRig(rig.id);
-                    return;
-                  }
-                  handleSelectRig(rig.id);
-                  handleClearSelection();
-                }}
-              >
-                <div className="flex flex-col items-start gap-0.5">
-                  <div className="flex items-center gap-1.5 font-semibold">
-                    <Box size={10} className="text-accent" />
-                    {rig.label}
+            {connections.rigs.map((rig) => {
+              const isExpanded = expandedRigIds.has(rig.id);
+              const affectedTargets = trace.targets.filter((t) =>
+                t.upstreamRigInputIds.includes(rig.id),
+              );
+
+              return (
+                <div key={rig.id} className="flex flex-col gap-0.5">
+                  <div className="flex items-center gap-1 group/rig">
+                    <button
+                      onClick={() => toggleRigExpansion(rig.id)}
+                      className="p-0.5 hover:bg-accent-subtle rounded transition-colors text-text-muted cursor-pointer"
+                    >
+                      {isExpanded ? (
+                        <ChevronDown size={12} />
+                      ) : (
+                        <ChevronRight size={12} />
+                      )}
+                    </button>
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      className="h-auto py-1 text-[10px] px-2 bg-bg-panel/30 hover:bg-accent-subtle hover:text-accent border-border-default/50 hover:border-accent/30 transition-colors justify-start flex-1"
+                      onClick={() => {
+                        if (onSelectRig) {
+                          onSelectRig(rig.id);
+                          return;
+                        }
+                        handleSelectRig(rig.id);
+                        handleClearSelection();
+                      }}
+                    >
+                      <div className="flex flex-col items-start gap-0.5 w-full">
+                        <div className="flex items-center gap-1.5 font-semibold">
+                          <Box size={10} className="text-accent" />
+                          {rig.label}
+                        </div>
+                        <span className="text-[9px] opacity-50 truncate max-w-[160px]">
+                          affects: {rig.features.join(", ")}
+                        </span>
+                      </div>
+                    </Button>
                   </div>
-                  <span className="text-[9px] opacity-50 truncate max-w-[160px]">
-                    affects: {rig.features.join(", ")}
-                  </span>
+                  {isExpanded && affectedTargets.length > 0 && (
+                    <div className="flex flex-col gap-1 ml-4 mt-0.5 pb-1 last:pb-0">
+                      {affectedTargets.map((target) => {
+                        const val = inputValues[rig.id] ?? 0;
+                        const anim = animatables[target.targetId];
+                        const constraints = anim?.constraints as any;
+                        const range =
+                          constraints &&
+                            typeof constraints.min === "number" &&
+                            typeof constraints.max === "number"
+                            ? `${constraints.min.toFixed(2)} - ${constraints.max.toFixed(2)}`
+                            : null;
+
+                        return (
+                          <div
+                            key={target.targetId}
+                            className="flex items-baseline gap-2 text-[9px] text-text-muted cursor-pointer group/item hover:text-accent transition-colors"
+                            onClick={() => onSelectTarget?.(target.targetId)}
+                          >
+                            <span className="truncate font-medium flex-1">
+                              {target.targetLabel}
+                            </span>
+                            <div className="flex gap-1.5 items-center shrink-0">
+                              <span className="font-mono text-accent">
+                                {val.toFixed(3)}
+                              </span>
+                              {range && (
+                                <span className="opacity-50 text-[8px] italic">
+                                  ({range})
+                                </span>
+                              )}
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
                 </div>
-              </Button>
-            ))}
+              );
+            })}
           </div>
         )}
       </div>

--- a/apps/vizij-authoring/src/components/inspector/InspectorContent.tsx
+++ b/apps/vizij-authoring/src/components/inspector/InspectorContent.tsx
@@ -60,22 +60,22 @@ import { resolveControllableInputId } from "./bindingSlotResolution";
 
 type PoseVariableItem =
   | {
-      type: "scalar";
+    type: "scalar";
+    varId: string;
+    poseVal: number;
+    drivenPropertyCount: number;
+    drivenVariableCount: number;
+  }
+  | {
+    type: "color";
+    label: string;
+    featureId: string;
+    components: {
       varId: string;
       poseVal: number;
-      drivenPropertyCount: number;
-      drivenVariableCount: number;
-    }
-  | {
-      type: "color";
-      label: string;
-      featureId: string;
-      components: {
-        varId: string;
-        poseVal: number;
-        channel: "r" | "g" | "b";
-      }[];
-    };
+      channel: "r" | "g" | "b";
+    }[];
+  };
 
 type InspectorChainMode = "scene" | "rig" | "pose";
 
@@ -94,15 +94,17 @@ export function InspectorContent() {
   );
   const [blendAmount, setBlendAmount] = useState(0);
   const [sceneInspectorView, setSceneInspectorView] = useState<
-    "quick" | "features" | "bindings"
+    "quick" | "bindings"
   >("quick");
+
   const [rigInspectorView, setRigInspectorView] = useState<
     "quick" | "bindings"
   >("quick");
   const scrubValuesRef = useRef<Record<string, number>>({});
   const pendingSceneInspectorViewRef = useRef<
-    "quick" | "features" | "bindings" | null
+    "quick" | "bindings" | null
   >(null);
+
   const pendingRigInspectorViewRef = useRef<"quick" | "bindings" | null>(null);
   const pendingChainNavigationRef = useRef<InspectorChainNode | null>(null);
   const [inspectorChainPath, setInspectorChainPath] = useState<
@@ -136,7 +138,11 @@ export function InspectorContent() {
     updateMaterialLabel,
     setAnimatableValue,
     setFeatureAnimated,
+    updateAnimatableDescriptor,
+    setStaticFeatureValue,
   } = useSceneComposer();
+
+
 
   const {
     poses,
@@ -431,7 +437,8 @@ export function InspectorContent() {
                   pendingChainNavigationRef.current = entry;
                   if (entry.mode === "scene") {
                     pendingSceneInspectorViewRef.current =
-                      entry.view ?? "bindings";
+                      entry.view === "bindings" ? "bindings" : "quick";
+
                     setFocusedSceneBindingTargetId(entry.targetId ?? null);
                     handleSelectObject(entry.id);
                     return;
@@ -581,16 +588,8 @@ export function InspectorContent() {
             >
               Quick
             </Button>
-            <Button
-              variant={
-                sceneInspectorView === "features" ? "secondary" : "ghost"
-              }
-              size="sm"
-              className="h-6 text-[10px]"
-              onClick={() => setSceneInspectorView("features")}
-            >
-              Feature Matrix
-            </Button>
+
+
             <Button
               variant={
                 sceneInspectorView === "bindings" ? "secondary" : "ghost"
@@ -602,56 +601,30 @@ export function InspectorContent() {
               My Drivers
             </Button>
           </div>
-          {sceneInspectorView === "quick" ? (
-            <>
-              <div className="flex flex-col gap-1 p-1.5 bg-bg-panel/40 rounded-lg border border-border-default/50">
-                <div className="text-[9px] font-bold text-text-secondary uppercase tracking-wider px-0.5">
-                  Animation State
-                </div>
-                <div className="flex flex-col gap-1 max-h-32 overflow-y-auto custom-scrollbar pr-1">
-                  {node.features.map((feature) => (
-                    <div
-                      key={feature.id}
-                      className="flex items-center justify-between gap-2 px-1.5 py-1 rounded bg-bg-panel/30 border border-border-default/40"
-                    >
-                      <span className="text-[11px] text-text-primary truncate">
-                        {feature.label}
-                      </span>
-                      <div className="flex items-center gap-2 flex-shrink-0">
-                        <span className="text-[9px] uppercase tracking-wide text-text-muted">
-                          {feature.animated ? "Animated" : "Static"}
-                        </span>
-                        <Switch
-                          checked={feature.animated}
-                          onChange={(checked) =>
-                            setFeatureAnimated(node.id, feature.id, checked)
-                          }
-                        />
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-              <RiggingTransformSection node={node} />
-              <RiggingMorphTargetsSection node={node} />
-              <RiggingMaterialSection node={node} />
-              <BindingConnections
+          {
+            sceneInspectorView === "quick" ? (
+              <>
+                <RiggingTransformSection node={node} />
+
+                <RiggingMorphTargetsSection node={node} />
+                <RiggingMaterialSection node={node} />
+                <BindingConnections
+                  node={node}
+                  onSelectPose={openPoseInspector}
+                  onSelectRig={(rigId) => openRigInspector(rigId, "quick")}
+                  onSelectTarget={openSceneBindingInspector}
+                />
+              </>
+            ) : (
+              <FeatureList
                 node={node}
-                onSelectPose={openPoseInspector}
-                onSelectRig={(rigId) => openRigInspector(rigId, "quick")}
-                onSelectTarget={openSceneBindingInspector}
+                mode="bindings"
+                focusedTargetId={focusedSceneBindingTargetId}
               />
-            </>
-          ) : sceneInspectorView === "features" ? (
-            <FeatureList node={node} mode="features" />
-          ) : (
-            <FeatureList
-              node={node}
-              mode="bindings"
-              focusedTargetId={focusedSceneBindingTargetId}
-            />
-          )}
-        </div>
+            )
+          }
+
+        </div >
       );
     }
   }
@@ -962,7 +935,7 @@ export function InspectorContent() {
                       const canInspectVariable = standardInputsById.has(varId);
                       const chainSummary =
                         item.drivenVariableCount > 0 ||
-                        item.drivenPropertyCount > 0
+                          item.drivenPropertyCount > 0
                           ? `${item.drivenVariableCount} vars · ${item.drivenPropertyCount} props`
                           : null;
 
@@ -1353,19 +1326,18 @@ export function InspectorContent() {
             onClose={() => setPoseBindingEditorInputId(null)}
             title={
               poseBindingEditorInputId
-                ? `Edit My Drivers · ${
-                    managedStandardInputs.find(
-                      (entry) => entry.input.id === poseBindingEditorInputId,
-                    )?.input.label ?? poseBindingEditorInputId
-                  }`
+                ? `Edit My Drivers · ${managedStandardInputs.find(
+                  (entry) => entry.input.id === poseBindingEditorInputId,
+                )?.input.label ?? poseBindingEditorInputId
+                }`
                 : "Edit My Drivers"
             }
             maxWidth="lg"
           >
             {poseBindingEditorInputId &&
-            managedStandardInputs.find(
-              (entry) => entry.input.id === poseBindingEditorInputId,
-            )?.input ? (
+              managedStandardInputs.find(
+                (entry) => entry.input.id === poseBindingEditorInputId,
+              )?.input ? (
               (() => {
                 const inputToEdit = managedStandardInputs.find(
                   (entry) => entry.input.id === poseBindingEditorInputId,
@@ -1489,7 +1461,7 @@ export function InspectorContent() {
       const directRigControlReason = controllableResolution.blockedReason
         ? controllableResolution.blockedReason
         : controllableResolution.inputId &&
-            controllableResolution.inputId !== input.id
+          controllableResolution.inputId !== input.id
           ? `This variable is derived from "${controllableResolution.inputId}" without a local self slot. Edit My Drivers to add local control or adjust "${controllableResolution.inputId}".`
           : null;
       const standardInputList = managedStandardInputs.map(
@@ -1814,16 +1786,15 @@ export function InspectorContent() {
                   onClose={() => setRigDrivenBindingTargetId(null)}
                   title={
                     rigDrivenBindingTargetId
-                      ? `Edit Target Drivers · ${
-                          targetLabelById.get(rigDrivenBindingTargetId) ??
-                          rigDrivenBindingTargetId
-                        }`
+                      ? `Edit Target Drivers · ${targetLabelById.get(rigDrivenBindingTargetId) ??
+                      rigDrivenBindingTargetId
+                      }`
                       : "Edit Target Drivers"
                   }
                   maxWidth="lg"
                 >
                   {rigDrivenBindingTargetId &&
-                  bindings[rigDrivenBindingTargetId] ? (
+                    bindings[rigDrivenBindingTargetId] ? (
                     <BindingEditor
                       binding={bindings[rigDrivenBindingTargetId]}
                       targetId={rigDrivenBindingTargetId}
@@ -1936,55 +1907,55 @@ export function InspectorContent() {
       const colorFeature =
         material.animated.color || material.staticValues.color !== undefined
           ? ({
-              id: `mat-color-${material.id}`,
-              key: "color",
-              label: "Color",
-              animated: !!material.animated.color,
-              value: material.animated.color || "",
-              staticValue: material.staticValues.color,
-              components: [
-                {
-                  label: "R",
-                  targetId: material.animated.color
-                    ? `${material.animated.color}:r`
-                    : undefined,
-                  staticValue: (material.staticValues.color as any)?.r,
-                },
-                {
-                  label: "G",
-                  targetId: material.animated.color
-                    ? `${material.animated.color}:g`
-                    : undefined,
-                  staticValue: (material.staticValues.color as any)?.g,
-                },
-                {
-                  label: "B",
-                  targetId: material.animated.color
-                    ? `${material.animated.color}:b`
-                    : undefined,
-                  staticValue: (material.staticValues.color as any)?.b,
-                },
-              ],
-            } as any)
+            id: `mat-color-${material.id}`,
+            key: "color",
+            label: "Color",
+            animated: !!material.animated.color,
+            value: material.animated.color || "",
+            staticValue: material.staticValues.color,
+            components: [
+              {
+                label: "R",
+                targetId: material.animated.color
+                  ? `${material.animated.color}:r`
+                  : undefined,
+                staticValue: (material.staticValues.color as any)?.r,
+              },
+              {
+                label: "G",
+                targetId: material.animated.color
+                  ? `${material.animated.color}:g`
+                  : undefined,
+                staticValue: (material.staticValues.color as any)?.g,
+              },
+              {
+                label: "B",
+                targetId: material.animated.color
+                  ? `${material.animated.color}:b`
+                  : undefined,
+                staticValue: (material.staticValues.color as any)?.b,
+              },
+            ],
+          } as any)
           : null;
 
       const opacityFeature =
         material.animated.opacity || material.staticValues.opacity !== undefined
           ? ({
-              id: `mat-opacity-${material.id}`,
-              key: "opacity",
-              label: "Opacity",
-              animated: !!material.animated.opacity,
-              value: material.animated.opacity || "",
-              staticValue: material.staticValues.opacity,
-              components: [
-                {
-                  label: "Opacity",
-                  targetId: material.animated.opacity || undefined,
-                  staticValue: material.staticValues.opacity,
-                },
-              ],
-            } as any)
+            id: `mat-opacity-${material.id}`,
+            key: "opacity",
+            label: "Opacity",
+            animated: !!material.animated.opacity,
+            value: material.animated.opacity || "",
+            staticValue: material.staticValues.opacity,
+            components: [
+              {
+                label: "Opacity",
+                targetId: material.animated.opacity || undefined,
+                staticValue: material.staticValues.opacity,
+              },
+            ],
+          } as any)
           : null;
 
       const handleStaticValueChange = (
@@ -2028,7 +1999,15 @@ export function InspectorContent() {
                     handleUpdateStandardInput(id, { defaultValue: val })
                   }
                   onStaticValueChange={handleStaticValueChange}
+                  onToggleAnimated={(animated) => setFeatureAnimated(material.id, `${material.id}-color`, animated)}
+                  onConstraintChange={updateAnimatableDescriptor}
+                  onUpdateStandardInput={handleUpdateStandardInput}
+                  setStaticFeatureValue={setStaticFeatureValue}
                 />
+
+
+
+
               )}
               {opacityFeature && (
                 <RiggingScalarRow
@@ -2044,7 +2023,15 @@ export function InspectorContent() {
                     handleUpdateStandardInput(id, { defaultValue: val })
                   }
                   onStaticValueChange={handleStaticValueChange}
+                  onToggleAnimated={(animated) => setFeatureAnimated(material.id, `${material.id}-opacity`, animated)}
+                  onConstraintChange={updateAnimatableDescriptor}
+                  onUpdateStandardInput={handleUpdateStandardInput}
+                  setStaticFeatureValue={setStaticFeatureValue}
                 />
+
+
+
+
               )}
             </div>
 

--- a/apps/vizij-authoring/src/components/inspector/InspectorContent.tsx
+++ b/apps/vizij-authoring/src/components/inspector/InspectorContent.tsx
@@ -60,22 +60,22 @@ import { resolveControllableInputId } from "./bindingSlotResolution";
 
 type PoseVariableItem =
   | {
-    type: "scalar";
-    varId: string;
-    poseVal: number;
-    drivenPropertyCount: number;
-    drivenVariableCount: number;
-  }
-  | {
-    type: "color";
-    label: string;
-    featureId: string;
-    components: {
+      type: "scalar";
       varId: string;
       poseVal: number;
-      channel: "r" | "g" | "b";
-    }[];
-  };
+      drivenPropertyCount: number;
+      drivenVariableCount: number;
+    }
+  | {
+      type: "color";
+      label: string;
+      featureId: string;
+      components: {
+        varId: string;
+        poseVal: number;
+        channel: "r" | "g" | "b";
+      }[];
+    };
 
 type InspectorChainMode = "scene" | "rig" | "pose";
 
@@ -101,9 +101,9 @@ export function InspectorContent() {
     "quick" | "bindings"
   >("quick");
   const scrubValuesRef = useRef<Record<string, number>>({});
-  const pendingSceneInspectorViewRef = useRef<
-    "quick" | "bindings" | null
-  >(null);
+  const pendingSceneInspectorViewRef = useRef<"quick" | "bindings" | null>(
+    null,
+  );
 
   const pendingRigInspectorViewRef = useRef<"quick" | "bindings" | null>(null);
   const pendingChainNavigationRef = useRef<InspectorChainNode | null>(null);
@@ -141,8 +141,6 @@ export function InspectorContent() {
     updateAnimatableDescriptor,
     setStaticFeatureValue,
   } = useSceneComposer();
-
-
 
   const {
     poses,
@@ -589,7 +587,6 @@ export function InspectorContent() {
               Quick
             </Button>
 
-
             <Button
               variant={
                 sceneInspectorView === "bindings" ? "secondary" : "ghost"
@@ -601,30 +598,27 @@ export function InspectorContent() {
               My Drivers
             </Button>
           </div>
-          {
-            sceneInspectorView === "quick" ? (
-              <>
-                <RiggingTransformSection node={node} />
+          {sceneInspectorView === "quick" ? (
+            <>
+              <RiggingTransformSection node={node} />
 
-                <RiggingMorphTargetsSection node={node} />
-                <RiggingMaterialSection node={node} />
-                <BindingConnections
-                  node={node}
-                  onSelectPose={openPoseInspector}
-                  onSelectRig={(rigId) => openRigInspector(rigId, "quick")}
-                  onSelectTarget={openSceneBindingInspector}
-                />
-              </>
-            ) : (
-              <FeatureList
+              <RiggingMorphTargetsSection node={node} />
+              <RiggingMaterialSection node={node} />
+              <BindingConnections
                 node={node}
-                mode="bindings"
-                focusedTargetId={focusedSceneBindingTargetId}
+                onSelectPose={openPoseInspector}
+                onSelectRig={(rigId) => openRigInspector(rigId, "quick")}
+                onSelectTarget={openSceneBindingInspector}
               />
-            )
-          }
-
-        </div >
+            </>
+          ) : (
+            <FeatureList
+              node={node}
+              mode="bindings"
+              focusedTargetId={focusedSceneBindingTargetId}
+            />
+          )}
+        </div>
       );
     }
   }
@@ -935,7 +929,7 @@ export function InspectorContent() {
                       const canInspectVariable = standardInputsById.has(varId);
                       const chainSummary =
                         item.drivenVariableCount > 0 ||
-                          item.drivenPropertyCount > 0
+                        item.drivenPropertyCount > 0
                           ? `${item.drivenVariableCount} vars · ${item.drivenPropertyCount} props`
                           : null;
 
@@ -1326,18 +1320,19 @@ export function InspectorContent() {
             onClose={() => setPoseBindingEditorInputId(null)}
             title={
               poseBindingEditorInputId
-                ? `Edit My Drivers · ${managedStandardInputs.find(
-                  (entry) => entry.input.id === poseBindingEditorInputId,
-                )?.input.label ?? poseBindingEditorInputId
-                }`
+                ? `Edit My Drivers · ${
+                    managedStandardInputs.find(
+                      (entry) => entry.input.id === poseBindingEditorInputId,
+                    )?.input.label ?? poseBindingEditorInputId
+                  }`
                 : "Edit My Drivers"
             }
             maxWidth="lg"
           >
             {poseBindingEditorInputId &&
-              managedStandardInputs.find(
-                (entry) => entry.input.id === poseBindingEditorInputId,
-              )?.input ? (
+            managedStandardInputs.find(
+              (entry) => entry.input.id === poseBindingEditorInputId,
+            )?.input ? (
               (() => {
                 const inputToEdit = managedStandardInputs.find(
                   (entry) => entry.input.id === poseBindingEditorInputId,
@@ -1461,7 +1456,7 @@ export function InspectorContent() {
       const directRigControlReason = controllableResolution.blockedReason
         ? controllableResolution.blockedReason
         : controllableResolution.inputId &&
-          controllableResolution.inputId !== input.id
+            controllableResolution.inputId !== input.id
           ? `This variable is derived from "${controllableResolution.inputId}" without a local self slot. Edit My Drivers to add local control or adjust "${controllableResolution.inputId}".`
           : null;
       const standardInputList = managedStandardInputs.map(
@@ -1786,15 +1781,16 @@ export function InspectorContent() {
                   onClose={() => setRigDrivenBindingTargetId(null)}
                   title={
                     rigDrivenBindingTargetId
-                      ? `Edit Target Drivers · ${targetLabelById.get(rigDrivenBindingTargetId) ??
-                      rigDrivenBindingTargetId
-                      }`
+                      ? `Edit Target Drivers · ${
+                          targetLabelById.get(rigDrivenBindingTargetId) ??
+                          rigDrivenBindingTargetId
+                        }`
                       : "Edit Target Drivers"
                   }
                   maxWidth="lg"
                 >
                   {rigDrivenBindingTargetId &&
-                    bindings[rigDrivenBindingTargetId] ? (
+                  bindings[rigDrivenBindingTargetId] ? (
                     <BindingEditor
                       binding={bindings[rigDrivenBindingTargetId]}
                       targetId={rigDrivenBindingTargetId}
@@ -1907,55 +1903,55 @@ export function InspectorContent() {
       const colorFeature =
         material.animated.color || material.staticValues.color !== undefined
           ? ({
-            id: `mat-color-${material.id}`,
-            key: "color",
-            label: "Color",
-            animated: !!material.animated.color,
-            value: material.animated.color || "",
-            staticValue: material.staticValues.color,
-            components: [
-              {
-                label: "R",
-                targetId: material.animated.color
-                  ? `${material.animated.color}:r`
-                  : undefined,
-                staticValue: (material.staticValues.color as any)?.r,
-              },
-              {
-                label: "G",
-                targetId: material.animated.color
-                  ? `${material.animated.color}:g`
-                  : undefined,
-                staticValue: (material.staticValues.color as any)?.g,
-              },
-              {
-                label: "B",
-                targetId: material.animated.color
-                  ? `${material.animated.color}:b`
-                  : undefined,
-                staticValue: (material.staticValues.color as any)?.b,
-              },
-            ],
-          } as any)
+              id: `mat-color-${material.id}`,
+              key: "color",
+              label: "Color",
+              animated: !!material.animated.color,
+              value: material.animated.color || "",
+              staticValue: material.staticValues.color,
+              components: [
+                {
+                  label: "R",
+                  targetId: material.animated.color
+                    ? `${material.animated.color}:r`
+                    : undefined,
+                  staticValue: (material.staticValues.color as any)?.r,
+                },
+                {
+                  label: "G",
+                  targetId: material.animated.color
+                    ? `${material.animated.color}:g`
+                    : undefined,
+                  staticValue: (material.staticValues.color as any)?.g,
+                },
+                {
+                  label: "B",
+                  targetId: material.animated.color
+                    ? `${material.animated.color}:b`
+                    : undefined,
+                  staticValue: (material.staticValues.color as any)?.b,
+                },
+              ],
+            } as any)
           : null;
 
       const opacityFeature =
         material.animated.opacity || material.staticValues.opacity !== undefined
           ? ({
-            id: `mat-opacity-${material.id}`,
-            key: "opacity",
-            label: "Opacity",
-            animated: !!material.animated.opacity,
-            value: material.animated.opacity || "",
-            staticValue: material.staticValues.opacity,
-            components: [
-              {
-                label: "Opacity",
-                targetId: material.animated.opacity || undefined,
-                staticValue: material.staticValues.opacity,
-              },
-            ],
-          } as any)
+              id: `mat-opacity-${material.id}`,
+              key: "opacity",
+              label: "Opacity",
+              animated: !!material.animated.opacity,
+              value: material.animated.opacity || "",
+              staticValue: material.staticValues.opacity,
+              components: [
+                {
+                  label: "Opacity",
+                  targetId: material.animated.opacity || undefined,
+                  staticValue: material.staticValues.opacity,
+                },
+              ],
+            } as any)
           : null;
 
       const handleStaticValueChange = (
@@ -1999,15 +1995,17 @@ export function InspectorContent() {
                     handleUpdateStandardInput(id, { defaultValue: val })
                   }
                   onStaticValueChange={handleStaticValueChange}
-                  onToggleAnimated={(animated) => setFeatureAnimated(material.id, `${material.id}-color`, animated)}
+                  onToggleAnimated={(animated) =>
+                    setFeatureAnimated(
+                      material.id,
+                      `${material.id}-color`,
+                      animated,
+                    )
+                  }
                   onConstraintChange={updateAnimatableDescriptor}
                   onUpdateStandardInput={handleUpdateStandardInput}
                   setStaticFeatureValue={setStaticFeatureValue}
                 />
-
-
-
-
               )}
               {opacityFeature && (
                 <RiggingScalarRow
@@ -2023,15 +2021,17 @@ export function InspectorContent() {
                     handleUpdateStandardInput(id, { defaultValue: val })
                   }
                   onStaticValueChange={handleStaticValueChange}
-                  onToggleAnimated={(animated) => setFeatureAnimated(material.id, `${material.id}-opacity`, animated)}
+                  onToggleAnimated={(animated) =>
+                    setFeatureAnimated(
+                      material.id,
+                      `${material.id}-opacity`,
+                      animated,
+                    )
+                  }
                   onConstraintChange={updateAnimatableDescriptor}
                   onUpdateStandardInput={handleUpdateStandardInput}
                   setStaticFeatureValue={setStaticFeatureValue}
                 />
-
-
-
-
               )}
             </div>
 

--- a/apps/vizij-authoring/src/components/inspector/RiggingMaterialSection.tsx
+++ b/apps/vizij-authoring/src/components/inspector/RiggingMaterialSection.tsx
@@ -1,7 +1,6 @@
 import React, { useRef } from "react";
 import { Lock, LockOpen, Palette, Box, ChevronRight, Info } from "lucide-react";
 import type { StandardRigInput, AnimatableValue } from "@vizij/utils";
-
 import { HexColorPicker } from "react-colorful";
 import { Popover as BasePopover } from "@base-ui/react";
 import type {

--- a/apps/vizij-authoring/src/components/inspector/RiggingMaterialSection.tsx
+++ b/apps/vizij-authoring/src/components/inspector/RiggingMaterialSection.tsx
@@ -1,5 +1,7 @@
 import React, { useRef } from "react";
-import type { StandardRigInput } from "@vizij/utils";
+import { Lock, LockOpen, Palette, Box, ChevronRight, Info } from "lucide-react";
+import type { StandardRigInput, AnimatableValue } from "@vizij/utils";
+
 import { HexColorPicker } from "react-colorful";
 import { Popover as BasePopover } from "@base-ui/react";
 import type {
@@ -31,8 +33,9 @@ export function RiggingMaterialSection({ node }: RiggingMaterialSectionProps) {
 
   const { handleSelectMaterial } = useUnifiedSelection();
 
-  const { materials, assignMaterial, duplicateMaterial, setAnimatableValue } =
+  const { materials, assignMaterial, duplicateMaterial, setAnimatableValue, setFeatureAnimated, updateAnimatableDescriptor, setStaticFeatureValue } =
     useSceneComposer();
+
 
   // Helper to find feature by key
   const findFeature = (key: string) =>
@@ -130,10 +133,15 @@ export function RiggingMaterialSection({ node }: RiggingMaterialSectionProps) {
           inputBindings={inputBindings}
           inputValues={inputValues}
           onValueChange={handleInputValueChange}
-          onDefaultChange={(id, val) =>
+          onDefaultChange={(id: string, val: number) =>
             handleUpdateStandardInput(id, { defaultValue: val })
           }
           onStaticValueChange={handleStaticValueChange}
+          onToggleAnimated={(animated: boolean) => setFeatureAnimated(node.id, colorFeature.id, animated)}
+          onConstraintChange={updateAnimatableDescriptor}
+          onUpdateStandardInput={handleUpdateStandardInput}
+          setStaticFeatureValue={setStaticFeatureValue}
+          node={node}
         />
       )}
 
@@ -147,10 +155,15 @@ export function RiggingMaterialSection({ node }: RiggingMaterialSectionProps) {
           inputBindings={inputBindings}
           inputValues={inputValues}
           onValueChange={handleInputValueChange}
-          onDefaultChange={(id, val) =>
+          onDefaultChange={(id: string, val: number) =>
             handleUpdateStandardInput(id, { defaultValue: val })
           }
           onStaticValueChange={handleStaticValueChange}
+          onToggleAnimated={(animated: boolean) => setFeatureAnimated(node.id, opacityFeature.id, animated)}
+          onConstraintChange={updateAnimatableDescriptor}
+          onUpdateStandardInput={handleUpdateStandardInput}
+          setStaticFeatureValue={setStaticFeatureValue}
+          node={node}
         />
       )}
     </div>
@@ -170,11 +183,12 @@ interface RiggingScalarRowProps {
   inputValues: Record<string, number>;
   onValueChange: (id: string, value: number) => void;
   onDefaultChange: (id: string, value: number) => void;
-  onStaticValueChange?: (
-    targetId: string,
-    value: number,
-    channel?: string,
-  ) => void;
+  onToggleAnimated: (animated: boolean) => void;
+  onConstraintChange: (id: string, updater: (curr: AnimatableValue) => AnimatableValue) => void;
+  onStaticValueChange?: (targetId: string, value: number, channel?: string) => void;
+  onUpdateStandardInput: (id: string, updates: any) => void;
+  setStaticFeatureValue?: (nodeId: string, featureId: string, value: any) => void;
+  node?: SceneObjectNode;
 }
 
 export function RiggingScalarRow({
@@ -188,7 +202,14 @@ export function RiggingScalarRow({
   onValueChange,
   onDefaultChange,
   onStaticValueChange,
+  onToggleAnimated,
+  onConstraintChange,
+  onUpdateStandardInput,
+  setStaticFeatureValue,
+  node,
 }: RiggingScalarRowProps) {
+  const scrubValuesRef = useRef<Record<string, number>>({});
+
   const component = feature.components[0];
   if (!component) return null;
 
@@ -213,7 +234,9 @@ export function RiggingScalarRow({
   }
 
   const isBound = !!(inputId && standardInput) && !blockedReason;
-  const canEdit = isBound || (!!targetId && !!onStaticValueChange);
+
+  const minVal = isBound ? (standardInput!.range.min) : ((feature.descriptor?.constraints as any)?.min ?? 0);
+  const maxVal = isBound ? (standardInput!.range.max) : ((feature.descriptor?.constraints as any)?.max ?? 0);
 
   const currentValue = isBound
     ? (inputValues[inputId!] ?? standardInput!.defaultValue ?? 0)
@@ -232,42 +255,138 @@ export function RiggingScalarRow({
   };
 
   const handleSaveToDefault = () => {
-    if (isBound && inputId) onDefaultChange(inputId, currentValue as number);
+    if (isBound && inputId) onUpdateStandardInput(inputId, { defaultValue: currentValue as number });
   };
 
-  const renderInput = (isDefault: boolean) => {
-    const val = isDefault ? defaultValue : currentValue;
+  const hasMinChanged = Math.abs((currentValue as number) - (minVal as number)) > 0.0001;
+  const hasMaxChanged = Math.abs((currentValue as number) - (maxVal as number)) > 0.0001;
+
+  const handleSaveToMin = () => {
+    if (isBound && inputId) {
+      onUpdateStandardInput(inputId, { range: { min: currentValue as number } });
+    } else if (feature.animatableId) {
+      onConstraintChange?.(feature.animatableId, (curr: AnimatableValue) => {
+        const nextConstraints = { ...(curr.constraints || {}) } as any;
+        nextConstraints.min = currentValue;
+        return { ...curr, constraints: nextConstraints } as AnimatableValue;
+      });
+    }
+  };
+
+  const handleSaveToMax = () => {
+    if (isBound && inputId) {
+      onUpdateStandardInput(inputId, { range: { max: currentValue as number } });
+    } else if (feature.animatableId) {
+      onConstraintChange?.(feature.animatableId, (curr: AnimatableValue) => {
+        const nextConstraints = { ...(curr.constraints || {}) } as any;
+        nextConstraints.max = currentValue;
+        return { ...curr, constraints: nextConstraints } as AnimatableValue;
+      });
+    }
+  };
+
+  const renderInput = (type: "current" | "default" | "min" | "max") => {
+    let val: number | undefined;
+    let canEdit = true;
+
+    if (type === "current") {
+      val = currentValue as number;
+      canEdit = isBound || !!onStaticValueChange;
+    } else if (type === "default") {
+      val = defaultValue as number;
+      canEdit = isBound;
+    } else if (type === "min") {
+      val = minVal;
+      canEdit = true;
+    } else if (type === "max") {
+      val = maxVal;
+      canEdit = true;
+    }
 
     return (
       <div
-        className={`flex items-center bg-bg-input/50 rounded-sm border border-transparent ${canEdit ? "focus-within:border-accent/50" : "opacity-70"} relative flex-1 min-w-0 h-5`}
+        className={cn(
+          "flex items-center bg-bg-input/50 rounded-sm border border-transparent relative flex-1 min-w-0 h-5 group/row",
+          canEdit ? "focus-within:border-accent/50" : "opacity-70",
+        )}
       >
+        <ScrubbableLabel
+          label={label}
+          onScrub={(_, totalDelta) => {
+            const step = 0.01;
+            if (type === "current") {
+              if (isBound && inputId) {
+                const startVal = scrubValuesRef.current[inputId] ?? 0;
+                onValueChange(inputId, startVal + totalDelta * step);
+              } else if (onStaticValueChange) {
+                const startValueToUse = scrubValuesRef.current["current"] ?? 0;
+                const newVal = startValueToUse + totalDelta * step;
+                if (feature.animated && feature.animatableId) {
+                  onStaticValueChange(feature.animatableId, newVal);
+                } else if (setStaticFeatureValue && node) {
+                  setStaticFeatureValue(node.id, feature.id, newVal);
+                }
+              }
+            } else if (type === "default" && inputId) {
+              const startVal = scrubValuesRef.current[inputId] ?? 0;
+              onDefaultChange(inputId, startVal + totalDelta * step);
+            } else if ((type === "min" || type === "max") && (inputId || feature.animatableId)) {
+              const startVal = scrubValuesRef.current[type] ?? 0;
+              const nextVal = startVal + totalDelta * step;
+              if (isBound && inputId) {
+                onUpdateStandardInput(inputId, { range: { [type]: nextVal } });
+              } else if (feature.animatableId) {
+                onConstraintChange?.(feature.animatableId, (curr: AnimatableValue) => {
+                  const nextConstraints = { ...(curr.constraints || {}) } as any;
+                  nextConstraints[type === "min" ? "min" : "max"] = nextVal;
+                  return { ...curr, constraints: nextConstraints } as AnimatableValue;
+                });
+              }
+            }
+          }}
+          onScrubStart={() => {
+            if (type === "current") {
+              if (isBound && inputId) scrubValuesRef.current[inputId] = (currentValue as number) ?? 0;
+              else scrubValuesRef.current["current"] = (currentValue as number) ?? 0;
+            } else if (type === "default" && inputId) {
+              scrubValuesRef.current[inputId] = (defaultValue as number) ?? 0;
+            } else if ((type === "min" || type === "max") && (inputId || feature.animatableId)) {
+              scrubValuesRef.current[type] = (type === "min" ? minVal : maxVal) ?? 0;
+            }
+          }}
+          className="text-[9px] font-bold px-1 select-none transition-colors text-text-muted"
+        />
         <input
           type="number"
           className="w-full bg-transparent border-0 text-[10px] p-0 h-5 focus:ring-0 text-text-primary placeholder-text-muted no-spinners font-mono leading-none pl-1"
-          value={typeof val === "number" ? parseFloat(val.toFixed(2)) : val}
-          step={0.1}
+          value={typeof val === "number" ? val : 0}
+          step={0.01}
           min={0}
           max={1}
           disabled={!canEdit}
-          title={
-            !canEdit
-              ? blockedReason
-                ? blockedReason
-                : unresolvedInputId
-                  ? `Driver "${unresolvedInputId}" is unresolved. Open My Drivers to remap.`
-                  : "Value is not driven by a rig input"
-              : undefined
-          }
           onChange={(e) => {
-            if (!canEdit) return;
             const num = parseFloat(e.target.value);
-            if (!isNaN(num)) {
+            if (isNaN(num)) return;
+            if (type === "current") {
+              if (isBound && inputId) onValueChange(inputId, num);
+              else if (onStaticValueChange) {
+                if (feature.animated && feature.animatableId) {
+                  onStaticValueChange(feature.animatableId, num);
+                } else if (setStaticFeatureValue && node) {
+                  setStaticFeatureValue(node.id, feature.id, num);
+                }
+              }
+            } else if (type === "default" && inputId) {
+              onDefaultChange(inputId, num);
+            } else if ((type === "min" || type === "max") && (inputId || feature.animatableId)) {
               if (isBound && inputId) {
-                if (isDefault) onDefaultChange(inputId, num);
-                else onValueChange(inputId, num);
-              } else if (targetId && onStaticValueChange) {
-                onStaticValueChange(targetId, num);
+                onUpdateStandardInput(inputId, { range: { [type]: num } });
+              } else if (feature.animatableId) {
+                onConstraintChange?.(feature.animatableId, (curr: AnimatableValue) => {
+                  const nextConstraints = { ...(curr.constraints || {}) } as any;
+                  nextConstraints[type === "min" ? "min" : "max"] = num;
+                  return { ...curr, constraints: nextConstraints } as AnimatableValue;
+                });
               }
             }
           }}
@@ -276,14 +395,42 @@ export function RiggingScalarRow({
     );
   };
 
+  const renderAnimatableRow = () => (
+    <div className="flex gap-1.5 flex-1">
+      <button
+        className={cn(
+          "flex items-center justify-center gap-1.5 flex-1 h-5 rounded-sm border border-transparent transition-colors text-[10px] font-bold uppercase tracking-wider",
+          feature.animated
+            ? "bg-accent/10 text-accent hover:bg-accent/20"
+            : "bg-bg-input/50 text-text-muted hover:bg-bg-input/70",
+        )}
+        onClick={() => onToggleAnimated?.(!feature.animated)}
+      >
+        {feature.animated ? (
+          <LockOpen size={10} className="shrink-0" />
+        ) : (
+          <Lock size={10} className="shrink-0" />
+        )}
+        <span>Value</span>
+      </button>
+    </div>
+  );
+
   return (
     <RiggingPropertyRow
       label={label}
       hasDifferentDefault={hasDifferentDefault}
+      hasMinChanged={hasMinChanged}
+      hasMaxChanged={hasMaxChanged}
       onResetToDefault={handleReset}
       onSaveToDefault={handleSaveToDefault}
-      renderMainInput={() => renderInput(false)}
-      renderDefaultInput={() => renderInput(true)}
+      onSaveToMin={handleSaveToMin}
+      onSaveToMax={handleSaveToMax}
+      renderMainInput={() => renderInput("current")}
+      renderDefaultInput={() => renderInput("default")}
+      renderMinInput={() => renderInput("min")}
+      renderMaxInput={() => renderInput("max")}
+      renderAnimatableRow={renderAnimatableRow}
     />
   );
 }
@@ -299,6 +446,11 @@ export function RiggingColorRow({
   onValueChange,
   onDefaultChange,
   onStaticValueChange,
+  onToggleAnimated,
+  onConstraintChange,
+  onUpdateStandardInput,
+  setStaticFeatureValue,
+  node,
 }: RiggingScalarRowProps) {
   const scrubValuesRef = useRef<Record<string, number>>({});
 
@@ -341,12 +493,17 @@ export function RiggingColorRow({
       ? (standardInput!.defaultValue ?? 0)
       : (comp.staticValue ?? 0);
 
+    const min = isBound ? (standardInput!.range.min) : 0;
+    const max = isBound ? (standardInput!.range.max) : 1;
+
     return {
       label: compLabel,
       inputId,
       targetId,
       currentValue,
       defaultValue,
+      min,
+      max,
       isBound,
       unresolvedInputId,
       blockedReason,
@@ -367,7 +524,7 @@ export function RiggingColorRow({
     (c) =>
       c.isBound &&
       Math.abs((c.currentValue as number) - (c.defaultValue as number)) >
-        0.0001,
+      0.0001,
   );
 
   const handleReset = () => {
@@ -380,8 +537,55 @@ export function RiggingColorRow({
   const handleSaveToDefault = () => {
     components.forEach((c) => {
       if (c.isBound && c.inputId)
-        onDefaultChange(c.inputId, c.currentValue as number);
+        onUpdateStandardInput(c.inputId, { defaultValue: c.currentValue as number });
     });
+  };
+
+  const hasMinChanged = components.some(c => Math.abs((c.currentValue as number) - (c.min as number)) > 0.0001);
+  const hasMaxChanged = components.some(c => Math.abs((c.currentValue as number) - (c.max as number)) > 0.0001);
+
+  const handleSaveToMin = () => {
+    components.forEach((c) => {
+      if (c.isBound && c.inputId) {
+        onUpdateStandardInput(c.inputId, { range: { min: c.currentValue as number } });
+      }
+    });
+
+    if (feature.animatableId) {
+      onConstraintChange?.(feature.animatableId, (curr: AnimatableValue) => {
+        const nextConstraints = { ...(curr.constraints || {}) } as any;
+        const currentVals = { ...(nextConstraints.min || {}) };
+        components.forEach((c) => {
+          if (!c.isBound) {
+            currentVals[c.label.toLowerCase()] = c.currentValue;
+          }
+        });
+        nextConstraints.min = currentVals;
+        return { ...curr, constraints: nextConstraints } as AnimatableValue;
+      });
+    }
+  };
+
+  const handleSaveToMax = () => {
+    components.forEach((c) => {
+      if (c.isBound && c.inputId) {
+        onUpdateStandardInput(c.inputId, { range: { max: c.currentValue as number } });
+      }
+    });
+
+    if (feature.animatableId) {
+      onConstraintChange?.(feature.animatableId, (curr: AnimatableValue) => {
+        const nextConstraints = { ...(curr.constraints || {}) } as any;
+        const currentVals = { ...(nextConstraints.max || {}) };
+        components.forEach((c) => {
+          if (!c.isBound) {
+            currentVals[c.label.toLowerCase()] = c.currentValue;
+          }
+        });
+        nextConstraints.max = currentVals;
+        return { ...curr, constraints: nextConstraints } as AnimatableValue;
+      });
+    }
   };
 
   const rgbToHex = (r: number, g: number, b: number) => {
@@ -396,48 +600,84 @@ export function RiggingColorRow({
     const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
     return result
       ? {
-          r: parseInt(result[1], 16) / 255,
-          g: parseInt(result[2], 16) / 255,
-          b: parseInt(result[3], 16) / 255,
-        }
+        r: parseInt(result[1], 16) / 255,
+        g: parseInt(result[2], 16) / 255,
+        b: parseInt(result[3], 16) / 255,
+      }
       : null;
   };
 
-  const renderInputs = (isDefault: boolean) => {
-    const currentR = isDefault
-      ? (rComp?.defaultValue ?? 0)
-      : (rComp?.currentValue ?? 0);
-    const currentG = isDefault
-      ? (gComp?.defaultValue ?? 0)
-      : (gComp?.currentValue ?? 0);
-    const currentB = isDefault
-      ? (bComp?.defaultValue ?? 0)
-      : (bComp?.currentValue ?? 0);
+  const renderInputs = (type: "current" | "default" | "min" | "max") => {
+    let rVal: number | undefined;
+    let gVal: number | undefined;
+    let bVal: number | undefined;
+
+    if (type === "current") {
+      rVal = rComp?.currentValue as number;
+      gVal = gComp?.currentValue as number;
+      bVal = bComp?.currentValue as number;
+    } else if (type === "default") {
+      rVal = rComp?.defaultValue as number;
+      gVal = gComp?.defaultValue as number;
+      bVal = bComp?.defaultValue as number;
+    } else if (type === "min") {
+      rVal = rComp?.min as number;
+      gVal = gComp?.min as number;
+      bVal = bComp?.min as number;
+    } else if (type === "max") {
+      rVal = rComp?.max as number;
+      gVal = gComp?.max as number;
+      bVal = bComp?.max as number;
+    }
 
     const hexColor = rgbToHex(
-      currentR as number,
-      currentG as number,
-      currentB as number,
+      (rVal ?? 0) as number,
+      (gVal ?? 0) as number,
+      (bVal ?? 0) as number,
     );
-    const canEditAny =
-      components.some((c) => c.isBound) || !!onStaticValueChange;
+
+    const canEditAny = type === "current"
+      ? (components.some((c) => c.isBound) || !!onStaticValueChange)
+      : (type === "default" ? components.some(c => c.isBound) : !!feature.animatableId);
 
     const handleColorChange = (newHex: string) => {
       const rgb = hexToRgb(newHex);
       if (!rgb) return;
 
-      [
-        { comp: rComp, val: rgb.r },
-        { comp: gComp, val: rgb.g },
-        { comp: bComp, val: rgb.b },
-      ].forEach(({ comp, val }) => {
-        if (comp?.isBound && comp.inputId) {
-          if (isDefault) onDefaultChange(comp.inputId, val);
-          else onValueChange(comp.inputId, val);
-        } else if (comp?.targetId && onStaticValueChange) {
-          onStaticValueChange(comp.targetId, val, comp.label.toLowerCase());
-        }
-      });
+      if (type === "current" || type === "default") {
+        [
+          { comp: rComp, val: rgb.r },
+          { comp: gComp, val: rgb.g },
+          { comp: bComp, val: rgb.b },
+        ].forEach(({ comp, val }) => {
+          if (!comp) return;
+          if (comp.isBound && comp.inputId) {
+            if (type === "current") onValueChange(comp.inputId, val);
+            else onDefaultChange(comp.inputId, val);
+          } else if (type === "current" && onStaticValueChange) {
+            if (feature.animated && feature.animatableId) {
+              onStaticValueChange(feature.animatableId, val, comp.label.toLowerCase());
+            } else if (setStaticFeatureValue && node) {
+              const current = (feature.staticValue as any) || {};
+              setStaticFeatureValue(node.id, feature.id, {
+                ...current,
+                [comp.label.toLowerCase()]: val,
+              });
+            }
+          }
+        });
+      } else if (feature.animatableId) {
+        onConstraintChange?.(feature.animatableId, (curr: AnimatableValue) => {
+          const nextConstraints = { ...(curr.constraints || {}) } as any;
+          const kind = type === "min" ? "min" : "max";
+          const currentVals = { ...(nextConstraints[kind] || {}) };
+          currentVals.r = rgb.r;
+          currentVals.g = rgb.g;
+          currentVals.b = rgb.b;
+          nextConstraints[kind] = currentVals;
+          return { ...curr, constraints: nextConstraints } as AnimatableValue;
+        });
+      }
     };
 
     return (
@@ -475,10 +715,16 @@ export function RiggingColorRow({
 
         <div className="flex gap-1.5 flex-1 min-w-0">
           {components.map((c, i) => {
-            const val = isDefault ? c.defaultValue : c.currentValue;
-            const canEdit =
-              c.isBound || (!!c.targetId && !!onStaticValueChange);
-            const label = c === rComp ? "R" : c === gComp ? "G" : "B";
+            let compVal: number | undefined;
+            if (c === rComp) compVal = rVal;
+            else if (c === gComp) compVal = gVal;
+            else if (c === bComp) compVal = bVal;
+
+            const canEditComp = type === "current"
+              ? (c.isBound || !!onStaticValueChange)
+              : (type === "default" ? c.isBound : !!feature.animatableId);
+
+            const labelKey = c === rComp ? "R" : c === gComp ? "G" : "B";
             const labelColor =
               c === rComp
                 ? "text-red-500"
@@ -491,39 +737,52 @@ export function RiggingColorRow({
                 key={i}
                 className={cn(
                   "flex items-center bg-bg-input/50 rounded-sm border border-transparent relative flex-1 min-w-0 h-5 group/row",
-                  canEdit ? "focus-within:border-accent/50" : "opacity-70",
+                  canEditComp ? "focus-within:border-accent/50" : "opacity-70",
                 )}
               >
                 <ScrubbableLabel
-                  label={label}
+                  label={labelKey}
                   onScrub={(_, totalDelta) => {
                     const step = 0.01;
-                    const startKey = c.inputId || c.targetId || "";
-                    if (!startKey) return;
-
-                    const startVal = scrubValuesRef.current[startKey] ?? 0;
+                    const scrubKey = c.isBound ? (c.inputId!) : (c.targetId || `static-${type}-${labelKey}`);
+                    const startVal = scrubValuesRef.current[scrubKey] ?? 0;
                     const nextVal = startVal + totalDelta * step;
 
-                    if (c.isBound && c.inputId) {
-                      if (isDefault) onDefaultChange(c.inputId, nextVal);
-                      else onValueChange(c.inputId, nextVal);
-                    } else if (c.targetId && onStaticValueChange) {
-                      onStaticValueChange(
-                        c.targetId,
-                        nextVal,
-                        c.label.toLowerCase(),
-                      );
+                    if (type === "current") {
+                      if (c.isBound && c.inputId) onValueChange(c.inputId, nextVal);
+                      else if (onStaticValueChange) {
+                        if (feature.animated && feature.animatableId) {
+                          onStaticValueChange(feature.animatableId, nextVal, c.label.toLowerCase());
+                        } else if (setStaticFeatureValue && node) {
+                          const current = (feature.staticValue as any) || {};
+                          setStaticFeatureValue(node.id, feature.id, {
+                            ...current,
+                            [c.label.toLowerCase()]: nextVal,
+                          });
+                        }
+                      }
+                    } else if (type === "default" && c.inputId) {
+                      onUpdateStandardInput(c.inputId, { defaultValue: nextVal });
+                    } else if (c.inputId || feature.animatableId) {
+                      if (c.isBound && c.inputId) {
+                        onUpdateStandardInput(c.inputId, { range: { [type]: nextVal } });
+                      } else if (feature.animatableId) {
+                        onConstraintChange?.(feature.animatableId, (curr: AnimatableValue) => {
+                          const nextConstraints = { ...(curr.constraints || {}) } as any;
+                          const kind = type === "min" ? "min" : "max";
+                          const currentVal = nextConstraints[kind] || {};
+                          nextConstraints[kind] = {
+                            ...(typeof currentVal === "object" ? currentVal : {}),
+                            [c.label.toLowerCase()]: nextVal,
+                          } as any;
+                          return { ...curr, constraints: nextConstraints } as AnimatableValue;
+                        });
+                      }
                     }
                   }}
                   onScrubStart={() => {
-                    const startKey = c.inputId || c.targetId || "";
-                    if (!startKey) return;
-
-                    const baseline = isDefault
-                      ? c.defaultValue
-                      : c.currentValue;
-                    scrubValuesRef.current[startKey] =
-                      (baseline as number) ?? 0;
+                    const scrubKey = c.isBound ? (c.inputId!) : (c.targetId || `static-${type}-${labelKey}`);
+                    scrubValuesRef.current[scrubKey] = (compVal as number) ?? 0;
                   }}
                   className={cn(
                     "text-[9px] font-bold px-1 select-none transition-colors",
@@ -533,35 +792,43 @@ export function RiggingColorRow({
                 <input
                   type="number"
                   className="w-full bg-transparent border-0 text-[10px] p-0 h-5 focus:ring-0 text-text-primary placeholder-text-muted no-spinners font-mono leading-none"
-                  value={
-                    typeof val === "number" ? parseFloat(val.toFixed(2)) : 0
-                  }
+                  value={typeof compVal === "number" ? compVal : 0}
                   step={0.01}
                   min={0}
                   max={1}
-                  disabled={!canEdit}
-                  title={
-                    !canEdit
-                      ? c.blockedReason
-                        ? c.blockedReason
-                        : c.unresolvedInputId
-                          ? `Driver "${c.unresolvedInputId}" is unresolved. Open My Drivers to remap.`
-                          : "Value is not driven by a rig input"
-                      : undefined
-                  }
+                  disabled={!canEditComp}
                   onChange={(e) => {
-                    if (!canEdit) return;
                     const num = parseFloat(e.target.value);
-                    if (!isNaN(num)) {
+                    if (isNaN(num)) return;
+                    if (type === "current") {
+                      if (c.isBound && c.inputId) onValueChange(c.inputId, num);
+                      else if (onStaticValueChange) {
+                        if (feature.animated && feature.animatableId) {
+                          onStaticValueChange(feature.animatableId, num, c.label.toLowerCase());
+                        } else if (setStaticFeatureValue && node) {
+                          const current = (feature.staticValue as any) || {};
+                          setStaticFeatureValue(node.id, feature.id, {
+                            ...current,
+                            [c.label.toLowerCase()]: num,
+                          });
+                        }
+                      }
+                    } else if (type === "default" && c.inputId) {
+                      onUpdateStandardInput(c.inputId, { defaultValue: num });
+                    } else if (c.inputId || feature.animatableId) {
                       if (c.isBound && c.inputId) {
-                        if (isDefault) onDefaultChange(c.inputId, num);
-                        else onValueChange(c.inputId, num);
-                      } else if (c.targetId && onStaticValueChange) {
-                        onStaticValueChange(
-                          c.targetId,
-                          num,
-                          c.label.toLowerCase(),
-                        );
+                        onUpdateStandardInput(c.inputId, { range: { [type]: num } });
+                      } else if (feature.animatableId) {
+                        onConstraintChange?.(feature.animatableId, (curr: AnimatableValue) => {
+                          const nextConstraints = { ...(curr.constraints || {}) } as any;
+                          const kind = type === "min" ? "min" : "max";
+                          const currentVal = nextConstraints[kind] || {};
+                          nextConstraints[kind] = {
+                            ...(typeof currentVal === "object" ? currentVal : {}),
+                            [c.label.toLowerCase()]: num,
+                          } as any;
+                          return { ...curr, constraints: nextConstraints } as AnimatableValue;
+                        });
                       }
                     }
                   }}
@@ -574,14 +841,45 @@ export function RiggingColorRow({
     );
   };
 
+  const renderAnimatableRow = () => (
+    <div className="flex gap-1.5 flex-1">
+      {components.map((c, i) => (
+        <button
+          key={i}
+          className={cn(
+            "flex items-center justify-center gap-1.5 flex-1 h-5 rounded-sm border border-transparent transition-colors text-[10px] font-bold uppercase tracking-wider",
+            feature.animated
+              ? "bg-accent/10 text-accent hover:bg-accent/20"
+              : "bg-bg-input/50 text-text-muted hover:bg-bg-input/70",
+          )}
+          onClick={() => onToggleAnimated?.(!feature.animated)}
+        >
+          {feature.animated ? (
+            <LockOpen size={10} className="shrink-0" />
+          ) : (
+            <Lock size={10} className="shrink-0" />
+          )}
+          <span>{c.label.substring(0, 1)}</span>
+        </button>
+      ))}
+    </div>
+  );
+
   return (
     <RiggingPropertyRow
       label={label}
       hasDifferentDefault={hasDifferentDefault}
+      hasMinChanged={hasMinChanged}
+      hasMaxChanged={hasMaxChanged}
       onResetToDefault={handleReset}
       onSaveToDefault={handleSaveToDefault}
-      renderMainInput={() => renderInputs(false)}
-      renderDefaultInput={() => renderInputs(true)}
+      onSaveToMin={handleSaveToMin}
+      onSaveToMax={handleSaveToMax}
+      renderMainInput={() => renderInputs("current")}
+      renderDefaultInput={() => renderInputs("default")}
+      renderMinInput={() => renderInputs("min")}
+      renderMaxInput={() => renderInputs("max")}
+      renderAnimatableRow={renderAnimatableRow}
     />
   );
 }

--- a/apps/vizij-authoring/src/components/inspector/RiggingMaterialSection.tsx
+++ b/apps/vizij-authoring/src/components/inspector/RiggingMaterialSection.tsx
@@ -33,9 +33,15 @@ export function RiggingMaterialSection({ node }: RiggingMaterialSectionProps) {
 
   const { handleSelectMaterial } = useUnifiedSelection();
 
-  const { materials, assignMaterial, duplicateMaterial, setAnimatableValue, setFeatureAnimated, updateAnimatableDescriptor, setStaticFeatureValue } =
-    useSceneComposer();
-
+  const {
+    materials,
+    assignMaterial,
+    duplicateMaterial,
+    setAnimatableValue,
+    setFeatureAnimated,
+    updateAnimatableDescriptor,
+    setStaticFeatureValue,
+  } = useSceneComposer();
 
   // Helper to find feature by key
   const findFeature = (key: string) =>
@@ -137,7 +143,9 @@ export function RiggingMaterialSection({ node }: RiggingMaterialSectionProps) {
             handleUpdateStandardInput(id, { defaultValue: val })
           }
           onStaticValueChange={handleStaticValueChange}
-          onToggleAnimated={(animated: boolean) => setFeatureAnimated(node.id, colorFeature.id, animated)}
+          onToggleAnimated={(animated: boolean) =>
+            setFeatureAnimated(node.id, colorFeature.id, animated)
+          }
           onConstraintChange={updateAnimatableDescriptor}
           onUpdateStandardInput={handleUpdateStandardInput}
           setStaticFeatureValue={setStaticFeatureValue}
@@ -159,7 +167,9 @@ export function RiggingMaterialSection({ node }: RiggingMaterialSectionProps) {
             handleUpdateStandardInput(id, { defaultValue: val })
           }
           onStaticValueChange={handleStaticValueChange}
-          onToggleAnimated={(animated: boolean) => setFeatureAnimated(node.id, opacityFeature.id, animated)}
+          onToggleAnimated={(animated: boolean) =>
+            setFeatureAnimated(node.id, opacityFeature.id, animated)
+          }
           onConstraintChange={updateAnimatableDescriptor}
           onUpdateStandardInput={handleUpdateStandardInput}
           setStaticFeatureValue={setStaticFeatureValue}
@@ -184,10 +194,21 @@ interface RiggingScalarRowProps {
   onValueChange: (id: string, value: number) => void;
   onDefaultChange: (id: string, value: number) => void;
   onToggleAnimated: (animated: boolean) => void;
-  onConstraintChange: (id: string, updater: (curr: AnimatableValue) => AnimatableValue) => void;
-  onStaticValueChange?: (targetId: string, value: number, channel?: string) => void;
+  onConstraintChange: (
+    id: string,
+    updater: (curr: AnimatableValue) => AnimatableValue,
+  ) => void;
+  onStaticValueChange?: (
+    targetId: string,
+    value: number,
+    channel?: string,
+  ) => void;
   onUpdateStandardInput: (id: string, updates: any) => void;
-  setStaticFeatureValue?: (nodeId: string, featureId: string, value: any) => void;
+  setStaticFeatureValue?: (
+    nodeId: string,
+    featureId: string,
+    value: any,
+  ) => void;
   node?: SceneObjectNode;
 }
 
@@ -235,8 +256,12 @@ export function RiggingScalarRow({
 
   const isBound = !!(inputId && standardInput) && !blockedReason;
 
-  const minVal = isBound ? (standardInput!.range.min) : ((feature.descriptor?.constraints as any)?.min ?? 0);
-  const maxVal = isBound ? (standardInput!.range.max) : ((feature.descriptor?.constraints as any)?.max ?? 0);
+  const minVal = isBound
+    ? standardInput!.range.min
+    : ((feature.descriptor?.constraints as any)?.min ?? 0);
+  const maxVal = isBound
+    ? standardInput!.range.max
+    : ((feature.descriptor?.constraints as any)?.max ?? 0);
 
   const currentValue = isBound
     ? (inputValues[inputId!] ?? standardInput!.defaultValue ?? 0)
@@ -255,15 +280,20 @@ export function RiggingScalarRow({
   };
 
   const handleSaveToDefault = () => {
-    if (isBound && inputId) onUpdateStandardInput(inputId, { defaultValue: currentValue as number });
+    if (isBound && inputId)
+      onUpdateStandardInput(inputId, { defaultValue: currentValue as number });
   };
 
-  const hasMinChanged = Math.abs((currentValue as number) - (minVal as number)) > 0.0001;
-  const hasMaxChanged = Math.abs((currentValue as number) - (maxVal as number)) > 0.0001;
+  const hasMinChanged =
+    Math.abs((currentValue as number) - (minVal as number)) > 0.0001;
+  const hasMaxChanged =
+    Math.abs((currentValue as number) - (maxVal as number)) > 0.0001;
 
   const handleSaveToMin = () => {
     if (isBound && inputId) {
-      onUpdateStandardInput(inputId, { range: { min: currentValue as number } });
+      onUpdateStandardInput(inputId, {
+        range: { min: currentValue as number },
+      });
     } else if (feature.animatableId) {
       onConstraintChange?.(feature.animatableId, (curr: AnimatableValue) => {
         const nextConstraints = { ...(curr.constraints || {}) } as any;
@@ -275,7 +305,9 @@ export function RiggingScalarRow({
 
   const handleSaveToMax = () => {
     if (isBound && inputId) {
-      onUpdateStandardInput(inputId, { range: { max: currentValue as number } });
+      onUpdateStandardInput(inputId, {
+        range: { max: currentValue as number },
+      });
     } else if (feature.animatableId) {
       onConstraintChange?.(feature.animatableId, (curr: AnimatableValue) => {
         const nextConstraints = { ...(curr.constraints || {}) } as any;
@@ -330,28 +362,46 @@ export function RiggingScalarRow({
             } else if (type === "default" && inputId) {
               const startVal = scrubValuesRef.current[inputId] ?? 0;
               onDefaultChange(inputId, startVal + totalDelta * step);
-            } else if ((type === "min" || type === "max") && (inputId || feature.animatableId)) {
+            } else if (
+              (type === "min" || type === "max") &&
+              (inputId || feature.animatableId)
+            ) {
               const startVal = scrubValuesRef.current[type] ?? 0;
               const nextVal = startVal + totalDelta * step;
               if (isBound && inputId) {
                 onUpdateStandardInput(inputId, { range: { [type]: nextVal } });
               } else if (feature.animatableId) {
-                onConstraintChange?.(feature.animatableId, (curr: AnimatableValue) => {
-                  const nextConstraints = { ...(curr.constraints || {}) } as any;
-                  nextConstraints[type === "min" ? "min" : "max"] = nextVal;
-                  return { ...curr, constraints: nextConstraints } as AnimatableValue;
-                });
+                onConstraintChange?.(
+                  feature.animatableId,
+                  (curr: AnimatableValue) => {
+                    const nextConstraints = {
+                      ...(curr.constraints || {}),
+                    } as any;
+                    nextConstraints[type === "min" ? "min" : "max"] = nextVal;
+                    return {
+                      ...curr,
+                      constraints: nextConstraints,
+                    } as AnimatableValue;
+                  },
+                );
               }
             }
           }}
           onScrubStart={() => {
             if (type === "current") {
-              if (isBound && inputId) scrubValuesRef.current[inputId] = (currentValue as number) ?? 0;
-              else scrubValuesRef.current["current"] = (currentValue as number) ?? 0;
+              if (isBound && inputId)
+                scrubValuesRef.current[inputId] = (currentValue as number) ?? 0;
+              else
+                scrubValuesRef.current["current"] =
+                  (currentValue as number) ?? 0;
             } else if (type === "default" && inputId) {
               scrubValuesRef.current[inputId] = (defaultValue as number) ?? 0;
-            } else if ((type === "min" || type === "max") && (inputId || feature.animatableId)) {
-              scrubValuesRef.current[type] = (type === "min" ? minVal : maxVal) ?? 0;
+            } else if (
+              (type === "min" || type === "max") &&
+              (inputId || feature.animatableId)
+            ) {
+              scrubValuesRef.current[type] =
+                (type === "min" ? minVal : maxVal) ?? 0;
             }
           }}
           className="text-[9px] font-bold px-1 select-none transition-colors text-text-muted"
@@ -378,15 +428,26 @@ export function RiggingScalarRow({
               }
             } else if (type === "default" && inputId) {
               onDefaultChange(inputId, num);
-            } else if ((type === "min" || type === "max") && (inputId || feature.animatableId)) {
+            } else if (
+              (type === "min" || type === "max") &&
+              (inputId || feature.animatableId)
+            ) {
               if (isBound && inputId) {
                 onUpdateStandardInput(inputId, { range: { [type]: num } });
               } else if (feature.animatableId) {
-                onConstraintChange?.(feature.animatableId, (curr: AnimatableValue) => {
-                  const nextConstraints = { ...(curr.constraints || {}) } as any;
-                  nextConstraints[type === "min" ? "min" : "max"] = num;
-                  return { ...curr, constraints: nextConstraints } as AnimatableValue;
-                });
+                onConstraintChange?.(
+                  feature.animatableId,
+                  (curr: AnimatableValue) => {
+                    const nextConstraints = {
+                      ...(curr.constraints || {}),
+                    } as any;
+                    nextConstraints[type === "min" ? "min" : "max"] = num;
+                    return {
+                      ...curr,
+                      constraints: nextConstraints,
+                    } as AnimatableValue;
+                  },
+                );
               }
             }
           }}
@@ -493,8 +554,8 @@ export function RiggingColorRow({
       ? (standardInput!.defaultValue ?? 0)
       : (comp.staticValue ?? 0);
 
-    const min = isBound ? (standardInput!.range.min) : 0;
-    const max = isBound ? (standardInput!.range.max) : 1;
+    const min = isBound ? standardInput!.range.min : 0;
+    const max = isBound ? standardInput!.range.max : 1;
 
     return {
       label: compLabel,
@@ -524,7 +585,7 @@ export function RiggingColorRow({
     (c) =>
       c.isBound &&
       Math.abs((c.currentValue as number) - (c.defaultValue as number)) >
-      0.0001,
+        0.0001,
   );
 
   const handleReset = () => {
@@ -537,17 +598,25 @@ export function RiggingColorRow({
   const handleSaveToDefault = () => {
     components.forEach((c) => {
       if (c.isBound && c.inputId)
-        onUpdateStandardInput(c.inputId, { defaultValue: c.currentValue as number });
+        onUpdateStandardInput(c.inputId, {
+          defaultValue: c.currentValue as number,
+        });
     });
   };
 
-  const hasMinChanged = components.some(c => Math.abs((c.currentValue as number) - (c.min as number)) > 0.0001);
-  const hasMaxChanged = components.some(c => Math.abs((c.currentValue as number) - (c.max as number)) > 0.0001);
+  const hasMinChanged = components.some(
+    (c) => Math.abs((c.currentValue as number) - (c.min as number)) > 0.0001,
+  );
+  const hasMaxChanged = components.some(
+    (c) => Math.abs((c.currentValue as number) - (c.max as number)) > 0.0001,
+  );
 
   const handleSaveToMin = () => {
     components.forEach((c) => {
       if (c.isBound && c.inputId) {
-        onUpdateStandardInput(c.inputId, { range: { min: c.currentValue as number } });
+        onUpdateStandardInput(c.inputId, {
+          range: { min: c.currentValue as number },
+        });
       }
     });
 
@@ -569,7 +638,9 @@ export function RiggingColorRow({
   const handleSaveToMax = () => {
     components.forEach((c) => {
       if (c.isBound && c.inputId) {
-        onUpdateStandardInput(c.inputId, { range: { max: c.currentValue as number } });
+        onUpdateStandardInput(c.inputId, {
+          range: { max: c.currentValue as number },
+        });
       }
     });
 
@@ -600,10 +671,10 @@ export function RiggingColorRow({
     const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
     return result
       ? {
-        r: parseInt(result[1], 16) / 255,
-        g: parseInt(result[2], 16) / 255,
-        b: parseInt(result[3], 16) / 255,
-      }
+          r: parseInt(result[1], 16) / 255,
+          g: parseInt(result[2], 16) / 255,
+          b: parseInt(result[3], 16) / 255,
+        }
       : null;
   };
 
@@ -636,9 +707,12 @@ export function RiggingColorRow({
       (bVal ?? 0) as number,
     );
 
-    const canEditAny = type === "current"
-      ? (components.some((c) => c.isBound) || !!onStaticValueChange)
-      : (type === "default" ? components.some(c => c.isBound) : !!feature.animatableId);
+    const canEditAny =
+      type === "current"
+        ? components.some((c) => c.isBound) || !!onStaticValueChange
+        : type === "default"
+          ? components.some((c) => c.isBound)
+          : !!feature.animatableId;
 
     const handleColorChange = (newHex: string) => {
       const rgb = hexToRgb(newHex);
@@ -656,7 +730,11 @@ export function RiggingColorRow({
             else onDefaultChange(comp.inputId, val);
           } else if (type === "current" && onStaticValueChange) {
             if (feature.animated && feature.animatableId) {
-              onStaticValueChange(feature.animatableId, val, comp.label.toLowerCase());
+              onStaticValueChange(
+                feature.animatableId,
+                val,
+                comp.label.toLowerCase(),
+              );
             } else if (setStaticFeatureValue && node) {
               const current = (feature.staticValue as any) || {};
               setStaticFeatureValue(node.id, feature.id, {
@@ -720,9 +798,12 @@ export function RiggingColorRow({
             else if (c === gComp) compVal = gVal;
             else if (c === bComp) compVal = bVal;
 
-            const canEditComp = type === "current"
-              ? (c.isBound || !!onStaticValueChange)
-              : (type === "default" ? c.isBound : !!feature.animatableId);
+            const canEditComp =
+              type === "current"
+                ? c.isBound || !!onStaticValueChange
+                : type === "default"
+                  ? c.isBound
+                  : !!feature.animatableId;
 
             const labelKey = c === rComp ? "R" : c === gComp ? "G" : "B";
             const labelColor =
@@ -744,15 +825,22 @@ export function RiggingColorRow({
                   label={labelKey}
                   onScrub={(_, totalDelta) => {
                     const step = 0.01;
-                    const scrubKey = c.isBound ? (c.inputId!) : (c.targetId || `static-${type}-${labelKey}`);
+                    const scrubKey = c.isBound
+                      ? c.inputId!
+                      : c.targetId || `static-${type}-${labelKey}`;
                     const startVal = scrubValuesRef.current[scrubKey] ?? 0;
                     const nextVal = startVal + totalDelta * step;
 
                     if (type === "current") {
-                      if (c.isBound && c.inputId) onValueChange(c.inputId, nextVal);
+                      if (c.isBound && c.inputId)
+                        onValueChange(c.inputId, nextVal);
                       else if (onStaticValueChange) {
                         if (feature.animated && feature.animatableId) {
-                          onStaticValueChange(feature.animatableId, nextVal, c.label.toLowerCase());
+                          onStaticValueChange(
+                            feature.animatableId,
+                            nextVal,
+                            c.label.toLowerCase(),
+                          );
                         } else if (setStaticFeatureValue && node) {
                           const current = (feature.staticValue as any) || {};
                           setStaticFeatureValue(node.id, feature.id, {
@@ -762,26 +850,42 @@ export function RiggingColorRow({
                         }
                       }
                     } else if (type === "default" && c.inputId) {
-                      onUpdateStandardInput(c.inputId, { defaultValue: nextVal });
+                      onUpdateStandardInput(c.inputId, {
+                        defaultValue: nextVal,
+                      });
                     } else if (c.inputId || feature.animatableId) {
                       if (c.isBound && c.inputId) {
-                        onUpdateStandardInput(c.inputId, { range: { [type]: nextVal } });
-                      } else if (feature.animatableId) {
-                        onConstraintChange?.(feature.animatableId, (curr: AnimatableValue) => {
-                          const nextConstraints = { ...(curr.constraints || {}) } as any;
-                          const kind = type === "min" ? "min" : "max";
-                          const currentVal = nextConstraints[kind] || {};
-                          nextConstraints[kind] = {
-                            ...(typeof currentVal === "object" ? currentVal : {}),
-                            [c.label.toLowerCase()]: nextVal,
-                          } as any;
-                          return { ...curr, constraints: nextConstraints } as AnimatableValue;
+                        onUpdateStandardInput(c.inputId, {
+                          range: { [type]: nextVal },
                         });
+                      } else if (feature.animatableId) {
+                        onConstraintChange?.(
+                          feature.animatableId,
+                          (curr: AnimatableValue) => {
+                            const nextConstraints = {
+                              ...(curr.constraints || {}),
+                            } as any;
+                            const kind = type === "min" ? "min" : "max";
+                            const currentVal = nextConstraints[kind] || {};
+                            nextConstraints[kind] = {
+                              ...(typeof currentVal === "object"
+                                ? currentVal
+                                : {}),
+                              [c.label.toLowerCase()]: nextVal,
+                            } as any;
+                            return {
+                              ...curr,
+                              constraints: nextConstraints,
+                            } as AnimatableValue;
+                          },
+                        );
                       }
                     }
                   }}
                   onScrubStart={() => {
-                    const scrubKey = c.isBound ? (c.inputId!) : (c.targetId || `static-${type}-${labelKey}`);
+                    const scrubKey = c.isBound
+                      ? c.inputId!
+                      : c.targetId || `static-${type}-${labelKey}`;
                     scrubValuesRef.current[scrubKey] = (compVal as number) ?? 0;
                   }}
                   className={cn(
@@ -804,7 +908,11 @@ export function RiggingColorRow({
                       if (c.isBound && c.inputId) onValueChange(c.inputId, num);
                       else if (onStaticValueChange) {
                         if (feature.animated && feature.animatableId) {
-                          onStaticValueChange(feature.animatableId, num, c.label.toLowerCase());
+                          onStaticValueChange(
+                            feature.animatableId,
+                            num,
+                            c.label.toLowerCase(),
+                          );
                         } else if (setStaticFeatureValue && node) {
                           const current = (feature.staticValue as any) || {};
                           setStaticFeatureValue(node.id, feature.id, {
@@ -817,18 +925,30 @@ export function RiggingColorRow({
                       onUpdateStandardInput(c.inputId, { defaultValue: num });
                     } else if (c.inputId || feature.animatableId) {
                       if (c.isBound && c.inputId) {
-                        onUpdateStandardInput(c.inputId, { range: { [type]: num } });
-                      } else if (feature.animatableId) {
-                        onConstraintChange?.(feature.animatableId, (curr: AnimatableValue) => {
-                          const nextConstraints = { ...(curr.constraints || {}) } as any;
-                          const kind = type === "min" ? "min" : "max";
-                          const currentVal = nextConstraints[kind] || {};
-                          nextConstraints[kind] = {
-                            ...(typeof currentVal === "object" ? currentVal : {}),
-                            [c.label.toLowerCase()]: num,
-                          } as any;
-                          return { ...curr, constraints: nextConstraints } as AnimatableValue;
+                        onUpdateStandardInput(c.inputId, {
+                          range: { [type]: num },
                         });
+                      } else if (feature.animatableId) {
+                        onConstraintChange?.(
+                          feature.animatableId,
+                          (curr: AnimatableValue) => {
+                            const nextConstraints = {
+                              ...(curr.constraints || {}),
+                            } as any;
+                            const kind = type === "min" ? "min" : "max";
+                            const currentVal = nextConstraints[kind] || {};
+                            nextConstraints[kind] = {
+                              ...(typeof currentVal === "object"
+                                ? currentVal
+                                : {}),
+                              [c.label.toLowerCase()]: num,
+                            } as any;
+                            return {
+                              ...curr,
+                              constraints: nextConstraints,
+                            } as AnimatableValue;
+                          },
+                        );
                       }
                     }
                   }}

--- a/apps/vizij-authoring/src/components/inspector/RiggingMorphTargetsSection.tsx
+++ b/apps/vizij-authoring/src/components/inspector/RiggingMorphTargetsSection.tsx
@@ -1,15 +1,14 @@
 import React, { useMemo, useRef, useCallback } from "react";
 import { Lock, LockOpen } from "lucide-react";
 import type { StandardRigInput, AnimatableValue } from "@vizij/utils";
-
 import type { SceneObjectNode } from "../../scene/sceneGraph";
 import { cn } from "../../utils/cn";
 import {
   useBindingAuthoring,
   useGraphRuntime,
 } from "../../state/RigControllerProvider";
-import { RiggingPropertyRow, ScrubbableLabel } from "./RiggingPropertyRow";
 import { useSceneComposer } from "../../scene/useSceneComposer";
+import { RiggingPropertyRow, ScrubbableLabel } from "./RiggingPropertyRow";
 import { resolveEffectiveControllableBindingStandardInput } from "./bindingSlotResolution";
 
 interface RiggingMorphTargetsSectionProps {

--- a/apps/vizij-authoring/src/components/inspector/RiggingMorphTargetsSection.tsx
+++ b/apps/vizij-authoring/src/components/inspector/RiggingMorphTargetsSection.tsx
@@ -5,14 +5,12 @@ import type { StandardRigInput, AnimatableValue } from "@vizij/utils";
 import type { SceneObjectNode } from "../../scene/sceneGraph";
 import { cn } from "../../utils/cn";
 import {
-
   useBindingAuthoring,
   useGraphRuntime,
 } from "../../state/RigControllerProvider";
 import { RiggingPropertyRow, ScrubbableLabel } from "./RiggingPropertyRow";
 import { useSceneComposer } from "../../scene/useSceneComposer";
 import { resolveEffectiveControllableBindingStandardInput } from "./bindingSlotResolution";
-
 
 interface RiggingMorphTargetsSectionProps {
   node: SceneObjectNode;
@@ -40,7 +38,6 @@ export function RiggingMorphTargetsSection({
     setStaticFeatureValue,
   } = useSceneComposer();
 
-
   const handleStaticValueChange = (
     targetId: string,
     value: number,
@@ -48,8 +45,6 @@ export function RiggingMorphTargetsSection({
   ) => {
     setAnimatableValue(targetId, value, { channel, saveToDefault: true });
   };
-
-
 
   // Get morph targets from runtime
   const morphTargetKeys = useGraphRuntime((state) => {
@@ -94,17 +89,15 @@ export function RiggingMorphTargetsSection({
           onDefaultChange={(id, val) =>
             handleUpdateStandardInput(id, { defaultValue: val })
           }
-          onToggleAnimated={(animated) => setFeatureAnimated(node.id, feature.id, animated)}
+          onToggleAnimated={(animated) =>
+            setFeatureAnimated(node.id, feature.id, animated)
+          }
           onConstraintChange={updateAnimatableDescriptor}
           onStaticValueChange={handleStaticValueChange}
           onUpdateStandardInput={handleUpdateStandardInput}
           setStaticFeatureValue={setStaticFeatureValue}
           node={node}
         />
-
-
-
-
       ))}
     </div>
   );
@@ -125,20 +118,23 @@ interface RiggingScalarRowProps {
   onValueChange: (id: string, value: number) => void;
   onDefaultChange: (id: string, value: number) => void;
   onToggleAnimated: (animated: boolean) => void;
-  onConstraintChange: (id: string, updater: (curr: AnimatableValue) => AnimatableValue) => void;
-  onStaticValueChange?: (targetId: string, value: number, channel?: string) => void;
+  onConstraintChange: (
+    id: string,
+    updater: (curr: AnimatableValue) => AnimatableValue,
+  ) => void;
+  onStaticValueChange?: (
+    targetId: string,
+    value: number,
+    channel?: string,
+  ) => void;
   onUpdateStandardInput: (id: string, updates: any) => void;
-  setStaticFeatureValue?: (nodeId: string, featureId: string, value: any) => void;
+  setStaticFeatureValue?: (
+    nodeId: string,
+    featureId: string,
+    value: any,
+  ) => void;
   node?: SceneObjectNode;
 }
-
-
-
-
-
-
-
-
 
 function RiggingScalarRow({
   label,
@@ -157,11 +153,6 @@ function RiggingScalarRow({
   setStaticFeatureValue,
   node,
 }: RiggingScalarRowProps) {
-
-
-
-
-
   const scrubValuesRef = useRef<Record<string, number>>({});
   const component = feature.components[0];
   if (!component) return null;
@@ -190,41 +181,44 @@ function RiggingScalarRow({
   const isBound = !!inputId && !blockedReason;
   const canEdit = isBound || !!onStaticValueChange;
 
-
-  const minVal = hasInputMetadata ? (standardInput!.range.min) : ((feature.descriptor?.constraints as any)?.min ?? 0);
-  const maxVal = hasInputMetadata ? (standardInput!.range.max) : ((feature.descriptor?.constraints as any)?.max ?? 0);
-
+  const minVal = hasInputMetadata
+    ? standardInput!.range.min
+    : ((feature.descriptor?.constraints as any)?.min ?? 0);
+  const maxVal = hasInputMetadata
+    ? standardInput!.range.max
+    : ((feature.descriptor?.constraints as any)?.max ?? 0);
 
   const currentValue = isBound
     ? (inputValues[inputId!] ?? standardInput?.defaultValue ?? 0)
     : (component.staticValue ?? 0);
 
-
   const defaultValue = isBound
     ? (standardInput?.defaultValue ?? 0)
     : (component.staticValue ?? 0);
 
-
-
   const hasDifferentDefault =
     hasInputMetadata &&
     Math.abs((currentValue as number) - (defaultValue as number)) > 0.0001;
-
 
   const handleReset = () => {
     if (isBound && inputId) onValueChange(inputId, defaultValue as number);
   };
 
   const handleSaveToDefault = () => {
-    if (isBound && inputId) onUpdateStandardInput(inputId, { defaultValue: currentValue as number });
+    if (isBound && inputId)
+      onUpdateStandardInput(inputId, { defaultValue: currentValue as number });
   };
 
-  const hasMinChanged = Math.abs((currentValue as number) - (minVal as number)) > 0.0001;
-  const hasMaxChanged = Math.abs((currentValue as number) - (maxVal as number)) > 0.0001;
+  const hasMinChanged =
+    Math.abs((currentValue as number) - (minVal as number)) > 0.0001;
+  const hasMaxChanged =
+    Math.abs((currentValue as number) - (maxVal as number)) > 0.0001;
 
   const handleSaveToMin = () => {
     if (isBound && inputId) {
-      onUpdateStandardInput(inputId, { range: { min: currentValue as number } });
+      onUpdateStandardInput(inputId, {
+        range: { min: currentValue as number },
+      });
     } else if (feature.animatableId) {
       onConstraintChange(feature.animatableId, (curr: AnimatableValue) => {
         const nextConstraints = { ...(curr.constraints || {}) } as any;
@@ -232,12 +226,13 @@ function RiggingScalarRow({
         return { ...curr, constraints: nextConstraints } as AnimatableValue;
       });
     }
-
   };
 
   const handleSaveToMax = () => {
     if (isBound && inputId) {
-      onUpdateStandardInput(inputId, { range: { max: currentValue as number } });
+      onUpdateStandardInput(inputId, {
+        range: { max: currentValue as number },
+      });
     } else if (feature.animatableId) {
       onConstraintChange(feature.animatableId, (curr: AnimatableValue) => {
         const nextConstraints = { ...(curr.constraints || {}) } as any;
@@ -245,9 +240,7 @@ function RiggingScalarRow({
         return { ...curr, constraints: nextConstraints } as AnimatableValue;
       });
     }
-
   };
-
 
   const renderInput = (type: "current" | "default" | "min" | "max") => {
     let val: number | undefined;
@@ -257,8 +250,6 @@ function RiggingScalarRow({
       val = currentValue;
       canEdit = isBound || !!onStaticValueChange;
     } else if (type === "default") {
-
-
       val = defaultValue;
       canEdit = isBound;
     } else if (type === "min") {
@@ -268,7 +259,6 @@ function RiggingScalarRow({
       val = maxVal;
       canEdit = true;
     }
-
 
     return (
       <div
@@ -294,40 +284,48 @@ function RiggingScalarRow({
                   setStaticFeatureValue(node.id, feature.id, newVal);
                 }
               }
-
             } else if (type === "default" && inputId) {
-
-
               const startVal = scrubValuesRef.current[inputId] ?? 0;
               onDefaultChange(inputId, startVal + totalDelta * step);
-            } else if ((type === "min" || type === "max") && (inputId || feature.animatableId)) {
+            } else if (
+              (type === "min" || type === "max") &&
+              (inputId || feature.animatableId)
+            ) {
               const startVal = scrubValuesRef.current[type] ?? 0;
               const nextVal = startVal + totalDelta * step;
               if (isBound && inputId) {
                 onUpdateStandardInput(inputId, { range: { [type]: nextVal } });
               } else if (feature.animatableId) {
-                onConstraintChange(feature.animatableId, (curr: AnimatableValue) => {
-                  const nextConstraints = { ...(curr.constraints || {}) } as any;
-                  nextConstraints[type === "min" ? "min" : "max"] = nextVal;
-                  return { ...curr, constraints: nextConstraints } as AnimatableValue;
-                });
+                onConstraintChange(
+                  feature.animatableId,
+                  (curr: AnimatableValue) => {
+                    const nextConstraints = {
+                      ...(curr.constraints || {}),
+                    } as any;
+                    nextConstraints[type === "min" ? "min" : "max"] = nextVal;
+                    return {
+                      ...curr,
+                      constraints: nextConstraints,
+                    } as AnimatableValue;
+                  },
+                );
               }
-
             }
-
           }}
           onScrubStart={() => {
             if (type === "current") {
-              if (isBound && inputId) scrubValuesRef.current[inputId] = currentValue ?? 0;
+              if (isBound && inputId)
+                scrubValuesRef.current[inputId] = currentValue ?? 0;
               else scrubValuesRef.current["current"] = currentValue ?? 0;
             } else if (type === "default" && inputId) {
-
-
               scrubValuesRef.current[inputId] = defaultValue ?? 0;
-            } else if ((type === "min" || type === "max") && (inputId || feature.animatableId)) {
-              scrubValuesRef.current[type] = (type === "min" ? minVal : maxVal) ?? 0;
+            } else if (
+              (type === "min" || type === "max") &&
+              (inputId || feature.animatableId)
+            ) {
+              scrubValuesRef.current[type] =
+                (type === "min" ? minVal : maxVal) ?? 0;
             }
-
           }}
           className="text-[9px] font-bold px-1 select-none transition-colors text-text-muted"
         />
@@ -336,7 +334,6 @@ function RiggingScalarRow({
           className="w-full bg-transparent border-0 text-[10px] p-0 h-5 focus:ring-0 text-text-primary placeholder-text-muted no-spinners font-mono leading-none pl-1"
           value={typeof val === "number" ? val : 0}
           step={0.01}
-
           disabled={!canEdit}
           onChange={(e) => {
             const num = parseFloat(e.target.value);
@@ -353,22 +350,29 @@ function RiggingScalarRow({
                 }
               }
             } else if (type === "default" && inputId) {
-
-
               onDefaultChange(inputId, num);
-            } else if ((type === "min" || type === "max") && (inputId || feature.animatableId)) {
+            } else if (
+              (type === "min" || type === "max") &&
+              (inputId || feature.animatableId)
+            ) {
               if (isBound && inputId) {
                 onUpdateStandardInput(inputId, { range: { [type]: num } });
               } else if (feature.animatableId) {
-                onConstraintChange(feature.animatableId, (curr: AnimatableValue) => {
-                  const nextConstraints = { ...(curr.constraints || {}) } as any;
-                  nextConstraints[type === "min" ? "min" : "max"] = num;
-                  return { ...curr, constraints: nextConstraints } as AnimatableValue;
-                });
+                onConstraintChange(
+                  feature.animatableId,
+                  (curr: AnimatableValue) => {
+                    const nextConstraints = {
+                      ...(curr.constraints || {}),
+                    } as any;
+                    nextConstraints[type === "min" ? "min" : "max"] = num;
+                    return {
+                      ...curr,
+                      constraints: nextConstraints,
+                    } as AnimatableValue;
+                  },
+                );
               }
-
             }
-
           }}
         />
       </div>
@@ -396,7 +400,6 @@ function RiggingScalarRow({
     </div>
   );
 
-
   return (
     <RiggingPropertyRow
       label={label}
@@ -415,4 +418,3 @@ function RiggingScalarRow({
     />
   );
 }
-

--- a/apps/vizij-authoring/src/components/inspector/RiggingMorphTargetsSection.tsx
+++ b/apps/vizij-authoring/src/components/inspector/RiggingMorphTargetsSection.tsx
@@ -1,12 +1,18 @@
-import React, { useMemo, useRef } from "react";
-import type { StandardRigInput } from "@vizij/utils";
+import React, { useMemo, useRef, useCallback } from "react";
+import { Lock, LockOpen } from "lucide-react";
+import type { StandardRigInput, AnimatableValue } from "@vizij/utils";
+
 import type { SceneObjectNode } from "../../scene/sceneGraph";
+import { cn } from "../../utils/cn";
 import {
+
   useBindingAuthoring,
   useGraphRuntime,
 } from "../../state/RigControllerProvider";
 import { RiggingPropertyRow, ScrubbableLabel } from "./RiggingPropertyRow";
+import { useSceneComposer } from "../../scene/useSceneComposer";
 import { resolveEffectiveControllableBindingStandardInput } from "./bindingSlotResolution";
+
 
 interface RiggingMorphTargetsSectionProps {
   node: SceneObjectNode;
@@ -26,6 +32,24 @@ export function RiggingMorphTargetsSection({
     handleInputValueChange,
     handleUpdateStandardInput,
   } = useBindingAuthoring((state) => state);
+
+  const {
+    setFeatureAnimated,
+    updateAnimatableDescriptor,
+    setAnimatableValue,
+    setStaticFeatureValue,
+  } = useSceneComposer();
+
+
+  const handleStaticValueChange = (
+    targetId: string,
+    value: number,
+    channel?: string,
+  ) => {
+    setAnimatableValue(targetId, value, { channel, saveToDefault: true });
+  };
+
+
 
   // Get morph targets from runtime
   const morphTargetKeys = useGraphRuntime((state) => {
@@ -70,7 +94,17 @@ export function RiggingMorphTargetsSection({
           onDefaultChange={(id, val) =>
             handleUpdateStandardInput(id, { defaultValue: val })
           }
+          onToggleAnimated={(animated) => setFeatureAnimated(node.id, feature.id, animated)}
+          onConstraintChange={updateAnimatableDescriptor}
+          onStaticValueChange={handleStaticValueChange}
+          onUpdateStandardInput={handleUpdateStandardInput}
+          setStaticFeatureValue={setStaticFeatureValue}
+          node={node}
         />
+
+
+
+
       ))}
     </div>
   );
@@ -90,7 +124,21 @@ interface RiggingScalarRowProps {
   inputValues: Record<string, number>;
   onValueChange: (id: string, value: number) => void;
   onDefaultChange: (id: string, value: number) => void;
+  onToggleAnimated: (animated: boolean) => void;
+  onConstraintChange: (id: string, updater: (curr: AnimatableValue) => AnimatableValue) => void;
+  onStaticValueChange?: (targetId: string, value: number, channel?: string) => void;
+  onUpdateStandardInput: (id: string, updates: any) => void;
+  setStaticFeatureValue?: (nodeId: string, featureId: string, value: any) => void;
+  node?: SceneObjectNode;
 }
+
+
+
+
+
+
+
+
 
 function RiggingScalarRow({
   label,
@@ -102,7 +150,18 @@ function RiggingScalarRow({
   inputValues,
   onValueChange,
   onDefaultChange,
+  onToggleAnimated,
+  onConstraintChange,
+  onStaticValueChange,
+  onUpdateStandardInput,
+  setStaticFeatureValue,
+  node,
 }: RiggingScalarRowProps) {
+
+
+
+
+
   const scrubValuesRef = useRef<Record<string, number>>({});
   const component = feature.components[0];
   if (!component) return null;
@@ -127,89 +186,233 @@ function RiggingScalarRow({
     blockedReason = resolved.blockedReason;
   }
 
-  const isBound = !!(inputId && standardInput) && !blockedReason;
+  const hasInputMetadata = !!(inputId && standardInput);
+  const isBound = !!inputId && !blockedReason;
+  const canEdit = isBound || !!onStaticValueChange;
+
+
+  const minVal = hasInputMetadata ? (standardInput!.range.min) : ((feature.descriptor?.constraints as any)?.min ?? 0);
+  const maxVal = hasInputMetadata ? (standardInput!.range.max) : ((feature.descriptor?.constraints as any)?.max ?? 0);
+
+
   const currentValue = isBound
-    ? (inputValues[inputId!] ?? standardInput!.defaultValue ?? 0)
+    ? (inputValues[inputId!] ?? standardInput?.defaultValue ?? 0)
     : (component.staticValue ?? 0);
+
 
   const defaultValue = isBound
-    ? (standardInput!.defaultValue ?? 0)
+    ? (standardInput?.defaultValue ?? 0)
     : (component.staticValue ?? 0);
 
+
+
   const hasDifferentDefault =
-    isBound &&
+    hasInputMetadata &&
     Math.abs((currentValue as number) - (defaultValue as number)) > 0.0001;
+
 
   const handleReset = () => {
     if (isBound && inputId) onValueChange(inputId, defaultValue as number);
   };
 
   const handleSaveToDefault = () => {
-    if (isBound && inputId) onDefaultChange(inputId, currentValue as number);
+    if (isBound && inputId) onUpdateStandardInput(inputId, { defaultValue: currentValue as number });
   };
 
-  const renderInput = (isDefault: boolean) => {
-    const val = isDefault ? defaultValue : currentValue;
-    const canEdit = isBound;
+  const hasMinChanged = Math.abs((currentValue as number) - (minVal as number)) > 0.0001;
+  const hasMaxChanged = Math.abs((currentValue as number) - (maxVal as number)) > 0.0001;
+
+  const handleSaveToMin = () => {
+    if (isBound && inputId) {
+      onUpdateStandardInput(inputId, { range: { min: currentValue as number } });
+    } else if (feature.animatableId) {
+      onConstraintChange(feature.animatableId, (curr: AnimatableValue) => {
+        const nextConstraints = { ...(curr.constraints || {}) } as any;
+        nextConstraints.min = currentValue;
+        return { ...curr, constraints: nextConstraints } as AnimatableValue;
+      });
+    }
+
+  };
+
+  const handleSaveToMax = () => {
+    if (isBound && inputId) {
+      onUpdateStandardInput(inputId, { range: { max: currentValue as number } });
+    } else if (feature.animatableId) {
+      onConstraintChange(feature.animatableId, (curr: AnimatableValue) => {
+        const nextConstraints = { ...(curr.constraints || {}) } as any;
+        nextConstraints.max = currentValue;
+        return { ...curr, constraints: nextConstraints } as AnimatableValue;
+      });
+    }
+
+  };
+
+
+  const renderInput = (type: "current" | "default" | "min" | "max") => {
+    let val: number | undefined;
+    let canEdit = true;
+
+    if (type === "current") {
+      val = currentValue;
+      canEdit = isBound || !!onStaticValueChange;
+    } else if (type === "default") {
+
+
+      val = defaultValue;
+      canEdit = isBound;
+    } else if (type === "min") {
+      val = minVal;
+      canEdit = true;
+    } else if (type === "max") {
+      val = maxVal;
+      canEdit = true;
+    }
+
+
     return (
       <div
-        className={`flex items-center bg-zinc-950/50 rounded-sm border border-transparent ${canEdit ? "focus-within:border-blue-500/50" : "opacity-70"} relative flex-1 min-w-0 h-5 group/row`}
+        className={cn(
+          "flex items-center bg-bg-input/50 rounded-sm border border-transparent relative flex-1 min-w-0 h-5 group/row",
+          canEdit ? "focus-within:border-accent/50" : "opacity-70",
+        )}
       >
         <ScrubbableLabel
           label={label}
           onScrub={(delta: number, totalDelta: number) => {
-            if (inputId) {
-              const step = 0.01;
+            const step = 0.01;
+            if (type === "current") {
+              if (isBound && inputId) {
+                const startVal = scrubValuesRef.current[inputId] ?? 0;
+                onValueChange(inputId, startVal + totalDelta * step);
+              } else if (onStaticValueChange) {
+                const startVal = scrubValuesRef.current["current"] ?? 0;
+                const newVal = startVal + totalDelta * step;
+                if (feature.animated && feature.animatableId) {
+                  onStaticValueChange(feature.animatableId, newVal);
+                } else if (setStaticFeatureValue && node) {
+                  setStaticFeatureValue(node.id, feature.id, newVal);
+                }
+              }
+
+            } else if (type === "default" && inputId) {
+
+
               const startVal = scrubValuesRef.current[inputId] ?? 0;
+              onDefaultChange(inputId, startVal + totalDelta * step);
+            } else if ((type === "min" || type === "max") && (inputId || feature.animatableId)) {
+              const startVal = scrubValuesRef.current[type] ?? 0;
               const nextVal = startVal + totalDelta * step;
-              if (isDefault) onDefaultChange(inputId, nextVal);
-              else onValueChange(inputId, nextVal);
+              if (isBound && inputId) {
+                onUpdateStandardInput(inputId, { range: { [type]: nextVal } });
+              } else if (feature.animatableId) {
+                onConstraintChange(feature.animatableId, (curr: AnimatableValue) => {
+                  const nextConstraints = { ...(curr.constraints || {}) } as any;
+                  nextConstraints[type === "min" ? "min" : "max"] = nextVal;
+                  return { ...curr, constraints: nextConstraints } as AnimatableValue;
+                });
+              }
+
             }
+
           }}
           onScrubStart={() => {
-            if (inputId) {
-              const baseline = isDefault ? defaultValue : currentValue;
-              scrubValuesRef.current[inputId] = (baseline as number) ?? 0;
+            if (type === "current") {
+              if (isBound && inputId) scrubValuesRef.current[inputId] = currentValue ?? 0;
+              else scrubValuesRef.current["current"] = currentValue ?? 0;
+            } else if (type === "default" && inputId) {
+
+
+              scrubValuesRef.current[inputId] = defaultValue ?? 0;
+            } else if ((type === "min" || type === "max") && (inputId || feature.animatableId)) {
+              scrubValuesRef.current[type] = (type === "min" ? minVal : maxVal) ?? 0;
             }
+
           }}
-          className="text-[9px] font-bold px-1 select-none transition-colors text-zinc-500"
+          className="text-[9px] font-bold px-1 select-none transition-colors text-text-muted"
         />
         <input
           type="number"
-          className="w-full bg-transparent border-0 text-[10px] p-0 h-5 focus:ring-0 text-zinc-300 placeholder-zinc-600 no-spinners font-mono leading-none pl-1"
-          value={typeof val === "number" ? parseFloat(val.toFixed(2)) : 0}
-          step={0.1}
+          className="w-full bg-transparent border-0 text-[10px] p-0 h-5 focus:ring-0 text-text-primary placeholder-text-muted no-spinners font-mono leading-none pl-1"
+          value={typeof val === "number" ? val : 0}
+          step={0.01}
+
           disabled={!canEdit}
-          title={
-            !canEdit
-              ? blockedReason
-                ? blockedReason
-                : unresolvedInputId
-                  ? `Driver "${unresolvedInputId}" is unresolved. Open My Drivers to remap.`
-                  : "Value is not driven by a rig input"
-              : undefined
-          }
           onChange={(e) => {
-            if (!canEdit || !inputId) return;
             const num = parseFloat(e.target.value);
-            if (!isNaN(num)) {
-              if (isDefault) onDefaultChange(inputId, num);
-              else onValueChange(inputId, num);
+            if (isNaN(num)) return;
+
+            if (type === "current") {
+              if (isBound && inputId) {
+                onValueChange(inputId, num);
+              } else if (onStaticValueChange) {
+                if (feature.animated && feature.animatableId) {
+                  onStaticValueChange(feature.animatableId, num);
+                } else if (setStaticFeatureValue && node) {
+                  setStaticFeatureValue(node.id, feature.id, num);
+                }
+              }
+            } else if (type === "default" && inputId) {
+
+
+              onDefaultChange(inputId, num);
+            } else if ((type === "min" || type === "max") && (inputId || feature.animatableId)) {
+              if (isBound && inputId) {
+                onUpdateStandardInput(inputId, { range: { [type]: num } });
+              } else if (feature.animatableId) {
+                onConstraintChange(feature.animatableId, (curr: AnimatableValue) => {
+                  const nextConstraints = { ...(curr.constraints || {}) } as any;
+                  nextConstraints[type === "min" ? "min" : "max"] = num;
+                  return { ...curr, constraints: nextConstraints } as AnimatableValue;
+                });
+              }
+
             }
+
           }}
         />
       </div>
     );
   };
 
+  const renderAnimatableRow = () => (
+    <div className="flex gap-1.5 flex-1">
+      <button
+        className={cn(
+          "flex items-center justify-center gap-1.5 flex-1 h-5 rounded-sm border border-transparent transition-colors text-[10px] font-bold uppercase tracking-wider",
+          feature.animated
+            ? "bg-accent/10 text-accent hover:bg-accent/20"
+            : "bg-bg-input/50 text-text-muted hover:bg-bg-input/70",
+        )}
+        onClick={() => onToggleAnimated(!feature.animated)}
+      >
+        {feature.animated ? (
+          <LockOpen size={10} className="shrink-0" />
+        ) : (
+          <Lock size={10} className="shrink-0" />
+        )}
+        <span>Value</span>
+      </button>
+    </div>
+  );
+
+
   return (
     <RiggingPropertyRow
       label={label}
       hasDifferentDefault={hasDifferentDefault}
+      hasMinChanged={hasMinChanged}
+      hasMaxChanged={hasMaxChanged}
       onResetToDefault={handleReset}
       onSaveToDefault={handleSaveToDefault}
-      renderMainInput={() => renderInput(false)}
-      renderDefaultInput={() => renderInput(true)}
+      onSaveToMin={handleSaveToMin}
+      onSaveToMax={handleSaveToMax}
+      renderMainInput={() => renderInput("current")}
+      renderDefaultInput={() => renderInput("default")}
+      renderMinInput={() => renderInput("min")}
+      renderMaxInput={() => renderInput("max")}
+      renderAnimatableRow={renderAnimatableRow}
     />
   );
 }
+

--- a/apps/vizij-authoring/src/components/inspector/RiggingPropertyRow.tsx
+++ b/apps/vizij-authoring/src/components/inspector/RiggingPropertyRow.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect } from "react";
-import { ChevronRight, ChevronDown, RotateCcw, Save } from "lucide-react";
+import { Pencil, X, RotateCcw, Save } from "lucide-react";
+
 import { Button as BaseButton } from "@base-ui/react";
 import { cn } from "../../utils/cn";
 
@@ -9,6 +10,9 @@ export interface RiggingPropertyRowProps {
   onExpandedChange?: (expanded: boolean) => void;
   renderMainInput: () => React.ReactNode;
   renderDefaultInput?: () => React.ReactNode;
+  renderMinInput?: () => React.ReactNode;
+  renderMaxInput?: () => React.ReactNode;
+  renderAnimatableRow?: () => React.ReactNode;
   defaultLabel?: string;
   hasDifferentDefault?: boolean;
   onResetToDefault?: () => void;
@@ -16,7 +20,15 @@ export interface RiggingPropertyRowProps {
   onScrubStart?: () => void;
   onScrubEnd?: () => void;
   onSaveToDefault?: () => void;
+  onSaveToMin?: () => void;
+  onSaveToMax?: () => void;
+  hasMinChanged?: boolean;
+  hasMaxChanged?: boolean;
+
+
   className?: string;
+
+
   icon?: React.ReactNode;
 }
 
@@ -115,10 +127,20 @@ export function RiggingPropertyRow({
   onExpandedChange,
   renderMainInput,
   renderDefaultInput,
+  renderMinInput,
+  renderMaxInput,
+  renderAnimatableRow,
   defaultLabel = "Def",
+
   hasDifferentDefault,
   onResetToDefault,
   onSaveToDefault,
+  onSaveToMin,
+  onSaveToMax,
+  hasMinChanged,
+  hasMaxChanged,
+
+
   onScrub,
   onScrubStart,
   onScrubEnd,
@@ -155,11 +177,8 @@ export function RiggingPropertyRow({
                 isExpanded && "text-text-primary",
               )}
             >
-              {isExpanded ? (
-                <ChevronDown size={12} />
-              ) : (
-                <ChevronRight size={12} />
-              )}
+              {isExpanded ? <X size={12} /> : <Pencil size={11} />}
+
             </BaseButton>
           ) : (
             <div className="w-3.5 flex justify-center text-zinc-500">
@@ -192,42 +211,134 @@ export function RiggingPropertyRow({
                 e.preventDefault();
                 onResetToDefault();
               }}
-              className="ml-1 text-zinc-500 hover:text-white p-1 hover:bg-white/10 rounded cursor-pointer transition-opacity"
+              className={cn(
+                "ml-1 p-1 rounded cursor-pointer transition-colors",
+                hasDifferentDefault ? "text-accent hover:text-accent-hover hover:bg-accent/10" : "text-zinc-600 cursor-default opacity-40 hover:bg-transparent"
+              )}
               title="Reset to default"
+              disabled={!hasDifferentDefault}
             >
               <RotateCcw size={10} />
             </BaseButton>
           )}
+
         </div>
       </div>
 
-      {isExpanded && renderDefaultInput && (
-        <div className="flex flex-col @[300px]:flex-row @[300px]:items-center gap-2 px-1.5 pb-2 pt-1 border-t border-white/5 mt-0.5 bg-black/20">
-          <div className="@[300px]:w-20 w-full flex-shrink-0 @[300px]:pl-4 flex items-center pl-6">
-            <span className="text-[9px] uppercase font-bold text-text-secondary tracking-wider">
-              {defaultLabel}
-            </span>
-          </div>
+      {isExpanded && (
+        <div className="flex flex-col gap-0.5 border-t border-white/5 mt-0.5 bg-black/20 pb-1.5">
+          {renderDefaultInput && (
+            <div className="flex flex-col @[300px]:flex-row @[300px]:items-center gap-2 px-1.5 pt-1">
+              <div className="@[300px]:w-20 w-full flex-shrink-0 @[300px]:pl-4 flex items-center pl-6">
+                <span className="text-[9px] uppercase font-bold text-text-secondary tracking-wider">
+                  {defaultLabel}
+                </span>
+              </div>
 
-          <div className="flex-1 min-w-0 flex items-center gap-1 w-full @[300px]:w-auto">
-            <div className="flex-1 min-w-0">{renderDefaultInput()}</div>
+              <div className="flex-1 min-w-0 flex items-center gap-1 w-full @[300px]:w-auto">
+                <div className="flex-1 min-w-0">{renderDefaultInput()}</div>
 
-            {hasDifferentDefault && onSaveToDefault && (
-              <BaseButton
-                onClick={(e) => {
-                  e.stopPropagation();
-                  e.preventDefault();
-                  onSaveToDefault();
-                }}
-                className="ml-1 p-1 text-accent hover:text-accent-hover hover:bg-accent-subtle rounded transition-colors flex-shrink-0"
-                title="Save to default"
-              >
-                <Save size={12} />
-              </BaseButton>
-            )}
-          </div>
+                {onSaveToDefault && (
+                  <BaseButton
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      e.preventDefault();
+                      onSaveToDefault();
+                    }}
+                    className={cn(
+                      "ml-1 p-1 rounded transition-colors flex-shrink-0",
+                      hasDifferentDefault ? "text-accent hover:text-accent-hover hover:bg-accent-subtle" : "text-zinc-600 cursor-default opacity-40 hover:bg-transparent"
+                    )}
+                    title="Save to default"
+                    disabled={!hasDifferentDefault}
+                  >
+                    <Save size={12} />
+                  </BaseButton>
+                )}
+
+              </div>
+            </div>
+          )}
+
+          {renderMinInput && (
+            <div className="flex flex-col @[300px]:flex-row @[300px]:items-center gap-2 px-1.5 pt-1">
+              <div className="@[300px]:w-20 w-full flex-shrink-0 @[300px]:pl-4 flex items-center pl-6">
+                <span className="text-[9px] uppercase font-bold text-text-secondary tracking-wider">
+                  Min
+                </span>
+              </div>
+              <div className="flex-1 min-w-0 flex items-center gap-1 w-full @[300px]:w-auto">
+                <div className="flex-1 min-w-0">{renderMinInput()}</div>
+                {onSaveToMin && (
+                  <BaseButton
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      e.preventDefault();
+                      onSaveToMin();
+                    }}
+                    className={cn(
+                      "ml-1 p-1 rounded transition-colors flex-shrink-0",
+                      hasMinChanged ? "text-accent hover:text-accent-hover hover:bg-accent-subtle" : "text-zinc-600 cursor-default opacity-40 hover:bg-transparent"
+                    )}
+                    title="Save current to min"
+                    disabled={!hasMinChanged}
+                  >
+                    <Save size={12} />
+                  </BaseButton>
+                )}
+
+              </div>
+
+            </div>
+          )}
+
+          {renderMaxInput && (
+            <div className="flex flex-col @[300px]:flex-row @[300px]:items-center gap-2 px-1.5 pt-1">
+              <div className="@[300px]:w-20 w-full flex-shrink-0 @[300px]:pl-4 flex items-center pl-6">
+                <span className="text-[9px] uppercase font-bold text-text-secondary tracking-wider">
+                  Max
+                </span>
+              </div>
+              <div className="flex-1 min-w-0 flex items-center gap-1 w-full @[300px]:w-auto">
+                <div className="flex-1 min-w-0">{renderMaxInput()}</div>
+                {onSaveToMax && (
+                  <BaseButton
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      e.preventDefault();
+                      onSaveToMax();
+                    }}
+                    className={cn(
+                      "ml-1 p-1 rounded transition-colors flex-shrink-0",
+                      hasMaxChanged ? "text-accent hover:text-accent-hover hover:bg-accent-subtle" : "text-zinc-600 cursor-default opacity-40 hover:bg-transparent"
+                    )}
+                    title="Save current to max"
+                    disabled={!hasMaxChanged}
+                  >
+                    <Save size={12} />
+                  </BaseButton>
+                )}
+
+              </div>
+
+            </div>
+          )}
+
+          {renderAnimatableRow && (
+            <div className="flex flex-col @[300px]:flex-row @[300px]:items-center gap-2 px-1.5 pt-1 mt-0.5">
+              <div className="@[300px]:w-20 w-full flex-shrink-0 @[300px]:pl-4 flex items-center pl-6">
+                <span className="text-[9px] uppercase font-bold text-text-secondary tracking-wider">
+                  Editable
+                </span>
+              </div>
+              <div className="flex-1 min-w-0 flex items-center gap-1 w-full @[300px]:w-auto">
+                {renderAnimatableRow()}
+              </div>
+            </div>
+          )}
         </div>
       )}
+
     </div>
   );
 }

--- a/apps/vizij-authoring/src/components/inspector/RiggingPropertyRow.tsx
+++ b/apps/vizij-authoring/src/components/inspector/RiggingPropertyRow.tsx
@@ -25,9 +25,7 @@ export interface RiggingPropertyRowProps {
   hasMinChanged?: boolean;
   hasMaxChanged?: boolean;
 
-
   className?: string;
-
 
   icon?: React.ReactNode;
 }
@@ -140,7 +138,6 @@ export function RiggingPropertyRow({
   hasMinChanged,
   hasMaxChanged,
 
-
   onScrub,
   onScrubStart,
   onScrubEnd,
@@ -178,7 +175,6 @@ export function RiggingPropertyRow({
               )}
             >
               {isExpanded ? <X size={12} /> : <Pencil size={11} />}
-
             </BaseButton>
           ) : (
             <div className="w-3.5 flex justify-center text-zinc-500">
@@ -213,7 +209,9 @@ export function RiggingPropertyRow({
               }}
               className={cn(
                 "ml-1 p-1 rounded cursor-pointer transition-colors",
-                hasDifferentDefault ? "text-accent hover:text-accent-hover hover:bg-accent/10" : "text-zinc-600 cursor-default opacity-40 hover:bg-transparent"
+                hasDifferentDefault
+                  ? "text-accent hover:text-accent-hover hover:bg-accent/10"
+                  : "text-zinc-600 cursor-default opacity-40 hover:bg-transparent",
               )}
               title="Reset to default"
               disabled={!hasDifferentDefault}
@@ -221,7 +219,6 @@ export function RiggingPropertyRow({
               <RotateCcw size={10} />
             </BaseButton>
           )}
-
         </div>
       </div>
 
@@ -247,7 +244,9 @@ export function RiggingPropertyRow({
                     }}
                     className={cn(
                       "ml-1 p-1 rounded transition-colors flex-shrink-0",
-                      hasDifferentDefault ? "text-accent hover:text-accent-hover hover:bg-accent-subtle" : "text-zinc-600 cursor-default opacity-40 hover:bg-transparent"
+                      hasDifferentDefault
+                        ? "text-accent hover:text-accent-hover hover:bg-accent-subtle"
+                        : "text-zinc-600 cursor-default opacity-40 hover:bg-transparent",
                     )}
                     title="Save to default"
                     disabled={!hasDifferentDefault}
@@ -255,7 +254,6 @@ export function RiggingPropertyRow({
                     <Save size={12} />
                   </BaseButton>
                 )}
-
               </div>
             </div>
           )}
@@ -278,7 +276,9 @@ export function RiggingPropertyRow({
                     }}
                     className={cn(
                       "ml-1 p-1 rounded transition-colors flex-shrink-0",
-                      hasMinChanged ? "text-accent hover:text-accent-hover hover:bg-accent-subtle" : "text-zinc-600 cursor-default opacity-40 hover:bg-transparent"
+                      hasMinChanged
+                        ? "text-accent hover:text-accent-hover hover:bg-accent-subtle"
+                        : "text-zinc-600 cursor-default opacity-40 hover:bg-transparent",
                     )}
                     title="Save current to min"
                     disabled={!hasMinChanged}
@@ -286,9 +286,7 @@ export function RiggingPropertyRow({
                     <Save size={12} />
                   </BaseButton>
                 )}
-
               </div>
-
             </div>
           )}
 
@@ -310,7 +308,9 @@ export function RiggingPropertyRow({
                     }}
                     className={cn(
                       "ml-1 p-1 rounded transition-colors flex-shrink-0",
-                      hasMaxChanged ? "text-accent hover:text-accent-hover hover:bg-accent-subtle" : "text-zinc-600 cursor-default opacity-40 hover:bg-transparent"
+                      hasMaxChanged
+                        ? "text-accent hover:text-accent-hover hover:bg-accent-subtle"
+                        : "text-zinc-600 cursor-default opacity-40 hover:bg-transparent",
                     )}
                     title="Save current to max"
                     disabled={!hasMaxChanged}
@@ -318,9 +318,7 @@ export function RiggingPropertyRow({
                     <Save size={12} />
                   </BaseButton>
                 )}
-
               </div>
-
             </div>
           )}
 
@@ -338,7 +336,6 @@ export function RiggingPropertyRow({
           )}
         </div>
       )}
-
     </div>
   );
 }

--- a/apps/vizij-authoring/src/components/inspector/RiggingPropertyRow.tsx
+++ b/apps/vizij-authoring/src/components/inspector/RiggingPropertyRow.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useRef, useEffect } from "react";
 import { Pencil, X, RotateCcw, Save } from "lucide-react";
-
 import { Button as BaseButton } from "@base-ui/react";
 import { cn } from "../../utils/cn";
 

--- a/apps/vizij-authoring/src/components/inspector/RiggingTransformSection.tsx
+++ b/apps/vizij-authoring/src/components/inspector/RiggingTransformSection.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo, useRef, useCallback } from "react";
 import { Lock, LockOpen } from "lucide-react";
 import type { StandardRigInput, AnimatableValue } from "@vizij/utils";
-
 import { cn } from "../../utils/cn";
 import type {
   SceneObjectNode,
@@ -10,7 +9,6 @@ import type {
 import { useBindingAuthoring } from "../../state/RigControllerProvider";
 import { useSceneComposer } from "../../scene/useSceneComposer";
 import { RiggingPropertyRow, ScrubbableLabel } from "./RiggingPropertyRow";
-
 import { resolveEffectiveControllableBindingStandardInput } from "./bindingSlotResolution";
 
 interface RiggingTransformSectionProps {
@@ -189,8 +187,6 @@ function RiggingVectorRow({
   onUpdateStandardInput,
   setStaticFeatureValue,
 }: RiggingVectorRowProps) {
-  const isAnimated = feature.animated;
-
   const scrubValuesRef = useRef<Record<string, number>>({});
 
   // Extract inputs for x, y, z components
@@ -295,7 +291,7 @@ function RiggingVectorRow({
     (c) =>
       c.hasInputMetadata &&
       Math.abs((c.currentValue as number) - (c.defaultValue as number)) >
-        0.0001,
+      0.0001,
   );
 
   const handleReset = () => {

--- a/apps/vizij-authoring/src/components/inspector/RiggingTransformSection.tsx
+++ b/apps/vizij-authoring/src/components/inspector/RiggingTransformSection.tsx
@@ -1,12 +1,16 @@
-import React, { useMemo, useRef } from "react";
-import type { StandardRigInput } from "@vizij/utils";
+import React, { useMemo, useRef, useCallback } from "react";
+import { Lock, LockOpen } from "lucide-react";
+import type { StandardRigInput, AnimatableValue } from "@vizij/utils";
+
 import { cn } from "../../utils/cn";
 import type {
   SceneObjectNode,
   SceneObjectFeature,
 } from "../../scene/sceneGraph";
 import { useBindingAuthoring } from "../../state/RigControllerProvider";
+import { useSceneComposer } from "../../scene/useSceneComposer";
 import { RiggingPropertyRow, ScrubbableLabel } from "./RiggingPropertyRow";
+
 import { resolveEffectiveControllableBindingStandardInput } from "./bindingSlotResolution";
 
 interface RiggingTransformSectionProps {
@@ -23,8 +27,26 @@ export function RiggingTransformSection({
     inputBindings,
     inputValues,
     handleInputValueChange,
-    handleUpdateStandardInput, // To update default value
+    handleUpdateStandardInput,
   } = useBindingAuthoring((state) => state);
+
+  const {
+    setFeatureAnimated,
+    updateAnimatableDescriptor,
+    setAnimatableValue,
+    setStaticFeatureValue,
+  } = useSceneComposer();
+
+
+  const handleStaticValueChange = useCallback((
+    targetId: string,
+    value: number,
+    channel?: string,
+  ) => {
+    setAnimatableValue(targetId, value, { channel, saveToDefault: true });
+  }, [setAnimatableValue]);
+
+
 
   // Helper to find feature by key
   const findFeature = (key: string) =>
@@ -48,6 +70,7 @@ export function RiggingTransformSection({
         <RiggingVectorRow
           label="Position"
           feature={positionFeature}
+          node={node}
           bindings={bindings}
           standardInputs={standardInputs}
           standardInputsById={standardInputsById}
@@ -57,13 +80,21 @@ export function RiggingTransformSection({
           onDefaultChange={(id, val) =>
             handleUpdateStandardInput(id, { defaultValue: val })
           }
+          onToggleAnimated={(animated) => setFeatureAnimated(node.id, positionFeature.id, animated)}
+          onConstraintChange={updateAnimatableDescriptor}
+          onStaticValueChange={handleStaticValueChange}
+          onUpdateStandardInput={handleUpdateStandardInput}
+          setStaticFeatureValue={setStaticFeatureValue}
         />
+
+
       )}
 
       {rotationFeature && (
         <RiggingVectorRow
           label="Rotation"
           feature={rotationFeature}
+          node={node}
           bindings={bindings}
           standardInputs={standardInputs}
           standardInputsById={standardInputsById}
@@ -73,13 +104,21 @@ export function RiggingTransformSection({
           onDefaultChange={(id, val) =>
             handleUpdateStandardInput(id, { defaultValue: val })
           }
+          onToggleAnimated={(animated) => setFeatureAnimated(node.id, rotationFeature.id, animated)}
+          onConstraintChange={updateAnimatableDescriptor}
+          onStaticValueChange={handleStaticValueChange}
+          onUpdateStandardInput={handleUpdateStandardInput}
+          setStaticFeatureValue={setStaticFeatureValue}
         />
+
+
       )}
 
       {scaleFeature && (
         <RiggingVectorRow
           label="Scale"
           feature={scaleFeature}
+          node={node}
           bindings={bindings}
           standardInputs={standardInputs}
           standardInputsById={standardInputsById}
@@ -89,8 +128,18 @@ export function RiggingTransformSection({
           onDefaultChange={(id, val) =>
             handleUpdateStandardInput(id, { defaultValue: val })
           }
+          onToggleAnimated={(animated) => setFeatureAnimated(node.id, scaleFeature.id, animated)}
+          onConstraintChange={updateAnimatableDescriptor}
+          onStaticValueChange={handleStaticValueChange}
+          onUpdateStandardInput={handleUpdateStandardInput}
+          setStaticFeatureValue={setStaticFeatureValue}
         />
+
+
       )}
+
+
+
     </div>
   );
 }
@@ -107,9 +156,29 @@ interface RiggingVectorRowProps {
     { inputId?: string | null; slots?: Array<{ inputId?: string | null }> }
   >;
   inputValues: Record<string, number>;
+
   onValueChange: (id: string, value: number) => void;
   onDefaultChange: (id: string, value: number) => void;
+  onToggleAnimated: (animated: boolean) => void;
+  onConstraintChange: (id: string, updater: (curr: AnimatableValue) => AnimatableValue) => void;
+  onStaticValueChange?: (targetId: string, value: number, channel?: string) => void;
+  onUpdateStandardInput: (id: string, updates: any) => void;
+  setStaticFeatureValue?: (nodeId: string, featureId: string, value: any) => void;
+  node?: SceneObjectNode;
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 function RiggingVectorRow({
   label,
@@ -119,9 +188,24 @@ function RiggingVectorRow({
   standardInputsById,
   inputBindings,
   inputValues,
+  node,
   onValueChange,
   onDefaultChange,
+
+  onToggleAnimated,
+  onConstraintChange,
+  onStaticValueChange,
+  onUpdateStandardInput,
+  setStaticFeatureValue,
 }: RiggingVectorRowProps) {
+
+
+
+  const isAnimated = feature.animated;
+
+
+
+
   const scrubValuesRef = useRef<Record<string, number>>({});
 
   // Extract inputs for x, y, z components
@@ -150,30 +234,60 @@ function RiggingVectorRow({
         blockedReason = resolved.blockedReason;
       }
 
-      // 2. Determine values
-      if (standardInput && inputId) {
+      const hasInputMetadata = !!(inputId && standardInput);
+      const isBound = !!inputId && !blockedReason;
+
+      if (hasInputMetadata && inputId) {
         // Bound Case
+        const range = standardInput!.range;
         return {
           componentLabel: label,
           inputId,
-          currentValue: inputValues[inputId] ?? standardInput.defaultValue ?? 0,
-          defaultValue: standardInput.defaultValue ?? 0,
+          targetId,
+          currentValue: inputValues[inputId] ?? standardInput!.defaultValue ?? 0,
+          defaultValue: standardInput!.defaultValue ?? 0,
+          min: range.min,
+          max: range.max,
           isBound: true,
+          hasInputMetadata: true,
           unresolvedInputId,
           blockedReason,
         };
       } else {
-        const val = comp.staticValue ?? 0;
+        // Descriptor Case (or dynamic input without metadata)
+        const val = isBound ? (inputValues[inputId!] ?? 0) : (comp.staticValue ?? 0);
+        const constraints = feature.descriptor?.constraints as any;
+        const key = label.toLowerCase();
+        const minVals = constraints?.min;
+        const maxVals = constraints?.max;
+
+        let minVal = 0;
+        let maxVal = 0;
+
+        if (typeof minVals === "object" && minVals !== null) minVal = (minVals as any)[key] ?? 0;
+        else if (Array.isArray(minVals)) minVal = minVals[feature.components.indexOf(comp)] ?? 0;
+        else if (typeof minVals === "number") minVal = minVals;
+
+        if (typeof maxVals === "object" && maxVals !== null) maxVal = (maxVals as any)[key] ?? 0;
+        else if (Array.isArray(maxVals)) maxVal = maxVals[feature.components.indexOf(comp)] ?? 0;
+        else if (typeof maxVals === "number") maxVal = maxVals;
+
         return {
           componentLabel: label,
-          inputId: null,
+          inputId,
+          targetId,
           currentValue: val,
           defaultValue: val,
-          isBound: false,
+          min: minVal,
+          max: maxVal,
+          isBound: isBound,
+          hasInputMetadata: false,
           unresolvedInputId,
           blockedReason,
         };
       }
+
+
     });
   }, [
     feature,
@@ -189,10 +303,11 @@ function RiggingVectorRow({
   // Only show reset if ANY component is bound and differs
   const hasDifferentDefault = components.some(
     (c) =>
-      c.isBound &&
+      c.hasInputMetadata &&
       Math.abs((c.currentValue as number) - (c.defaultValue as number)) >
-        0.0001,
+      0.0001,
   );
+
 
   const handleReset = () => {
     components.forEach((c) => {
@@ -204,15 +319,81 @@ function RiggingVectorRow({
   const handleSaveToDefault = () => {
     components.forEach((c) => {
       if (c.isBound && c.inputId)
-        onDefaultChange(c.inputId, c.currentValue as number);
+        onUpdateStandardInput(c.inputId, { defaultValue: c.currentValue as number });
     });
   };
 
-  const renderInputs = (isDefault: boolean) => (
+  const hasMinChanged = components.some(c => Math.abs((c.currentValue as number) - (c.min as number)) > 0.0001);
+
+  const hasMaxChanged = components.some(c => Math.abs((c.currentValue as number) - (c.max as number)) > 0.0001);
+
+  const handleSaveToMin = () => {
+    components.forEach((c) => {
+      if (c.isBound && c.inputId) {
+        onUpdateStandardInput(c.inputId, { range: { min: c.currentValue as number } });
+      }
+    });
+
+    if (feature.animatableId) {
+      onConstraintChange(feature.animatableId, (curr) => {
+        const nextConstraints = { ...(curr.constraints || {}) } as any;
+        const currentVals = { ...(nextConstraints.min || {}) };
+        components.forEach((c) => {
+          if (!c.isBound) {
+            currentVals[c.componentLabel.toLowerCase()] = c.currentValue;
+          }
+        });
+        nextConstraints.min = currentVals;
+        return { ...curr, constraints: nextConstraints } as any;
+      });
+    }
+  };
+
+  const handleSaveToMax = () => {
+    components.forEach((c) => {
+      if (c.isBound && c.inputId) {
+        onUpdateStandardInput(c.inputId, { range: { max: c.currentValue as number } });
+      }
+    });
+
+    if (feature.animatableId) {
+      onConstraintChange(feature.animatableId, (curr) => {
+        const nextConstraints = { ...(curr.constraints || {}) } as any;
+        const currentVals = { ...(nextConstraints.max || {}) };
+        components.forEach((c) => {
+          if (!c.isBound) {
+            currentVals[c.componentLabel.toLowerCase()] = c.currentValue;
+          }
+        });
+        nextConstraints.max = currentVals;
+        return { ...curr, constraints: nextConstraints } as any;
+      });
+    }
+  };
+
+
+  const renderInputs = (type: "current" | "default" | "min" | "max") => (
     <div className="flex gap-1.5 flex-1">
       {components.map((c, i) => {
-        const val = isDefault ? c.defaultValue : c.currentValue;
-        const canEdit = c.isBound;
+        let val: number | undefined;
+        let canEdit = true;
+
+        if (type === "current") {
+          val = c.currentValue;
+          canEdit = c.isBound || !!onStaticValueChange;
+        } else if (type === "default") {
+
+          val = c.defaultValue;
+          canEdit = c.hasInputMetadata;
+        } else if (type === "min") {
+
+          val = c.min as number;
+          canEdit = true;
+        } else if (type === "max") {
+          val = c.max as number;
+          canEdit = true;
+        }
+
 
         return (
           <div
@@ -225,19 +406,66 @@ function RiggingVectorRow({
             <ScrubbableLabel
               label={c.componentLabel}
               onScrub={(_, totalDelta) => {
-                if (c.inputId) {
-                  const step = 0.05;
+                const step = 0.05;
+                if (type === "current") {
+                  if (c.isBound && c.inputId) {
+                    const startVal = scrubValuesRef.current[c.inputId] ?? 0;
+                    onValueChange(c.inputId, startVal + totalDelta * step);
+                  } else if (onStaticValueChange) {
+                    const startValueToUse = (scrubValuesRef.current["current"] ?? 0);
+                    const newVal = startValueToUse + totalDelta * step;
+                    if (feature.animated && feature.animatableId) {
+                      onStaticValueChange(feature.animatableId, newVal, c.componentLabel.toLowerCase());
+                    } else if (setStaticFeatureValue && node) {
+                      const current = (feature.staticValue as any) || {};
+                      setStaticFeatureValue(node.id, feature.id, {
+                        ...current,
+                        [c.componentLabel.toLowerCase()]: newVal,
+                      });
+                    }
+                  }
+                } else if (type === "default" && c.inputId) {
+
+
                   const startVal = scrubValuesRef.current[c.inputId] ?? 0;
+                  onDefaultChange(c.inputId, startVal + totalDelta * step);
+                } else if ((type === "min" || type === "max") && (c.inputId || feature.animatableId)) {
+                  const key = c.componentLabel.toLowerCase();
+                  const startVal = scrubValuesRef.current[`${type}:${key}`] ?? 0;
                   const nextVal = startVal + totalDelta * step;
-                  if (isDefault) onDefaultChange(c.inputId, nextVal);
-                  else onValueChange(c.inputId, nextVal);
+
+                  if (c.isBound && c.inputId) {
+                    onUpdateStandardInput(c.inputId, {
+                      range: { [type]: nextVal }
+                    });
+                  } else if (feature.animatableId) {
+                    onConstraintChange(feature.animatableId, (curr) => {
+                      const nextConstraints = { ...(curr.constraints || {}) } as any;
+                      const kind = type === "min" ? "min" : "max";
+                      const currentVal = nextConstraints[kind] || {};
+                      nextConstraints[kind] = {
+                        ...(typeof currentVal === "object" ? currentVal : {}),
+                        [key]: nextVal,
+                      } as any;
+                      return { ...curr, constraints: nextConstraints } as any;
+                    });
+                  }
                 }
+
               }}
               onScrubStart={() => {
-                if (c.inputId) {
-                  const baseline = isDefault ? c.defaultValue : c.currentValue;
-                  scrubValuesRef.current[c.inputId] = (baseline as number) ?? 0;
+                if (type === "current") {
+                  if (c.isBound && c.inputId) scrubValuesRef.current[c.inputId] = c.currentValue ?? 0;
+                  else scrubValuesRef.current["current"] = c.currentValue ?? 0;
+                } else if (type === "default" && c.inputId) {
+
+                  scrubValuesRef.current[c.inputId] = c.defaultValue ?? 0;
+                } else if ((type === "min" || type === "max") && (c.inputId || feature.animatableId)) {
+
+                  const key = c.componentLabel.toLowerCase();
+                  scrubValuesRef.current[`${type}:${key}`] = (type === "min" ? c.min : c.max) as number ?? 0;
                 }
+
               }}
               className={cn(
                 "text-[9px] font-bold px-1",
@@ -253,25 +481,52 @@ function RiggingVectorRow({
             <input
               type="number"
               className="w-full bg-transparent border-0 text-[10px] p-0 h-5 focus:ring-0 text-text-primary placeholder-text-muted no-spinners font-mono leading-none"
-              value={typeof val === "number" ? parseFloat(val.toFixed(2)) : 0}
+              value={typeof val === "number" ? val : 0}
+
               step={0.01}
               disabled={!canEdit}
-              title={
-                !canEdit
-                  ? c.blockedReason
-                    ? c.blockedReason
-                    : c.unresolvedInputId
-                      ? `Driver "${c.unresolvedInputId}" is unresolved. Open My Drivers to remap.`
-                      : "Value is not driven by a rig input"
-                  : undefined
-              }
               onChange={(e) => {
-                if (!canEdit || !c.inputId) return;
                 const num = parseFloat(e.target.value);
-                if (!isNaN(num)) {
-                  if (isDefault) onDefaultChange(c.inputId, num);
-                  else onValueChange(c.inputId, num);
+                if (isNaN(num)) return;
+
+                if (type === "current") {
+                  if (c.isBound && c.inputId) {
+                    onValueChange(c.inputId, num);
+                  } else if (onStaticValueChange) {
+                    if (feature.animated && feature.animatableId) {
+                      onStaticValueChange(feature.animatableId, num, c.componentLabel.toLowerCase());
+                    } else if (setStaticFeatureValue && node) {
+                      const current = (feature.staticValue as any) || {};
+                      setStaticFeatureValue(node.id, feature.id, {
+                        ...current,
+                        [c.componentLabel.toLowerCase()]: num,
+                      });
+                    }
+                  }
+                } else if (type === "default" && c.inputId) {
+
+                  onDefaultChange(c.inputId, num);
+                } else if ((type === "min" || type === "max") && (c.inputId || feature.animatableId)) {
+
+                  const key = c.componentLabel.toLowerCase();
+                  if (c.isBound && c.inputId) {
+                    onUpdateStandardInput(c.inputId, {
+                      range: { [type]: num }
+                    });
+                  } else if (feature.animatableId) {
+                    onConstraintChange(feature.animatableId, (curr) => {
+                      const nextConstraints = { ...(curr.constraints || {}) } as any;
+                      const kind = type === "min" ? "min" : "max";
+                      const currentVal = nextConstraints[kind] || {};
+                      nextConstraints[kind] = {
+                        ...(typeof currentVal === "object" ? currentVal : {}),
+                        [key]: num,
+                      } as any;
+                      return { ...curr, constraints: nextConstraints } as any;
+                    });
+                  }
                 }
+
               }}
             />
           </div>
@@ -280,14 +535,51 @@ function RiggingVectorRow({
     </div>
   );
 
+
+  const renderAnimatableRow = () => (
+    <div className="flex gap-1.5 flex-1">
+      {components.map((c, i) => (
+        <button
+          key={i}
+          className={cn(
+            "flex items-center justify-center gap-1.5 flex-1 h-5 rounded-sm border border-transparent transition-colors text-[10px] font-bold uppercase tracking-wider",
+            feature.animated
+              ? "bg-accent/10 text-accent hover:bg-accent/20"
+              : "bg-bg-input/50 text-text-muted hover:bg-bg-input/70",
+          )}
+          onClick={() => onToggleAnimated(!feature.animated)}
+        >
+          {feature.animated ? (
+            <LockOpen size={10} className="shrink-0" />
+          ) : (
+            <Lock size={10} className="shrink-0" />
+          )}
+          <span>{c.componentLabel}</span>
+        </button>
+      ))}
+    </div>
+  );
+
+
+
+
+
   return (
     <RiggingPropertyRow
       label={label}
       hasDifferentDefault={hasDifferentDefault}
+      hasMinChanged={hasMinChanged}
+      hasMaxChanged={hasMaxChanged}
       onResetToDefault={handleReset}
       onSaveToDefault={handleSaveToDefault}
-      renderMainInput={() => renderInputs(false)}
-      renderDefaultInput={() => renderInputs(true)}
+      onSaveToMin={handleSaveToMin}
+      onSaveToMax={handleSaveToMax}
+      renderMainInput={() => renderInputs("current")}
+      renderDefaultInput={() => renderInputs("default")}
+      renderMinInput={() => renderInputs("min")}
+      renderMaxInput={() => renderInputs("max")}
+      renderAnimatableRow={renderAnimatableRow}
     />
   );
 }
+

--- a/apps/vizij-authoring/src/components/inspector/RiggingTransformSection.tsx
+++ b/apps/vizij-authoring/src/components/inspector/RiggingTransformSection.tsx
@@ -37,16 +37,12 @@ export function RiggingTransformSection({
     setStaticFeatureValue,
   } = useSceneComposer();
 
-
-  const handleStaticValueChange = useCallback((
-    targetId: string,
-    value: number,
-    channel?: string,
-  ) => {
-    setAnimatableValue(targetId, value, { channel, saveToDefault: true });
-  }, [setAnimatableValue]);
-
-
+  const handleStaticValueChange = useCallback(
+    (targetId: string, value: number, channel?: string) => {
+      setAnimatableValue(targetId, value, { channel, saveToDefault: true });
+    },
+    [setAnimatableValue],
+  );
 
   // Helper to find feature by key
   const findFeature = (key: string) =>
@@ -80,14 +76,14 @@ export function RiggingTransformSection({
           onDefaultChange={(id, val) =>
             handleUpdateStandardInput(id, { defaultValue: val })
           }
-          onToggleAnimated={(animated) => setFeatureAnimated(node.id, positionFeature.id, animated)}
+          onToggleAnimated={(animated) =>
+            setFeatureAnimated(node.id, positionFeature.id, animated)
+          }
           onConstraintChange={updateAnimatableDescriptor}
           onStaticValueChange={handleStaticValueChange}
           onUpdateStandardInput={handleUpdateStandardInput}
           setStaticFeatureValue={setStaticFeatureValue}
         />
-
-
       )}
 
       {rotationFeature && (
@@ -104,14 +100,14 @@ export function RiggingTransformSection({
           onDefaultChange={(id, val) =>
             handleUpdateStandardInput(id, { defaultValue: val })
           }
-          onToggleAnimated={(animated) => setFeatureAnimated(node.id, rotationFeature.id, animated)}
+          onToggleAnimated={(animated) =>
+            setFeatureAnimated(node.id, rotationFeature.id, animated)
+          }
           onConstraintChange={updateAnimatableDescriptor}
           onStaticValueChange={handleStaticValueChange}
           onUpdateStandardInput={handleUpdateStandardInput}
           setStaticFeatureValue={setStaticFeatureValue}
         />
-
-
       )}
 
       {scaleFeature && (
@@ -128,18 +124,15 @@ export function RiggingTransformSection({
           onDefaultChange={(id, val) =>
             handleUpdateStandardInput(id, { defaultValue: val })
           }
-          onToggleAnimated={(animated) => setFeatureAnimated(node.id, scaleFeature.id, animated)}
+          onToggleAnimated={(animated) =>
+            setFeatureAnimated(node.id, scaleFeature.id, animated)
+          }
           onConstraintChange={updateAnimatableDescriptor}
           onStaticValueChange={handleStaticValueChange}
           onUpdateStandardInput={handleUpdateStandardInput}
           setStaticFeatureValue={setStaticFeatureValue}
         />
-
-
       )}
-
-
-
     </div>
   );
 }
@@ -160,25 +153,23 @@ interface RiggingVectorRowProps {
   onValueChange: (id: string, value: number) => void;
   onDefaultChange: (id: string, value: number) => void;
   onToggleAnimated: (animated: boolean) => void;
-  onConstraintChange: (id: string, updater: (curr: AnimatableValue) => AnimatableValue) => void;
-  onStaticValueChange?: (targetId: string, value: number, channel?: string) => void;
+  onConstraintChange: (
+    id: string,
+    updater: (curr: AnimatableValue) => AnimatableValue,
+  ) => void;
+  onStaticValueChange?: (
+    targetId: string,
+    value: number,
+    channel?: string,
+  ) => void;
   onUpdateStandardInput: (id: string, updates: any) => void;
-  setStaticFeatureValue?: (nodeId: string, featureId: string, value: any) => void;
+  setStaticFeatureValue?: (
+    nodeId: string,
+    featureId: string,
+    value: any,
+  ) => void;
   node?: SceneObjectNode;
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 function RiggingVectorRow({
   label,
@@ -198,13 +189,7 @@ function RiggingVectorRow({
   onUpdateStandardInput,
   setStaticFeatureValue,
 }: RiggingVectorRowProps) {
-
-
-
   const isAnimated = feature.animated;
-
-
-
 
   const scrubValuesRef = useRef<Record<string, number>>({});
 
@@ -244,7 +229,8 @@ function RiggingVectorRow({
           componentLabel: label,
           inputId,
           targetId,
-          currentValue: inputValues[inputId] ?? standardInput!.defaultValue ?? 0,
+          currentValue:
+            inputValues[inputId] ?? standardInput!.defaultValue ?? 0,
           defaultValue: standardInput!.defaultValue ?? 0,
           min: range.min,
           max: range.max,
@@ -255,7 +241,9 @@ function RiggingVectorRow({
         };
       } else {
         // Descriptor Case (or dynamic input without metadata)
-        const val = isBound ? (inputValues[inputId!] ?? 0) : (comp.staticValue ?? 0);
+        const val = isBound
+          ? (inputValues[inputId!] ?? 0)
+          : (comp.staticValue ?? 0);
         const constraints = feature.descriptor?.constraints as any;
         const key = label.toLowerCase();
         const minVals = constraints?.min;
@@ -264,12 +252,16 @@ function RiggingVectorRow({
         let minVal = 0;
         let maxVal = 0;
 
-        if (typeof minVals === "object" && minVals !== null) minVal = (minVals as any)[key] ?? 0;
-        else if (Array.isArray(minVals)) minVal = minVals[feature.components.indexOf(comp)] ?? 0;
+        if (typeof minVals === "object" && minVals !== null)
+          minVal = (minVals as any)[key] ?? 0;
+        else if (Array.isArray(minVals))
+          minVal = minVals[feature.components.indexOf(comp)] ?? 0;
         else if (typeof minVals === "number") minVal = minVals;
 
-        if (typeof maxVals === "object" && maxVals !== null) maxVal = (maxVals as any)[key] ?? 0;
-        else if (Array.isArray(maxVals)) maxVal = maxVals[feature.components.indexOf(comp)] ?? 0;
+        if (typeof maxVals === "object" && maxVals !== null)
+          maxVal = (maxVals as any)[key] ?? 0;
+        else if (Array.isArray(maxVals))
+          maxVal = maxVals[feature.components.indexOf(comp)] ?? 0;
         else if (typeof maxVals === "number") maxVal = maxVals;
 
         return {
@@ -286,8 +278,6 @@ function RiggingVectorRow({
           blockedReason,
         };
       }
-
-
     });
   }, [
     feature,
@@ -305,9 +295,8 @@ function RiggingVectorRow({
     (c) =>
       c.hasInputMetadata &&
       Math.abs((c.currentValue as number) - (c.defaultValue as number)) >
-      0.0001,
+        0.0001,
   );
-
 
   const handleReset = () => {
     components.forEach((c) => {
@@ -319,18 +308,26 @@ function RiggingVectorRow({
   const handleSaveToDefault = () => {
     components.forEach((c) => {
       if (c.isBound && c.inputId)
-        onUpdateStandardInput(c.inputId, { defaultValue: c.currentValue as number });
+        onUpdateStandardInput(c.inputId, {
+          defaultValue: c.currentValue as number,
+        });
     });
   };
 
-  const hasMinChanged = components.some(c => Math.abs((c.currentValue as number) - (c.min as number)) > 0.0001);
+  const hasMinChanged = components.some(
+    (c) => Math.abs((c.currentValue as number) - (c.min as number)) > 0.0001,
+  );
 
-  const hasMaxChanged = components.some(c => Math.abs((c.currentValue as number) - (c.max as number)) > 0.0001);
+  const hasMaxChanged = components.some(
+    (c) => Math.abs((c.currentValue as number) - (c.max as number)) > 0.0001,
+  );
 
   const handleSaveToMin = () => {
     components.forEach((c) => {
       if (c.isBound && c.inputId) {
-        onUpdateStandardInput(c.inputId, { range: { min: c.currentValue as number } });
+        onUpdateStandardInput(c.inputId, {
+          range: { min: c.currentValue as number },
+        });
       }
     });
 
@@ -352,7 +349,9 @@ function RiggingVectorRow({
   const handleSaveToMax = () => {
     components.forEach((c) => {
       if (c.isBound && c.inputId) {
-        onUpdateStandardInput(c.inputId, { range: { max: c.currentValue as number } });
+        onUpdateStandardInput(c.inputId, {
+          range: { max: c.currentValue as number },
+        });
       }
     });
 
@@ -371,7 +370,6 @@ function RiggingVectorRow({
     }
   };
 
-
   const renderInputs = (type: "current" | "default" | "min" | "max") => (
     <div className="flex gap-1.5 flex-1">
       {components.map((c, i) => {
@@ -382,18 +380,15 @@ function RiggingVectorRow({
           val = c.currentValue;
           canEdit = c.isBound || !!onStaticValueChange;
         } else if (type === "default") {
-
           val = c.defaultValue;
           canEdit = c.hasInputMetadata;
         } else if (type === "min") {
-
           val = c.min as number;
           canEdit = true;
         } else if (type === "max") {
           val = c.max as number;
           canEdit = true;
         }
-
 
         return (
           <div
@@ -412,10 +407,15 @@ function RiggingVectorRow({
                     const startVal = scrubValuesRef.current[c.inputId] ?? 0;
                     onValueChange(c.inputId, startVal + totalDelta * step);
                   } else if (onStaticValueChange) {
-                    const startValueToUse = (scrubValuesRef.current["current"] ?? 0);
+                    const startValueToUse =
+                      scrubValuesRef.current["current"] ?? 0;
                     const newVal = startValueToUse + totalDelta * step;
                     if (feature.animated && feature.animatableId) {
-                      onStaticValueChange(feature.animatableId, newVal, c.componentLabel.toLowerCase());
+                      onStaticValueChange(
+                        feature.animatableId,
+                        newVal,
+                        c.componentLabel.toLowerCase(),
+                      );
                     } else if (setStaticFeatureValue && node) {
                       const current = (feature.staticValue as any) || {};
                       setStaticFeatureValue(node.id, feature.id, {
@@ -425,22 +425,26 @@ function RiggingVectorRow({
                     }
                   }
                 } else if (type === "default" && c.inputId) {
-
-
                   const startVal = scrubValuesRef.current[c.inputId] ?? 0;
                   onDefaultChange(c.inputId, startVal + totalDelta * step);
-                } else if ((type === "min" || type === "max") && (c.inputId || feature.animatableId)) {
+                } else if (
+                  (type === "min" || type === "max") &&
+                  (c.inputId || feature.animatableId)
+                ) {
                   const key = c.componentLabel.toLowerCase();
-                  const startVal = scrubValuesRef.current[`${type}:${key}`] ?? 0;
+                  const startVal =
+                    scrubValuesRef.current[`${type}:${key}`] ?? 0;
                   const nextVal = startVal + totalDelta * step;
 
                   if (c.isBound && c.inputId) {
                     onUpdateStandardInput(c.inputId, {
-                      range: { [type]: nextVal }
+                      range: { [type]: nextVal },
                     });
                   } else if (feature.animatableId) {
                     onConstraintChange(feature.animatableId, (curr) => {
-                      const nextConstraints = { ...(curr.constraints || {}) } as any;
+                      const nextConstraints = {
+                        ...(curr.constraints || {}),
+                      } as any;
                       const kind = type === "min" ? "min" : "max";
                       const currentVal = nextConstraints[kind] || {};
                       nextConstraints[kind] = {
@@ -451,21 +455,22 @@ function RiggingVectorRow({
                     });
                   }
                 }
-
               }}
               onScrubStart={() => {
                 if (type === "current") {
-                  if (c.isBound && c.inputId) scrubValuesRef.current[c.inputId] = c.currentValue ?? 0;
+                  if (c.isBound && c.inputId)
+                    scrubValuesRef.current[c.inputId] = c.currentValue ?? 0;
                   else scrubValuesRef.current["current"] = c.currentValue ?? 0;
                 } else if (type === "default" && c.inputId) {
-
                   scrubValuesRef.current[c.inputId] = c.defaultValue ?? 0;
-                } else if ((type === "min" || type === "max") && (c.inputId || feature.animatableId)) {
-
+                } else if (
+                  (type === "min" || type === "max") &&
+                  (c.inputId || feature.animatableId)
+                ) {
                   const key = c.componentLabel.toLowerCase();
-                  scrubValuesRef.current[`${type}:${key}`] = (type === "min" ? c.min : c.max) as number ?? 0;
+                  scrubValuesRef.current[`${type}:${key}`] =
+                    ((type === "min" ? c.min : c.max) as number) ?? 0;
                 }
-
               }}
               className={cn(
                 "text-[9px] font-bold px-1",
@@ -482,7 +487,6 @@ function RiggingVectorRow({
               type="number"
               className="w-full bg-transparent border-0 text-[10px] p-0 h-5 focus:ring-0 text-text-primary placeholder-text-muted no-spinners font-mono leading-none"
               value={typeof val === "number" ? val : 0}
-
               step={0.01}
               disabled={!canEdit}
               onChange={(e) => {
@@ -494,7 +498,11 @@ function RiggingVectorRow({
                     onValueChange(c.inputId, num);
                   } else if (onStaticValueChange) {
                     if (feature.animated && feature.animatableId) {
-                      onStaticValueChange(feature.animatableId, num, c.componentLabel.toLowerCase());
+                      onStaticValueChange(
+                        feature.animatableId,
+                        num,
+                        c.componentLabel.toLowerCase(),
+                      );
                     } else if (setStaticFeatureValue && node) {
                       const current = (feature.staticValue as any) || {};
                       setStaticFeatureValue(node.id, feature.id, {
@@ -504,18 +512,21 @@ function RiggingVectorRow({
                     }
                   }
                 } else if (type === "default" && c.inputId) {
-
                   onDefaultChange(c.inputId, num);
-                } else if ((type === "min" || type === "max") && (c.inputId || feature.animatableId)) {
-
+                } else if (
+                  (type === "min" || type === "max") &&
+                  (c.inputId || feature.animatableId)
+                ) {
                   const key = c.componentLabel.toLowerCase();
                   if (c.isBound && c.inputId) {
                     onUpdateStandardInput(c.inputId, {
-                      range: { [type]: num }
+                      range: { [type]: num },
                     });
                   } else if (feature.animatableId) {
                     onConstraintChange(feature.animatableId, (curr) => {
-                      const nextConstraints = { ...(curr.constraints || {}) } as any;
+                      const nextConstraints = {
+                        ...(curr.constraints || {}),
+                      } as any;
                       const kind = type === "min" ? "min" : "max";
                       const currentVal = nextConstraints[kind] || {};
                       nextConstraints[kind] = {
@@ -526,7 +537,6 @@ function RiggingVectorRow({
                     });
                   }
                 }
-
               }}
             />
           </div>
@@ -534,7 +544,6 @@ function RiggingVectorRow({
       })}
     </div>
   );
-
 
   const renderAnimatableRow = () => (
     <div className="flex gap-1.5 flex-1">
@@ -560,10 +569,6 @@ function RiggingVectorRow({
     </div>
   );
 
-
-
-
-
   return (
     <RiggingPropertyRow
       label={label}
@@ -582,4 +587,3 @@ function RiggingVectorRow({
     />
   );
 }
-


### PR DESCRIPTION
Moved the feature matrix and animatable toggles to be in the row for each feature:
<img width="419" height="182" alt="image" src="https://github.com/user-attachments/assets/688c6648-ba75-4a1a-b1f6-ff47ab72d85b" />

Still needs functional work, but UX should mostly be there. 

Added expandable driver chain for now 
<img width="429" height="506" alt="image" src="https://github.com/user-attachments/assets/715dc364-d0b3-4ee5-9582-0965ddc58c34" />
