### PR TITLE
refactor(arora): move arora-websocket onto arora-sdk arora-types (Vizij Phase 5B)

### DIFF
--- a/packages/arora-connection/Cargo.toml
+++ b/packages/arora-connection/Cargo.toml
@@ -9,7 +9,7 @@ default = ["async"]
 async = ["tokio-util"]
 
 [dependencies]
-arora-schema = { git = "https://github.com/semio-ai/arora-types.git" }
+arora-types = "1.5"
 serde = { version = "1", features = ["derive"] }
 
 # Async support (optional but default)

--- a/packages/arora-connection/src/lib.rs
+++ b/packages/arora-connection/src/lib.rs
@@ -27,8 +27,8 @@ mod method;
 mod slot;
 mod traits;
 
-// Re-export arora-schema types for convenience
-pub use arora_schema::value::{Type, Value};
+// Re-export arora-types types for convenience
+pub use arora_types::value::{Type, Value};
 
 // Slot types
 pub use slot::SlotInfo;

--- a/packages/arora-connection/src/method.rs
+++ b/packages/arora-connection/src/method.rs
@@ -1,6 +1,6 @@
 //! RPC method metadata types for the Arora protocol.
 
-use arora_schema::value::{Type, Value};
+use arora_types::value::{Type, Value};
 use serde::{Deserialize, Serialize};
 
 /// Descriptor for an RPC method parameter.

--- a/packages/arora-connection/src/slot.rs
+++ b/packages/arora-connection/src/slot.rs
@@ -1,6 +1,6 @@
 //! Slot metadata types for the Arora protocol.
 
-use arora_schema::value::{Type, Value};
+use arora_types::value::{Type, Value};
 use serde::{Deserialize, Serialize};
 
 /// Metadata describing an available slot in the system.

--- a/packages/arora-connection/src/traits.rs
+++ b/packages/arora-connection/src/traits.rs
@@ -9,7 +9,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use arora_schema::value::Value;
+use arora_types::value::Value;
 
 #[cfg(feature = "async")]
 use tokio_util::sync::CancellationToken;

--- a/packages/arora-websocket/Cargo.lock
+++ b/packages/arora-websocket/Cargo.lock
@@ -6,21 +6,25 @@ version = 4
 name = "arora-connection"
 version = "0.1.0"
 dependencies = [
- "arora-schema",
+ "arora-types",
  "serde",
  "tokio-util",
 ]
 
 [[package]]
-name = "arora-schema"
-version = "0.1.0"
-source = "git+https://github.com/semio-ai/arora-types.git#56ca70a50e23ddc6ccad473232e8a3fe19cef4bd"
+name = "arora-types"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b19ef73d661ad225f6d208877fea9257c2300d1a50814e7a1709d03be5821fc"
 dependencies = [
+ "async-trait",
  "derive_more",
+ "js-sys",
  "lazy_static",
  "semver",
  "serde",
  "uuid",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -28,7 +32,7 @@ name = "arora-websocket"
 version = "0.2.0"
 dependencies = [
  "arora-connection",
- "arora-schema",
+ "arora-types",
  "futures-util",
  "log",
  "serde",
@@ -36,6 +40,17 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tokio-util",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -383,6 +398,10 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"

--- a/packages/arora-websocket/Cargo.toml
+++ b/packages/arora-websocket/Cargo.toml
@@ -10,7 +10,7 @@ server = ["tokio", "tokio-tungstenite", "futures-util", "log", "tokio-util", "ar
 
 [dependencies]
 arora-connection = { path = "../arora-connection" }
-arora-schema = { git = "https://github.com/semio-ai/arora-types.git" }
+arora-types = "1.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/packages/arora-websocket/src/lib.rs
+++ b/packages/arora-websocket/src/lib.rs
@@ -79,8 +79,8 @@ pub use arora_connection::{
     SetSlotValuesResult,
 };
 
-// Re-export arora-schema types for backwards compatibility
-pub use arora_schema::keyvalue::{KeyValue, KeyValueField};
+// Re-export arora-types types for backwards compatibility
+pub use arora_types::keyvalue::{KeyValue, KeyValueField};
 
 // Protocol message types (WebSocket-specific)
 pub use messages::{Incoming, Outgoing};


### PR DESCRIPTION
Phase 5B of running Vizij on Arora. `arora-connection` and `arora-websocket` pulled `Value`/`Type`/`KeyValue` from **`arora-schema`** (the standalone `arora-types.git` repo). That schema and arora-sdk's **`arora-types`** are the *same protocol*, and arora-sdk is the live one — so both crates move onto the published `arora-types` (crates.io 1.5) and the git dep on `arora-types.git` is dropped.

### Change
Mechanical swap:
- `arora_schema::value::{Type, Value}` → `arora_types::value::{Type, Value}`
- `arora_schema::keyvalue::{KeyValue, KeyValueField}` → `arora_types::keyvalue::{KeyValue, KeyValueField}`
- both `Cargo.toml`s: `arora-schema = { git … }` → `arora-types = "1.5"`

### Non-breaking
The `messages` serde round-trip tests pass unchanged — the JSON wire format (`{"f64":0.5}`) is byte-identical. 8/8 tests green.

### Why it matters
After this, `arora_connection::Value` **is** `arora_types::Value`, so WebSocket values map straight onto Arora's `BridgeOp` with **zero conversion** — the seam that **Phase 5C** (`WsBridge: arora_bridge::Bridge`) builds on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)