### PR TITLE
test(e2e): playwright smoke for the authoring workspace + CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,23 @@ jobs:
       - run: pnpm run typecheck:all
       - run: pnpm run test:all
       - run: pnpm run build
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build:packages
+      - run: pnpm --filter vizij-e2e exec playwright install --with-deps chromium
+      - run: pnpm run e2e
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: e2e/test-results/

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,2 @@
+test-results/
+playwright-report/

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "vizij-e2e",
+  "private": true,
+  "version": "0.0.0",
+  "description": "End-to-end smoke and journey tests for the Vizij apps (Playwright).",
+  "scripts": {
+    "e2e": "playwright test",
+    "e2e:heavy": "RUN_HEAVY=1 playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.0"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from "@playwright/test";
+
+// The light suite boots the authoring workspace (the editing surface) and
+// asserts it renders without page errors — cheap enough for CI on every push.
+// Journey specs that drive real editing interactions are gated behind
+// RUN_HEAVY=1 (pnpm run e2e:heavy) so they can be run on demand.
+export default defineConfig({
+  testDir: "./tests",
+  timeout: 60_000,
+  retries: process.env.CI ? 1 : 0,
+  use: {
+    baseURL: "http://127.0.0.1:5199",
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+  },
+  webServer: {
+    command:
+      "pnpm --filter vizij-authoring exec vite --port 5199 --strictPort --host 127.0.0.1",
+    url: "http://127.0.0.1:5199",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    cwd: "..",
+  },
+});

--- a/e2e/tests/authoring-journey.spec.ts
+++ b/e2e/tests/authoring-journey.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from "@playwright/test";
+
+// Heavy suite (on demand: `pnpm run e2e:heavy`): drives real editing
+// interactions in the workspace. Kept out of CI because it is slower and
+// more UI-coupled; run it before releases or after changes to the editing
+// surface. Selectors are intentionally role-based; when the workspace gains
+// data-testid hooks, tighten them.
+
+test.skip(!process.env.RUN_HEAVY, "heavy suite: set RUN_HEAVY=1 to run");
+
+test("the workspace exposes its primary editing surfaces", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator("#root")).not.toBeEmpty({ timeout: 30_000 });
+
+  // The workspace should expose interactive controls (buttons, menus) —
+  // an interaction-free page means the shell rendered but the app did not.
+  const buttons = page.getByRole("button");
+  await expect
+    .poll(async () => buttons.count(), { timeout: 15_000 })
+    .toBeGreaterThan(0);
+
+  // Every button that opens a menu/dialog must not crash the page.
+  const pageErrors: Error[] = [];
+  page.on("pageerror", (error) => pageErrors.push(error));
+  const count = Math.min(await buttons.count(), 5);
+  for (let i = 0; i < count; i += 1) {
+    const button = buttons.nth(i);
+    if (await button.isVisible()) {
+      await button.click({ trial: false }).catch(() => {});
+      await page.keyboard.press("Escape").catch(() => {});
+    }
+  }
+  expect(pageErrors).toHaveLength(0);
+});

--- a/e2e/tests/authoring-smoke.spec.ts
+++ b/e2e/tests/authoring-smoke.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from "@playwright/test";
+
+// Light suite (CI): the editing workspace boots and renders without errors.
+// This is the canary for "the Vizij app / workspace is broken" regressions —
+// wasm packages failing to load, a crashed React root, or a module-level
+// exception all fail here.
+
+test("the authoring workspace boots without page errors", async ({ page }) => {
+  const pageErrors: Error[] = [];
+  page.on("pageerror", (error) => pageErrors.push(error));
+
+  await page.goto("/");
+
+  // The React root must render actual UI, not stay empty (a crashed app
+  // leaves #root empty while the HTTP request still succeeds).
+  const root = page.locator("#root");
+  await expect(root).not.toBeEmpty({ timeout: 30_000 });
+
+  // Give lazy wasm modules a moment to initialize, then assert nothing threw.
+  await page.waitForTimeout(2_000);
+  expect(
+    pageErrors,
+    `page errors: ${pageErrors.map((e) => e.message).join("; ")}`,
+  ).toHaveLength(0);
+});

--- a/package.json
+++ b/package.json
@@ -53,7 +53,9 @@
     "rebuild-nodes": "node ./scripts/rebuild-nodes.mjs",
     "wasm:status": "node ./scripts/wasm-links.mjs status",
     "wasm:link": "node ./scripts/wasm-links.mjs link",
-    "wasm:unlink": "node ./scripts/wasm-links.mjs unlink"
+    "wasm:unlink": "node ./scripts/wasm-links.mjs unlink",
+    "e2e": "pnpm --filter vizij-e2e run e2e",
+    "e2e:heavy": "pnpm --filter vizij-e2e run e2e:heavy"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -716,6 +716,12 @@ importers:
         specifier: ^6.3.5
         version: 6.4.1(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1)
 
+  e2e:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.49.0
+        version: 1.58.2
+
   packages/@vizij/animation-react:
     dependencies:
       '@vizij/animation-wasm':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,4 @@ packages:
   - apps/*
   - packages/*
   - packages/*/*
+  - e2e


### PR DESCRIPTION
Automated validation that the Vizij app and the editing workspace aren't broken, in two tiers:

- **Light (CI, every push)**: boots `vizij-authoring` headless via the playwright `webServer`, asserts the React root renders real UI and **zero page errors** — catches wasm load failures, crashed roots, module-level exceptions. Runs in ~10 s after build. Verified green locally.
- **Heavy (on demand)**: `pnpm run e2e:heavy` (`RUN_HEAVY=1`) drives generic editing interactions (buttons/menus must not crash the page). This is the seed for real journeys (add node → bind → save → reload) once the workspace exposes `data-testid` hooks — selectors are deliberately role-based until then.

CI: new `e2e` job (pnpm install → build:packages → install chromium → run light suite → upload traces on failure). The existing `smoke:ws-app` protocol script remains the transport-level check; a full app↔WS round-trip harness is the natural next heavy tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)