### PR TITLE
chore: ignore Rust/Cargo + Tauri build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,9 @@
 .eslintcache
 .claude/settings.local.json
 .worktrees/
+
+# Rust / Cargo build output (nested crates, incl. Tauri src-tauri and arora-* packages)
+**/target/
+
+# Tauri auto-generated capability/ACL schemas (regenerated on build)
+**/src-tauri/gen/schemas/


### PR DESCRIPTION
Add `**/target/` (nested Cargo crates — the arora-* packages and the Tauri `src-tauri` app) and `**/src-tauri/gen/schemas/` (Tauri-regenerated capability/ACL schemas) so build/generated output stays out of `git status`. Forward-looking: in place before the Rust crates on feature branches merge to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)