### PR TITLE
Post-swap cleanup + docs: one Arora device per provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,17 +40,17 @@ This workspace consumes the Rust artefacts from [`vizij-rs`](../vizij-rs) via `@
 
 ### Packages
 
-| Package                       | Path                                   | Summary                                                        | Key scripts                                  |
-| ----------------------------- | -------------------------------------- | -------------------------------------------------------------- | -------------------------------------------- |
-| `@vizij/animation-react`      | `packages/@vizij/animation-react`      | React provider for the animation WASM engine.                  | `dev`, `build`, `typecheck`, `clean`         |
-| `@vizij/arora-types`          | `packages/@vizij/arora-types`          | TypeScript protocol types for standalone/control work.         | `dev`, `build`, `test`, `typecheck`, `clean` |
-| `@vizij/minimal-demo-ui`      | `packages/@vizij/minimal-demo-ui`      | Shared chrome and theme layer for minimal demos.               | `dev`, `build`, `typecheck`, `clean`         |
-| `@vizij/node-graph-authoring` | `packages/@vizij/node-graph-authoring` | Authoring/compiler helpers and IR report CLI.                  | `dev`, `build`, `test`, `typecheck`, `clean` |
-| `@vizij/node-graph-react`     | `packages/@vizij/node-graph-react`     | React provider & hooks for node graphs.                        | `dev`, `build`, `test`, `typecheck`, `clean` |
-| `@vizij/orchestrator-react`   | `packages/@vizij/orchestrator-react`   | React orchestrator bindings and hooks.                         | `dev`, `build`, `test`, `typecheck`, `clean` |
-| `@vizij/render`               | `packages/@vizij/render`               | Three.js renderer + controllers for Vizij rigs.                | `dev`, `build`, `typecheck`, `clean`         |
-| `@vizij/runtime-react`        | `packages/@vizij/runtime-react`        | Higher-level runtime provider wiring renderer + orchestration. | `dev`, `build`, `test`, `typecheck`, `clean` |
-| `@vizij/utils`                | `packages/@vizij/utils`                | Shared math/value utilities consumed across packages/apps.     | `dev`, `build`, `test`, `clean`              |
+| Package                       | Path                                   | Summary                                                         | Key scripts                                  |
+| ----------------------------- | -------------------------------------- | --------------------------------------------------------------- | -------------------------------------------- |
+| `@vizij/animation-react`      | `packages/@vizij/animation-react`      | React provider for the animation WASM engine.                   | `dev`, `build`, `typecheck`, `clean`         |
+| `@vizij/arora-types`          | `packages/@vizij/arora-types`          | TypeScript protocol types for standalone/control work.          | `dev`, `build`, `test`, `typecheck`, `clean` |
+| `@vizij/minimal-demo-ui`      | `packages/@vizij/minimal-demo-ui`      | Shared chrome and theme layer for minimal demos.                | `dev`, `build`, `typecheck`, `clean`         |
+| `@vizij/node-graph-authoring` | `packages/@vizij/node-graph-authoring` | Authoring/compiler helpers and IR report CLI.                   | `dev`, `build`, `test`, `typecheck`, `clean` |
+| `@vizij/node-graph-react`     | `packages/@vizij/node-graph-react`     | React provider & hooks for node graphs.                         | `dev`, `build`, `test`, `typecheck`, `clean` |
+| `@vizij/orchestrator-react`   | `packages/@vizij/orchestrator-react`   | React orchestrator bindings and hooks.                          | `dev`, `build`, `test`, `typecheck`, `clean` |
+| `@vizij/render`               | `packages/@vizij/render`               | Three.js renderer + controllers for Vizij rigs.                 | `dev`, `build`, `typecheck`, `clean`         |
+| `@vizij/runtime-react`        | `packages/@vizij/runtime-react`        | Runtime provider wiring the renderer to an Arora device engine. | `dev`, `build`, `test`, `typecheck`, `clean` |
+| `@vizij/utils`                | `packages/@vizij/utils`                | Shared math/value utilities consumed across packages/apps.      | `dev`, `build`, `test`, `clean`              |
 
 ### Local protocol / standalone crates
 
@@ -66,7 +66,7 @@ This workspace consumes the Rust artefacts from [`vizij-rs`](../vizij-rs) via `@
 | `demo-animation-studio`        | `apps/demo-animation-studio`        | Playground for animation presets & advanced rig control.                | `dev`, `build`, `typecheck`, `preview` |
 | `demo-graph-studio`            | `apps/demo-graph-studio`            | Work-in-progress Vizij node graph editor.                               | `dev`, `build`, `typecheck`, `preview` |
 | `vizij-authoring`              | `apps/vizij-authoring`              | Author vizij assets, configure rig bindings, and export GLBs.           | `dev`, `build`, `typecheck`, `preview` |
-| `demo-vizij-player`            | `apps/demo-vizij-player`            | Authoring surface for facial rigs and orchestrator-driven playback.     | `dev`, `build`, `typecheck`, `preview` |
+| `demo-vizij-player`            | `apps/demo-vizij-player`            | Authoring surface for facial rigs and runtime-driven playback.          | `dev`, `build`, `typecheck`, `preview` |
 | `minimal-demo-animation`       | `apps/minimal-demo-animation`       | Minimal animation runtime example for quick smoke tests.                | `dev`, `build`, `typecheck`, `preview` |
 | `minimal-demo-animation-graph` | `apps/minimal-demo-animation-graph` | Animation + node-graph integration showcase (URDF IK, filtering).       | `dev`, `build`, `typecheck`, `preview` |
 | `minimal-demo-graph`           | `apps/minimal-demo-graph`           | Lightweight node-graph playground (inputs, outputs, staging behaviour). | `dev`, `build`, `typecheck`, `preview` |

--- a/apps/demo-vizij-player/src/App.tsx
+++ b/apps/demo-vizij-player/src/App.tsx
@@ -251,7 +251,6 @@ export default function App() {
             key={source!.id}
             assetBundle={assetBundle}
             autostart
-            orchestratorScope="isolated"
           >
             <WorkspaceSurface
               sourceLabel={sourceLabel}

--- a/apps/vizij-authoring/README.md
+++ b/apps/vizij-authoring/README.md
@@ -18,7 +18,7 @@ In practice, authoring uses runtime-react in more advanced ways than the simpler
 
 - `setGraphBundle()` hot-swaps rig/pose/animation/program payloads without always reloading the underlying GLB
 - `transformOutputWrite()` filters/remaps runtime outputs before they hit the renderer store
-- reference-face surfaces use shared orchestrator mode rather than isolated runtimes
+- reference-face surfaces run on their own runtime, stepped only while visible
 
 See [`src/components/app/Viewer.tsx`](./src/components/app/Viewer.tsx) and [`src/components/app/ReferenceFaceRuntime.tsx`](./src/components/app/ReferenceFaceRuntime.tsx).
 

--- a/apps/vizij-authoring/src/components/app/ReferenceFacePanel.tsx
+++ b/apps/vizij-authoring/src/components/app/ReferenceFacePanel.tsx
@@ -1,6 +1,5 @@
 import { useRef, useCallback, type ChangeEvent } from "react";
 import { X } from "lucide-react";
-import { OrchestratorProvider } from "@vizij/orchestrator-react";
 import { useReferenceFace } from "../../state/ReferenceFaceContext";
 import { Button } from "../ui";
 import { ReferenceFaceRuntime } from "./ReferenceFaceRuntime";
@@ -83,7 +82,7 @@ export function ReferenceFacePanel({
         onChange={handleFileChange}
       />
 
-      <OrchestratorProvider autostart={true}>
+      <>
         {referenceFace.file && runtimeEnabled ? (
           <ReferenceFaceRuntime
             file={referenceFace.file}
@@ -232,7 +231,7 @@ export function ReferenceFacePanel({
             </Button>
           </div>
         )}
-      </OrchestratorProvider>
+      </>
     </div>
   );
 }

--- a/apps/vizij-authoring/src/components/app/ReferenceFaceRuntime.tsx
+++ b/apps/vizij-authoring/src/components/app/ReferenceFaceRuntime.tsx
@@ -304,7 +304,6 @@ export function ReferenceFaceRuntime({
       assetBundle={activeBundleConfig.bundle}
       autostart={shouldAutostart}
       driveOrchestrator={shouldDriveVisible}
-      orchestratorScope="shared"
     >
       <ReferenceFaceBridge
         onStandardInputsReady={onStandardInputsReady}

--- a/apps/vizij-showcase/README.md
+++ b/apps/vizij-showcase/README.md
@@ -1,6 +1,6 @@
 # vizij-showcase
 
-`vizij-showcase` is the main multi-surface runtime demo in this repo. It renders several face experiences inside one app and uses `@vizij/runtime-react` in shared-orchestrator mode rather than the simpler isolated pattern used by the tutorials and `demo-vizij-player`.
+`vizij-showcase` is the main multi-surface runtime demo in this repo. It renders several face experiences inside one app, each on its own runtime, and throttles the ones that are not in view.
 
 ## Runtime Pattern
 
@@ -10,10 +10,10 @@ Each section-level face:
 
 - creates a bundle with `createShowcaseBundle()`
 - gets a unique namespace like `vizij-showcase-<section>`
-- mounts `VizijRuntimeProvider` with `orchestratorScope="shared"`
-- decides whether it should actively drive the orchestrator or stay passive
+- mounts its own `VizijRuntimeProvider` (one Arora device per face)
+- decides whether it should actively drive its runtime or stay passive
 
-This lets the showcase keep multiple runtime surfaces alive without every section running a full independent loop.
+This lets the showcase keep multiple runtime surfaces alive without every section stepping at full rate.
 
 ### Driver vs passive faces
 

--- a/apps/vizij-showcase/package.json
+++ b/apps/vizij-showcase/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.5.0",
-    "@vizij/orchestrator-react": "workspace:*",
     "@vizij/render": "workspace:*",
     "@vizij/runtime-react": "workspace:*",
     "react": "^19.2.3",

--- a/apps/vizij-showcase/src/components/ShowcaseRuntime.tsx
+++ b/apps/vizij-showcase/src/components/ShowcaseRuntime.tsx
@@ -50,7 +50,6 @@ export function ShowcaseRuntime({
       assetBundle={bundle}
       autostart={shouldAutostart}
       driveOrchestrator={shouldDriveVisible}
-      orchestratorScope="shared"
     >
       <HiddenStepController enabled={shouldDriveHidden} hz={hiddenStepHz} />
       <RuntimeDebugBeacon

--- a/apps/vizij-showcase/src/main.tsx
+++ b/apps/vizij-showcase/src/main.tsx
@@ -1,11 +1,6 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
-import { OrchestratorProvider } from "@vizij/orchestrator-react";
 import { FaceApp } from "./FaceApp";
 
 const root = createRoot(document.getElementById("root")!);
-root.render(
-  <OrchestratorProvider autostart={false}>
-    <FaceApp />
-  </OrchestratorProvider>,
-);
+root.render(<FaceApp />);

--- a/packages/@vizij/render/README.md
+++ b/packages/@vizij/render/README.md
@@ -2,7 +2,7 @@
 
 > Three.js + React renderer, scene store, and helper controllers for Vizij faces.
 
-This package exposes the `Vizij` canvas component along with hooks, stores, and GLTF helpers that power Vizij’s real-time character visualisation. It is the foundation that other packages (`@vizij/rig`, `@vizij/orchestrator-react`, etc.) build upon.
+This package exposes the `Vizij` canvas component along with hooks, stores, and GLTF helpers that power Vizij’s real-time character visualisation. It is the foundation that other packages (`@vizij/runtime-react`, etc.) build upon.
 
 ---
 
@@ -103,7 +103,7 @@ All exports are re-exported through `src/index.tsx`, so a simple `import { loadG
 
 ### Dual-format Vizij bundles
 
-Vizij scenes persist authoring metadata inside GLBs so third-party tools see baked animation, while Vizij runtimes retain orchestrator graphs and clips.
+Vizij scenes persist authoring metadata inside GLBs so third-party tools see baked animation, while Vizij runtimes retain the authored graphs and clips.
 
 - Every renderable still carries a `RobotData` extension in `userData` describing features and animatable bindings.
 - The exporter now writes a root-level `extensions.VIZIJ_bundle` block following the schema in [`src/types/vizij-bundle.ts`](./src/types/vizij-bundle.ts). It contains rig graphs, pose configs, stored Vizij clips, and provenance hashes.
@@ -112,7 +112,7 @@ Vizij scenes persist authoring metadata inside GLBs so third-party tools see bak
 - The new `animations` field exposes `VizijAnimationClipData[]`, which maps each glTF animation channel back to Vizij animatable ids (`RobotData.features.*.value.id`). Each track provides component-aware `times`/`values` arrays so runtimes can register clips without re-parsing the GLB.
 - `extractVizijBundle(scene)` and `applyVizijBundle(scene, bundle)` (under `src/functions/vizij-bundle.ts`) let advanced tooling inspect or mutate bundles without triggering a fresh export.
 
-With this structure, authoring tools can round-trip orchestrator assets while shipping native glTF animations for viewers that do not understand Vizij.
+With this structure, authoring tools can round-trip Vizij runtime assets while shipping native glTF animations for viewers that do not understand Vizij.
 
 ---
 

--- a/packages/@vizij/runtime-react/README.md
+++ b/packages/@vizij/runtime-react/README.md
@@ -1,6 +1,6 @@
 # @vizij/runtime-react
 
-`@vizij/runtime-react` is the bundle-first React runtime for Vizij faces. It loads a GLB or prebuilt world, extracts embedded Vizij metadata, registers rig/pose/program/animation controllers with the orchestrator, mirrors resolved values into the renderer store, and exposes a React-friendly control surface for apps.
+`@vizij/runtime-react` is the bundle-first React runtime for Vizij faces. It loads a GLB or prebuilt world, extracts embedded Vizij metadata, composes the rig/pose/program graphs into the behavior of an Arora device ([`@vizij/arora-web-wasm`](https://www.npmjs.com/package/@vizij/arora-web-wasm) — an Arora runtime compiled to WebAssembly), mirrors resolved values into the renderer store, and exposes a React-friendly control surface for apps.
 
 The package is intentionally aimed at app authors. If your app wants to render a Vizij face and drive it through authored rig inputs, this is the layer to build on.
 
@@ -11,7 +11,7 @@ The package is intentionally aimed at app authors. If your app wants to render a
 - load a face from a GLB URL, a `Blob`, or an already loaded world
 - extract the embedded `VIZIJ_bundle` payload when present
 - merge explicit `rig`, `pose`, `animations`, and `programs` with discovered bundle content
-- register controllers with either an isolated orchestrator or a shared parent orchestrator
+- compose the registered graphs into the device's behavior and drive its step loop
 - expose runtime status, controls, diagnostics, and update hooks through React context
 - render the resolved face with `VizijRuntimeFace`
 
@@ -21,13 +21,13 @@ The package is intentionally aimed at app authors. If your app wants to render a
 pnpm add @vizij/runtime-react react react-dom
 ```
 
-If your app also imports lower-level renderer or orchestrator APIs directly, install those packages too:
+If your app also imports lower-level renderer or engine APIs directly, install those packages too:
 
 ```bash
-pnpm add @vizij/render @vizij/orchestrator-react
+pnpm add @vizij/render @vizij/arora-web-wasm
 ```
 
-`@vizij/runtime-react`, `@vizij/render`, and `@vizij/orchestrator-react` should stay on the same workspace/release line.
+`@vizij/runtime-react`, `@vizij/render`, and `@vizij/arora-web-wasm` should stay on the same workspace/release line.
 
 ### Bundler Notes
 
@@ -101,7 +101,7 @@ function RuntimeStage() {
 }
 ```
 
-The provider resolves the face bundle, creates or reuses an orchestrator, registers the relevant controllers, and publishes the merged runtime state through `useVizijRuntime()`.
+The provider resolves the face bundle, boots its Arora device with the composed graphs as the device's behavior, and publishes the merged runtime state through `useVizijRuntime()`.
 
 ## Core Concepts
 
@@ -111,15 +111,18 @@ The main contract is `VizijAssetBundle`. In the default workflow you hand the ru
 
 Explicit overrides still work. If you provide `rig`, `pose`, `animations`, or `programs`, the runtime merges them with embedded bundle data and deduplicates animations/programs by id.
 
-### Shared or isolated orchestration
+### One device per provider
 
-`VizijRuntimeProvider` can:
+Each `VizijRuntimeProvider` owns one Arora device. The device runs the
+composed graph as its behavior on a shared key/value store: graph `input`
+nodes read store paths each tick, graph outputs write back, and the provider
+mirrors changed values into the renderer store after every step. Providers
+are fully isolated from each other — multiple faces mean multiple devices,
+and namespacing keeps their store keys apart.
 
-- create its own isolated orchestrator
-- reuse a parent `OrchestratorProvider`
-- require a shared parent and warn/fallback if one is missing
-
-This is how `vizij-showcase` and `vizij-authoring` host multiple runtime surfaces without every face spinning up its own orchestrator loop.
+`driveOrchestrator={false}` mounts a runtime that does not step its device
+from its own loop; use it for surfaces that are stepped manually (see
+[Manual stepping](#manual-stepping)) or at a background cadence.
 
 ### Asset reloads vs graph re-registration
 
@@ -156,7 +159,7 @@ Required. One of:
 - `{ kind: "blob", blob, aggressiveImport?, rootBounds? }`
 - `{ kind: "world", world, animatables, bundle? }`
 
-Use `kind: "world"` when your app already loaded the scene and wants runtime-react to wire only the orchestration/runtime layer.
+Use `kind: "world"` when your app already loaded the scene and wants runtime-react to wire only the engine/runtime layer.
 
 ### `rig`
 
@@ -199,20 +202,18 @@ Optional pre-parsed `VizijBundleExtension`. Useful when you already decoded bund
 - `assetBundle`: required runtime bundle
 - `namespace`, `faceId`: override resolved ids without mutating the incoming bundle
 - `updateTier`: `"auto"` (default), `"assets"`, or `"graphs"`
-- `autoCreate`, `createOptions`: forwarded to orchestrator creation when this provider owns the orchestrator
+- `autoCreate`: load the engine wasm and boot the device automatically on mount
 - `autostart`: start the runtime loop automatically after registration
 - `driveOrchestrator`: whether this runtime instance should call `step()` during its loop
-- `mergeStrategy`: forwarded to graph/animation registration
-- `orchestratorScope`: `"auto"`, `"shared"`, or `"isolated"`
+- `mergeStrategy`: forwarded to graph registration
 - `transformOutputWrite(write)`: intercept or drop output writes before they hit the renderer store
 - `onRegisterControllers(ids)`: receive registered graph/animation ids
 - `onStatusChange(status)`: subscribe to runtime status changes
 
 ### Important runtime flags
 
-- `autostart` controls whether the orchestrator begins stepping automatically once ready.
-- `driveOrchestrator={false}` is useful for non-driver faces in shared-orchestrator layouts.
-- `orchestratorScope="shared"` is the strict mode for apps that expect an outer `OrchestratorProvider`.
+- `autostart` controls whether the device begins stepping automatically once ready.
+- `driveOrchestrator={false}` is useful for faces stepped manually or at a background cadence.
 - `transformOutputWrite` is the hook to remap or suppress specific runtime outputs before they update renderer state.
 
 ## Runtime Context API
@@ -235,6 +236,7 @@ Use `useVizijRuntime()` inside the provider tree.
 ### Input and renderer writes
 
 - `setInput(path, value, shape?)`
+- `getValueSnapshot(path)` — the current engine-store value of a path (reads your own writes)
 - `setValue(id, namespace, value)`
 - `stagePoseNeutral(force?)`
 
@@ -301,7 +303,7 @@ Returns `null` when no provider is present. This is useful for shared components
 
 ### `useRigInput(path)`
 
-Returns `[value, setValue]` for a single runtime input path. The setter writes through the orchestrator, while the value mirrors the renderer store.
+Returns `[value, setValue]` for a single runtime input path. The setter writes into the device's store, while the value mirrors the renderer store.
 
 ### `useVizijOutputs(paths)`
 
@@ -380,9 +382,9 @@ This is the same policy used internally by the provider to decide between:
 
 ## Common Patterns
 
-### Shared orchestrator across multiple faces
+### Multiple faces in one app
 
-Wrap the outer app in `OrchestratorProvider`, then mount each runtime with `orchestratorScope="shared"`. Only one visible/driver face should normally have `driveOrchestrator={true}`.
+Mount one `VizijRuntimeProvider` per face; each owns its device. Give hidden or non-driver faces `driveOrchestrator={false}` and step them at a background cadence (see `vizij-showcase`'s `HiddenStepController`).
 
 ### Bundle-first player
 

--- a/packages/@vizij/runtime-react/src/VizijRuntimeProvider.tsx
+++ b/packages/@vizij/runtime-react/src/VizijRuntimeProvider.tsx
@@ -16,7 +16,6 @@ import { getLookup, type AnimatableValue, type RawValue } from "@vizij/utils";
 import { DeviceSlot, ensureWasmInit, isGoldenPath } from "./engine/aroraEngine";
 import { composeGraphSpecs, type GraphSource } from "./utils/composeGraph";
 import type {
-  CreateOrchOptions,
   GraphRegistrationConfig,
   GraphSubscriptions,
   MergeStrategyOptions,
@@ -1245,14 +1244,12 @@ export function VizijRuntimeProvider({
   faceId: faceIdProp,
   updateTier = "auto",
   autoCreate = true,
-  createOptions,
   autostart = false,
   driveOrchestrator = true,
   mergeStrategy,
   onRegisterControllers,
   onStatusChange,
   transformOutputWrite,
-  orchestratorScope = "auto",
 }: ProviderProps) {
   const storeRef = useRef<VizijStore | null>(null);
   if (!storeRef.current) {
@@ -1260,10 +1257,7 @@ export function VizijRuntimeProvider({
   }
 
   // The engine is an Arora device owned by this provider; every provider is
-  // isolated (its own device, its own store namespace). `orchestratorScope`
-  // is accepted for compatibility and ignored.
-  void orchestratorScope;
-
+  // isolated (its own device, its own store namespace).
   return (
     <VizijContext.Provider value={storeRef.current}>
       <VizijRuntimeProviderInner
@@ -1274,7 +1268,6 @@ export function VizijRuntimeProvider({
         autoCreate={autoCreate}
         autostart={autostart}
         driveOrchestrator={driveOrchestrator}
-        createOptions={createOptions}
         mergeStrategy={mergeStrategy}
         onRegisterControllers={onRegisterControllers}
         onStatusChange={onStatusChange}
@@ -1302,7 +1295,6 @@ type VizijRuntimeProviderInnerProps = {
   children: ReactNode;
   autoCreate: boolean;
   autostart: boolean;
-  createOptions?: CreateOrchOptions;
   driveOrchestrator: boolean;
 };
 
@@ -1319,7 +1311,6 @@ function VizijRuntimeProviderInner({
   children,
   autoCreate,
   autostart,
-  createOptions,
   driveOrchestrator,
 }: VizijRuntimeProviderInnerProps) {
   const [assetBundleOverride, setAssetBundleOverride] =
@@ -1788,13 +1779,10 @@ function VizijRuntimeProviderInner({
   }, [deviceSlot, pushError]);
 
   /** `ready` = wasm loaded; the device itself boots on first registration. */
-  const createOrchestrator = useCallback(
-    async (_options?: CreateOrchOptions) => {
-      await ensureWasmInit();
-      setReady(true);
-    },
-    [],
-  );
+  const createOrchestrator = useCallback(async () => {
+    await ensureWasmInit();
+    setReady(true);
+  }, []);
 
   const removeGraph = useCallback(
     (id: ControllerId) => {
@@ -2094,7 +2082,7 @@ function VizijRuntimeProviderInner({
 
   useEffect(() => {
     if (!ready && autoCreate) {
-      createOrchestrator(createOptions).catch((err: unknown) => {
+      createOrchestrator().catch((err: unknown) => {
         pushError({
           message: "Failed to create orchestrator runtime",
           cause: err,
@@ -2103,7 +2091,7 @@ function VizijRuntimeProviderInner({
         });
       });
     }
-  }, [ready, autoCreate, createOptions, createOrchestrator, pushError]);
+  }, [ready, autoCreate, createOrchestrator, pushError]);
 
   const registerControllers = useCallback(async () => {
     clearControllers();

--- a/packages/@vizij/runtime-react/src/types.ts
+++ b/packages/@vizij/runtime-react/src/types.ts
@@ -15,9 +15,6 @@ import type { World, VizijProps, VizijBundleExtension } from "@vizij/render";
 /** Value shape hint. Accepted through the public surface, unused by the device. */
 export type ShapeJSON = Record<string, unknown>;
 
-/** Legacy engine-creation options. Accepted for compatibility; ignored. */
-export type CreateOrchOptions = Record<string, unknown>;
-
 /** Paths a graph reads/writes — metadata for output tracking and seeding. */
 export type GraphSubscriptions = {
   inputs?: string[];
@@ -349,7 +346,6 @@ export type VizijRuntimeProviderProps = {
   faceId?: string;
   updateTier?: RuntimeUpdateTier;
   autoCreate?: boolean;
-  createOptions?: CreateOrchOptions;
   autostart?: boolean;
   driveOrchestrator?: boolean;
   mergeStrategy?: MergeStrategyOptions;
@@ -358,7 +354,6 @@ export type VizijRuntimeProviderProps = {
   transformOutputWrite?: (
     write: RuntimeOutputWrite,
   ) => RuntimeOutputWrite | null;
-  orchestratorScope?: "auto" | "shared" | "isolated";
 };
 
 export type RuntimeUpdateTier = "auto" | "assets" | "graphs";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -593,9 +593,6 @@ importers:
       '@react-three/fiber':
         specifier: ^9.5.0
         version: 9.5.0(@types/react@19.2.9)(immer@10.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(three@0.170.0)
-      '@vizij/orchestrator-react':
-        specifier: workspace:*
-        version: link:../../packages/@vizij/orchestrator-react
       '@vizij/render':
         specifier: workspace:*
         version: link:../../packages/@vizij/render


### PR DESCRIPTION
Two commits, both follow-through on the engine swap ([#39](https://github.com/vizij-ai/vizij-web/pull/39)):

**Cleanup** — `VizijRuntimeProvider` drops the `orchestratorScope` and `createOptions` props (every provider owns one isolated Arora device; the wasm needs no creation options). The app-root `OrchestratorProvider` wrappers in showcase `main.tsx` and authoring `ReferenceFacePanel` wrapped nothing that reads an orchestrator context and are gone; showcase drops `@vizij/orchestrator-react` entirely. The authoring motiongraph tooling keeps its own provider — [VIZ-62](https://linear.app/semio-ai/issue/VIZ-62) migrates it to the device API.

**Docs** — READMEs describe the runtime as it is: each provider owns one Arora device (`@vizij/arora-web-wasm`) running the composed rig/pose/program graph on a shared key/value store; multi-face apps mount one provider per face and throttle hidden ones. Provider props, context members (`getValueSnapshot`), install notes, and patterns match the shipped API (runtime-react, showcase, authoring, render, root).

Gates: runtime-react typecheck/lint/58 tests green; authoring, standalone, showcase, demo-player typecheck green; markdownlint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)