### PR TITLE
Clearing an input restores its neutral value, not zero (VIZ-60)

### DIFF
--- a/packages/@vizij/runtime-react/src/VizijRuntimeProvider.tsx
+++ b/packages/@vizij/runtime-react/src/VizijRuntimeProvider.tsx
@@ -874,6 +874,44 @@ function convertBundlePrograms(
     .filter(Boolean) as VizijProgramAsset[];
 }
 
+/**
+ * The default (neutral) value declared for an input path, resolved across the
+ * path forms the constraint map is keyed by (namespaced, base, rig/face-
+ * stripped, relative). Returns `undefined` when no finite default is declared.
+ */
+export function resolveConstraintDefault(
+  path: string,
+  namespace: string,
+  inputConstraints: Record<string, { defaultValue?: number }>,
+): number | undefined {
+  const trimmed = path.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const stripped = stripRigFacePrefix(trimmed);
+  const relativePath = stripped ? `/${stripped}` : "";
+  const candidates = [
+    namespaceTypedPath(trimmed, namespace),
+    trimmed,
+    stripped ? namespaceTypedPath(stripped, namespace) : undefined,
+    stripped || undefined,
+    relativePath || undefined,
+  ];
+
+  for (const candidate of candidates) {
+    if (!candidate) {
+      continue;
+    }
+    const defaultValue = inputConstraints[candidate]?.defaultValue;
+    if (Number.isFinite(defaultValue)) {
+      return Number(defaultValue);
+    }
+  }
+
+  return undefined;
+}
+
 export function deriveProgramInputSeedValues(args: {
   program: VizijProgramAsset;
   namespace: string;
@@ -884,35 +922,6 @@ export function deriveProgramInputSeedValues(args: {
   getPathSnapshot: (path: string) => ValueJSON | undefined;
   stagedInputs: Map<string, { value: ValueJSON; shape?: ShapeJSON }>;
 }): Array<{ path: string; value: ValueJSON }> {
-  const resolveConstraintDefault = (path: string): number | undefined => {
-    const trimmed = path.trim();
-    if (!trimmed) {
-      return undefined;
-    }
-
-    const stripped = stripRigFacePrefix(trimmed);
-    const relativePath = stripped ? `/${stripped}` : "";
-    const candidates = [
-      namespaceTypedPath(trimmed, args.namespace),
-      trimmed,
-      stripped ? namespaceTypedPath(stripped, args.namespace) : undefined,
-      stripped || undefined,
-      relativePath || undefined,
-    ];
-
-    for (const candidate of candidates) {
-      if (!candidate) {
-        continue;
-      }
-      const defaultValue = args.inputConstraints[candidate]?.defaultValue;
-      if (Number.isFinite(defaultValue)) {
-        return Number(defaultValue);
-      }
-    }
-
-    return undefined;
-  };
-
   const graphSpec = resolveGraphSpec(
     args.program.graph,
     `${args.program.id ?? "program"} graph (seed defaults)`,
@@ -933,7 +942,11 @@ export function deriveProgramInputSeedValues(args: {
         return [];
       }
 
-      const defaultValue = resolveConstraintDefault(path);
+      const defaultValue = resolveConstraintDefault(
+        path,
+        args.namespace,
+        args.inputConstraints,
+      );
       if (!Number.isFinite(defaultValue)) {
         return [];
       }
@@ -1867,11 +1880,20 @@ function VizijRuntimeProviderInner({
   /**
    * The device store has no key removal through this surface; clearing an
    * input means writing its neutral value so the graph stops acting on it.
+   * The neutral is the input's declared default from `inputConstraints`; with
+   * no declared default we fall back to `{ float: 0 }`.
    */
   const removeInput = useCallback(
     (path: string) => {
       pendingWritesRef.current.delete(path);
-      deviceSlot.current?.device.setValue(path, { float: 0 } as ValueJSON);
+      const neutral = resolveConstraintDefault(
+        path,
+        namespaceRef.current,
+        inputConstraintsRef.current,
+      );
+      const value: ValueJSON =
+        neutral !== undefined ? { float: neutral } : { float: 0 };
+      deviceSlot.current?.device.setValue(path, value);
     },
     [deviceSlot],
   );

--- a/packages/@vizij/runtime-react/src/__tests__/programInputs.test.ts
+++ b/packages/@vizij/runtime-react/src/__tests__/programInputs.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { deriveProgramInputSeedValues } from "../VizijRuntimeProvider";
+import {
+  deriveProgramInputSeedValues,
+  resolveConstraintDefault,
+} from "../VizijRuntimeProvider";
 import type { VizijProgramAsset } from "../types";
 
 function makeProgram(path: string): VizijProgramAsset {
@@ -94,5 +97,51 @@ describe("deriveProgramInputSeedValues", () => {
     });
 
     expect(writes).toEqual([]);
+  });
+});
+
+describe("resolveConstraintDefault", () => {
+  const inputPath =
+    "rig/quori_latest/standard/vmotion/idle/eyes/jitter_amplitude";
+
+  it("resolves the declared default from the namespaced path form", () => {
+    // `removeInput` receives an already-namespaced path.
+    const namespaced = `demo-player/${inputPath}`;
+    expect(
+      resolveConstraintDefault(namespaced, "demo-player", {
+        [namespaced]: { defaultValue: 0.25 },
+      }),
+    ).toBe(0.25);
+  });
+
+  it("resolves a base input path against a namespaced constraint key", () => {
+    // `deriveProgramInputSeedValues` passes base paths from the graph spec;
+    // the constraint map is keyed by the namespaced form.
+    const namespaced = `demo-player/${inputPath}`;
+    expect(
+      resolveConstraintDefault(inputPath, "demo-player", {
+        [namespaced]: { defaultValue: 0.5 },
+      }),
+    ).toBe(0.5);
+  });
+
+  it("resolves defaults keyed by the rig/face-stripped relative path", () => {
+    expect(
+      resolveConstraintDefault(inputPath, "demo-player", {
+        "/standard/vmotion/idle/eyes/jitter_amplitude": { defaultValue: 0.25 },
+      }),
+    ).toBe(0.25);
+  });
+
+  it("returns undefined when no finite default is declared", () => {
+    // No declared default -> removeInput falls back to { float: 0 }.
+    expect(
+      resolveConstraintDefault(inputPath, "demo-player", {}),
+    ).toBeUndefined();
+    expect(
+      resolveConstraintDefault(inputPath, "demo-player", {
+        [inputPath]: {},
+      }),
+    ).toBeUndefined();
   });
 });


### PR DESCRIPTION
`removeInput` wrote a hardcoded `{ float: 0 }` into the device store, so clearing an animation input (e.g. when a clip stops driving a channel) snapped the rig to zero instead of the input's authored neutral. It now resolves the input's declared default from `inputConstraints` and writes that, falling back to `{ float: 0 }` only when no finite default is declared.

The default-resolution logic (`resolveConstraintDefault`) is hoisted out of `deriveProgramInputSeedValues` to module scope and shared by both call sites, so the two paths resolve neutrals identically across the path forms the constraint map is keyed by (namespaced, base, rig/face-stripped, relative). Covered by direct unit tests for the resolver plus the existing seed-value tests.

Gates: runtime-react typecheck 0, lint clean, 62/62 tests, prettier clean.

Closes [VIZ-60](https://linear.app/semio-ai/issue/VIZ-60).

🤖 Generated with [Claude Code](https://claude.com/claude-code)