### PR TITLE
test(e2e): smoke the standalone demos (player, animation-studio, graph-studio)

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from "@playwright/test";
+import { STANDALONE_DEMOS } from "./standalone-demos";
 
-// The light suite boots the authoring workspace (the editing surface) and
-// asserts it renders without page errors — cheap enough for CI on every push.
-// Journey specs that drive real editing interactions are gated behind
-// RUN_HEAVY=1 (pnpm run e2e:heavy) so they can be run on demand.
+// The light suite boots the authoring workspace (the editing surface) and each
+// standalone demo, and asserts they render without page errors — cheap enough
+// for CI on every push. Journey specs that drive real editing interactions are
+// gated behind RUN_HEAVY=1 (pnpm run e2e:heavy) so they can be run on demand.
 export default defineConfig({
   testDir: "./tests",
   timeout: 60_000,
@@ -13,12 +14,24 @@ export default defineConfig({
     screenshot: "only-on-failure",
     trace: "retain-on-failure",
   },
-  webServer: {
-    command:
-      "pnpm --filter vizij-authoring exec vite --port 5199 --strictPort --host 127.0.0.1",
-    url: "http://127.0.0.1:5199",
-    reuseExistingServer: !process.env.CI,
-    timeout: 120_000,
-    cwd: "..",
-  },
+  // One dev server per app under test. Playwright boots them all and waits for
+  // each URL before running. The authoring specs use the shared baseURL (5199);
+  // the standalone-demo specs navigate to their own ports (see standalone-demos.ts).
+  webServer: [
+    {
+      command:
+        "pnpm --filter vizij-authoring exec vite --port 5199 --strictPort --host 127.0.0.1",
+      url: "http://127.0.0.1:5199",
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      cwd: "..",
+    },
+    ...STANDALONE_DEMOS.map((demo) => ({
+      command: `pnpm --filter ${demo.filter} exec vite --port ${demo.port} --strictPort --host 127.0.0.1`,
+      url: `http://127.0.0.1:${demo.port}`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      cwd: "..",
+    })),
+  ],
 });

--- a/e2e/standalone-demos.ts
+++ b/e2e/standalone-demos.ts
@@ -1,0 +1,25 @@
+// The standalone demo apps covered by the smoke suite. Each runs on its own
+// vite dev server (booted by playwright.config.ts) and is smoke-tested by
+// tests/standalone-demos-smoke.spec.ts. Keep this list and the ports in sync —
+// both the web servers and the specs are generated from it.
+//
+// These are the "run it on its own" demos that exercise the wasm + render stack
+// end to end (orchestrator / animation / node-graph). Booting each and asserting
+// it renders without page errors is the canary for that stack regressing.
+export interface StandaloneDemo {
+  /** pnpm workspace filter / package name. */
+  filter: string;
+  /** Dedicated dev-server port (must be unique across the list + authoring 5199). */
+  port: number;
+}
+
+export const STANDALONE_DEMOS: StandaloneDemo[] = [
+  { filter: "demo-vizij-player", port: 5200 },
+  { filter: "demo-animation-studio", port: 5201 },
+  { filter: "demo-graph-studio", port: 5202 },
+];
+
+/** The base URL a demo is served on. */
+export function demoUrl(demo: StandaloneDemo): string {
+  return `http://127.0.0.1:${demo.port}/`;
+}

--- a/e2e/tests/standalone-demos-smoke.spec.ts
+++ b/e2e/tests/standalone-demos-smoke.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "@playwright/test";
+import { STANDALONE_DEMOS, demoUrl } from "../standalone-demos";
+
+// Light suite (CI): each standalone demo boots and renders without page errors.
+// These demos drive the wasm packages (orchestrator / animation / node-graph)
+// and the renderer end to end, so a failed wasm load, a crashed React root, or
+// a module-level exception all surface here — the canary that a standalone demo
+// regressed. One test per demo (see standalone-demos.ts); each runs on its own
+// dev server, so we navigate to its absolute URL.
+for (const demo of STANDALONE_DEMOS) {
+  test(`${demo.filter} boots without page errors`, async ({ page }) => {
+    const pageErrors: Error[] = [];
+    page.on("pageerror", (error) => pageErrors.push(error));
+
+    await page.goto(demoUrl(demo));
+
+    // The React root must render actual UI, not stay empty (a crashed app leaves
+    // #root empty while the HTTP request still succeeds).
+    const root = page.locator("#root");
+    await expect(root).not.toBeEmpty({ timeout: 30_000 });
+
+    // Give the lazy wasm packages a moment to initialize, then assert nothing threw.
+    await page.waitForTimeout(2_000);
+    expect(
+      pageErrors,
+      `page errors: ${pageErrors.map((e) => e.message).join("; ")}`,
+    ).toHaveLength(0);
+  });
+}


### PR DESCRIPTION
## What

Extend the Playwright smoke suite to the **standalone demos** so a broken demo is caught automatically. Adds one smoke test per demo (boot its dev server, assert `#root` renders with **zero page errors** — the canary for a wasm-load / React-crash / module-exception regression):

- `demo-vizij-player`
- `demo-animation-studio`
- `demo-graph-studio`

Driven by a shared `e2e/standalone-demos.ts` list, so both the Playwright web servers and the specs are generated from it — **adding a demo is one line**.

## Testing

`pnpm --filter vizij-e2e run e2e --grep "boots without page errors"` → **4 passed** (authoring + the 3 demos).

Local setup notes (CI already does these): run `pnpm run build:packages` and `pnpm --filter vizij-e2e exec playwright install chromium` first — the browser build must match the resolved `@playwright/test`.

Stacked on `feat/e2e-smoke` (the authoring smoke + CI job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
