### PR TITLE
test(vizij-authoring): de-flake Viewer test (stub orchestrator-react)

### DIFF
--- a/apps/vizij-authoring/src/components/app/Viewer.test.tsx
+++ b/apps/vizij-authoring/src/components/app/Viewer.test.tsx
@@ -86,6 +86,18 @@ vi.mock("@vizij/runtime-react", () => ({
   }),
 }));
 
+// `Viewer` renders the real `OrchestratorProvider`, which otherwise kicks off a
+// fire-and-forget wasm `fetch` in the test env; its rejection lands after the
+// jsdom teardown ("window is not defined") and flakily fails the run. Stub it —
+// the real `useOrchestrator` is only consumed by the mocked motiongraph
+// components below, so a passthrough provider is enough.
+vi.mock("@vizij/orchestrator-react", () => ({
+  OrchestratorProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="orchestrator-provider">{children}</div>
+  ),
+  useOrchestrator: () => ({}),
+}));
+
 vi.mock("../../motiongraph/components/MotionGraphValueSampler", () => ({
   MotionGraphValueSampler: ({ active }: { active: boolean }) => {
     motionGraphValueSamplerSpy({ active });


### PR DESCRIPTION
## Problem
The `apps/vizij-authoring` vitest `build` job flakily fails with `ReferenceError: window is not defined` in `Viewer.test.tsx`. Root cause: `Viewer` renders the real `OrchestratorProvider` from `@vizij/orchestrator-react`, which kicks off a fire-and-forget wasm `fetch`. In the jsdom test env that fetch fails and its rejection lands *after* the environment tears down, so Vitest catches an unhandled `window is not defined` error and fails the run non-deterministically. This has reddened unrelated PRs (e.g. the #43 icon PR) that only needed a rerun.

## Fix
Stub `@vizij/orchestrator-react` in `Viewer.test.tsx`, exactly like the existing `@vizij/render` and `@vizij/runtime-react` mocks. The real `useOrchestrator` is consumed only by the already-mocked motiongraph children, so a passthrough `OrchestratorProvider` is enough. No real wasm init → no async rejection → deterministic.

## Verify
`vitest run src/components/app/Viewer.test.tsx` → 13/13 pass, clean (no unhandled errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)