### PR TITLE
ci: stop double CI runs on PRs (scope push to main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: ci
 on:
   push:
+    branches: [main]
   pull_request:
 
 concurrency:


### PR DESCRIPTION
`ci.yml` triggered on bare `push:` + `pull_request:`, so same-repo PR branches ran build/e2e twice (once per event; the concurrency group keys on `github.ref` so they never cancel). Scope `push` to `branches: [main]` — matching `android.yml`. PRs now run once; `main` still builds on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)