### PR TITLE
fix(vite): exclude @vizij/arora-web-wasm from optimizeDeps (fixes 'Failed to create orchestrator runtime')

### DIFF
--- a/apps/demo-vizij-player/vite.config.ts
+++ b/apps/demo-vizij-player/vite.config.ts
@@ -45,7 +45,11 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
-    exclude: ["@vizij/orchestrator-wasm", "@vizij/node-graph-wasm"],
+    exclude: [
+      "@vizij/orchestrator-wasm",
+      "@vizij/node-graph-wasm",
+      "@vizij/arora-web-wasm",
+    ],
     include: ["@vizij/orchestrator-react", "@vizij/render"],
   },
 });

--- a/apps/vizij-authoring/vite.config.ts
+++ b/apps/vizij-authoring/vite.config.ts
@@ -85,6 +85,7 @@ export default defineConfig(({ mode }) => {
         "@vizij/animation-wasm",
         "@vizij/orchestrator-wasm",
         "@vizij/node-graph-wasm",
+        "@vizij/arora-web-wasm",
       ],
       include: [
         "@vizij/animation-react",

--- a/apps/vizij-showcase/vite.config.ts
+++ b/apps/vizij-showcase/vite.config.ts
@@ -45,7 +45,11 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
-    exclude: ["@vizij/orchestrator-wasm", "@vizij/node-graph-wasm"],
+    exclude: [
+      "@vizij/orchestrator-wasm",
+      "@vizij/node-graph-wasm",
+      "@vizij/arora-web-wasm",
+    ],
     include: ["@vizij/orchestrator-react", "@vizij/render"],
   },
 });

--- a/apps/vizij-standalone/vite.config.ts
+++ b/apps/vizij-standalone/vite.config.ts
@@ -52,7 +52,11 @@ export default defineConfig(async () => ({
     },
   },
   optimizeDeps: {
-    exclude: ["@vizij/orchestrator-wasm", "@vizij/node-graph-wasm"],
+    exclude: [
+      "@vizij/orchestrator-wasm",
+      "@vizij/node-graph-wasm",
+      "@vizij/arora-web-wasm",
+    ],
     include: [
       "@vizij/orchestrator-react",
       "@vizij/node-graph-react",


### PR DESCRIPTION
## Symptom
Running the arora-runtime apps in dev throws **"Failed to create orchestrator runtime"** (`VizijRuntimeProvider.tsx:2109`) with a console `TypeError: fetch failed` from `@vizij/arora-web-wasm`. In `vizij-authoring`, loading a GLB instead **wedges at "Synchronize Bundle State"** (`bundle-sync`) — the loader waits on a runtime that never becomes ready.

## Root cause
The engine swap made `@vizij/runtime-react` drive `@vizij/arora-web-wasm` (`engine/aroraEngine.ts` → `ensureWasmInit` → `startDevice`), but **no app added it to Vite's `optimizeDeps.exclude`** — unlike the pre-existing `@vizij/orchestrator-wasm` / `@vizij/node-graph-wasm` entries. esbuild prebundles the package into `.vite/deps/`, so its wasm bootstrap — `new URL("../../pkg/vizij_arora_web_bg.wasm", import.meta.url)` and the relative glue import (`../../pkg/vizij_arora_web.js`) — resolves the `.wasm` against the prebundle cache and 404s.

## Fix
Add `@vizij/arora-web-wasm` to `optimizeDeps.exclude` in the four apps that mount the arora runtime (they alias `@vizij/runtime-react`): `demo-vizij-player`, `vizij-authoring`, `vizij-showcase`, `vizij-standalone`. Dev-only config; no app code changes.

## Verification
`demo-vizij-player dev` driven headless (Playwright): **0 console errors**, the runtime initializes, no "Failed to create orchestrator" message, page renders. The same root cause + fix applies to the other three; `vizij-authoring`'s `bundle-sync` hang is the same "device never inits" symptom and should clear (please confirm a GLB load).

## Not covered
This is a **dev-server** fix (`optimizeDeps` is esbuild/dev-only; production builds use Rollup). If the Android emulator smoke (vizij-web #44) is failing for a wasm reason rather than emulator flake, that's a separate build-path investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)