### PR TITLE
test(e2e): guard arora load-sample marshalling + require arora-web-wasm 0.1.2

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -13,6 +13,17 @@ export default defineConfig({
     baseURL: "http://127.0.0.1:5199",
     screenshot: "only-on-failure",
     trace: "retain-on-failure",
+    launchOptions: {
+      // Software WebGL (SwiftShader) so three.js can create a GL context in
+      // headless CI. Without it, context creation fails and cascades into the
+      // React tree — which would mask the runtime assertions the specs make.
+      args: [
+        "--enable-unsafe-swiftshader",
+        "--use-gl=angle",
+        "--use-angle=swiftshader",
+        "--ignore-gpu-blocklist",
+      ],
+    },
   },
   // One dev server per app under test. Playwright boots them all and waits for
   // each URL before running. The authoring specs use the shared baseURL (5199);

--- a/e2e/tests/demo-vizij-player-load-sample.spec.ts
+++ b/e2e/tests/demo-vizij-player-load-sample.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from "@playwright/test";
+import { STANDALONE_DEMOS, demoUrl } from "../standalone-demos";
+
+// Regression for the arora value-marshalling bug: `demo-vizij-player` mounts the
+// arora runtime (`@vizij/runtime-react` → `@vizij/arora-web-wasm`). Loading a
+// sample drives `setValue` with vizij `ValueJSON` shorthand (`{"float": …}`,
+// `{"vec3": …}`); the arora store speaks the canonical `Value` serde (`{"f32": …}`),
+// so before @vizij/arora-web-wasm@0.1.2 every write threw `unknown variant 'float'`
+// and surfaced as "Failed to create orchestrator runtime". The boot-only smoke
+// (standalone-demos-smoke) never loaded a sample, so it missed this. This test
+// loads the curated sample and asserts the runtime accepts the values.
+//
+// It ignores WebGL context errors: the three.js face renderer needs a GL context,
+// which only exists headlessly via the swiftshader launch flags in
+// playwright.config.ts; a GL hiccup is not what this test guards.
+const player = STANDALONE_DEMOS.find((d) => d.filter === "demo-vizij-player");
+if (!player) throw new Error("demo-vizij-player missing from STANDALONE_DEMOS");
+
+const RUNTIME_ERROR =
+  /unknown variant|Failed to create orchestrator|expected magic word|failed to init wasm/i;
+
+test("demo-vizij-player loads a sample without a runtime value error", async ({
+  page,
+}) => {
+  const runtimeErrors: string[] = [];
+  const record = (msg: string) => {
+    if (RUNTIME_ERROR.test(msg)) runtimeErrors.push(msg);
+  };
+  page.on("pageerror", (e) => record(e.message));
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") record(m.text());
+  });
+
+  await page.goto(demoUrl(player));
+  // The curated-library "Load sample" button loads the Quori bundle and creates
+  // the arora device with its real graph, then drives it.
+  await page
+    .getByRole("button", { name: /load sample/i })
+    .first()
+    .click();
+  // Let the device create + a few frames of setValue/step run.
+  await page.waitForTimeout(8_000);
+
+  expect(
+    runtimeErrors,
+    `arora runtime value errors:\n${runtimeErrors.join("\n")}`,
+  ).toHaveLength(0);
+});

--- a/packages/@vizij/runtime-react/package.json
+++ b/packages/@vizij/runtime-react/package.json
@@ -38,7 +38,7 @@
     "prepack": "pnpm run build && pnpm run test && pnpm run typecheck && pnpm run lint"
   },
   "dependencies": {
-    "@vizij/arora-web-wasm": "^0.1.0",
+    "@vizij/arora-web-wasm": "^0.1.2",
     "@vizij/node-graph-authoring": "workspace:*",
     "@vizij/orchestrator-react": "workspace:*",
     "@vizij/render": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -985,8 +985,8 @@ importers:
   packages/@vizij/runtime-react:
     dependencies:
       '@vizij/arora-web-wasm':
-        specifier: ^0.1.0
-        version: 0.1.0
+        specifier: ^0.1.2
+        version: 0.1.2
       '@vizij/node-graph-authoring':
         specifier: workspace:*
         version: link:../node-graph-authoring
@@ -2771,8 +2771,8 @@ packages:
   '@vizij/animation-wasm@0.4.0':
     resolution: {integrity: sha512-CbDWOZQ73tx/syzGfKjlPwIOo0Hw/v1TK4JYg/rpuyBQAaGP7pFzxYyYVZ8cj1bEPV6gJO9jk+5jxt0Q2QgnIw==}
 
-  '@vizij/arora-web-wasm@0.1.0':
-    resolution: {integrity: sha512-wLYOIKEKbYqRcX9KTmk2Ny/7GuntW4FpH31RpqBq7/cV36LD6CTsMAF2LNiCrYigxzwbHTTxTe0BhYLwJecvAQ==}
+  '@vizij/arora-web-wasm@0.1.2':
+    resolution: {integrity: sha512-jyLXoF+7nuI6SdHuso1GYA14ILI9K6DmmPVMkQvlPhqogLn4SdHXxTFXm0mxh96Lc9B3SKkuuLAD65wHUEhFfg==}
 
   '@vizij/node-graph-wasm@0.7.0':
     resolution: {integrity: sha512-h9R+84qLxWn4G9fT2DumgWylg5eTgktMM02k+jlxaNZcKZa62ZaHnJijF+0TnTA+GEQEmKGuDdf+A6JBSh7HAw==}
@@ -7019,7 +7019,7 @@ snapshots:
       '@vizij/value-json': 0.2.0
       '@vizij/wasm-loader': 0.1.5
 
-  '@vizij/arora-web-wasm@0.1.0':
+  '@vizij/arora-web-wasm@0.1.2':
     dependencies:
       '@vizij/value-json': 0.2.0
       '@vizij/wasm-loader': 0.1.5


### PR DESCRIPTION
Pairs with vizij-rs #48 (published as **@vizij/arora-web-wasm 0.1.2**), which fixes the value-marshalling bug where the arora runtime rejected vizij `ValueJSON` shorthand (`{"float": …}`) with `unknown variant 'float'` → **"Failed to create orchestrator runtime"**.

## Changes
- **Floor** `@vizij/runtime-react` → `@vizij/arora-web-wasm ^0.1.2` (lock updated) so the fix is required.
- **New e2e regression test** (`e2e/tests/demo-vizij-player-load-sample.spec.ts`): loads `demo-vizij-player`'s curated sample and asserts the arora runtime accepts the driven values (no `unknown variant`, no "Failed to create orchestrator"). The existing boot-only smoke never loaded a sample, so it missed this class of bug.
- **SwiftShader launch flags** in `e2e/playwright.config.ts` so three.js gets a headless GL context (without it, the render crash cascades and would mask the runtime assertion).

## Verified
Ran the load-sample flow headless against the published **0.1.2** in this branch's install: wasm serves from `@vizij+arora-web-wasm@0.1.2`, **zero** runtime/marshalling errors, device creates, values flow.

Also unblocks the `vizij-authoring` GLB `bundle-sync` hang (same "device never inits" root cause, now that init + writes both succeed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)