### PR TITLE
fix(runtime): DeviceSlot restart race, empty-list render loop, stale optimizeDeps

### DIFF
--- a/apps/demo-vizij-player/src/components/AnimationPanel.tsx
+++ b/apps/demo-vizij-player/src/components/AnimationPanel.tsx
@@ -16,7 +16,11 @@ function useAnimationSnapshots(animationIds: string[]) {
 
   useEffect(() => {
     if (animationIds.length === 0) {
-      setSnapshots({});
+      // Bail if already empty: `assetBundle.animations` is rebuilt every render,
+      // so `animationIds` is a fresh reference each time and this effect re-runs
+      // on every render. Setting a new `{}` here would then loop forever
+      // ("Maximum update depth"); returning `prev` unchanged lets React bail.
+      setSnapshots((prev) => (Object.keys(prev).length === 0 ? prev : {}));
       return;
     }
     let frameId = 0;
@@ -30,7 +34,10 @@ function useAnimationSnapshots(animationIds: string[]) {
     };
     tick();
     return () => window.cancelAnimationFrame(frameId);
-  }, [animationIds, animationIdsKey, getAnimationState]);
+    // Keyed by `animationIdsKey` (stable by value), not `animationIds`
+    // (unstable identity) — otherwise the rAF loop is restarted every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [animationIdsKey, getAnimationState]);
 
   return snapshots;
 }

--- a/apps/demo-vizij-player/src/components/ProgramsPanel.tsx
+++ b/apps/demo-vizij-player/src/components/ProgramsPanel.tsx
@@ -16,7 +16,11 @@ function useProgramSnapshots(programIds: string[]) {
 
   useEffect(() => {
     if (programIds.length === 0) {
-      setSnapshots({});
+      // Bail if already empty: `assetBundle.programs` is rebuilt every render,
+      // so `programIds` is a fresh reference each time and this effect re-runs
+      // on every render. Setting a new `{}` here would then loop forever
+      // ("Maximum update depth"); returning `prev` unchanged lets React bail.
+      setSnapshots((prev) => (Object.keys(prev).length === 0 ? prev : {}));
       return;
     }
     const timer = window.setInterval(() => {
@@ -25,7 +29,11 @@ function useProgramSnapshots(programIds: string[]) {
       );
     }, 150);
     return () => window.clearInterval(timer);
-  }, [getProgramState, programIds, programIdsKey]);
+    // Keyed by `programIdsKey` (stable by value), not `programIds` (unstable
+    // identity) — otherwise the interval is torn down and rebuilt every render
+    // and its snapshots never settle.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [getProgramState, programIdsKey]);
 
   return snapshots;
 }

--- a/apps/vizij-authoring/vite.config.ts
+++ b/apps/vizij-authoring/vite.config.ts
@@ -87,11 +87,7 @@ export default defineConfig(({ mode }) => {
         "@vizij/node-graph-wasm",
         "@vizij/arora-web-wasm",
       ],
-      include: [
-        "@vizij/animation-react",
-        "@vizij/orchestrator-react",
-        "@vizij/node-graph-react",
-      ],
+      include: ["@vizij/orchestrator-react", "@vizij/node-graph-react"],
       force: true,
     },
     test: {

--- a/packages/@vizij/runtime-react/src/engine/aroraEngine.ts
+++ b/packages/@vizij/runtime-react/src/engine/aroraEngine.ts
@@ -54,56 +54,80 @@ export interface DeviceHandle {
  */
 export class DeviceSlot {
   private handle: DeviceHandle | null = null;
-  private pending: Promise<DeviceHandle> | null = null;
+  /**
+   * Serializes device (re)starts. Every `ensure`/`restart` chains behind the
+   * previous op so two recomposes never run concurrently — a second restart
+   * that captured the same `old` handle would dispose an already-freed device
+   * (wasm "null pointer passed to rust"). A bundle whose import fans out into
+   * several graph registrations recomposes several times in a burst, which is
+   * exactly when that race fires. Failures are swallowed on the chain so one
+   * failed (re)start doesn't wedge later ones; each caller still sees its own
+   * rejection through the promise `enqueue` returns.
+   */
+  private opChain: Promise<unknown> = Promise.resolve();
 
   get current(): DeviceHandle | null {
     return this.handle;
   }
 
+  private enqueue<T>(op: () => Promise<T>): Promise<T> {
+    const run = this.opChain.then(op, op);
+    this.opChain = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
   /** Boot the device with `spec` if none is live; otherwise return the live one. */
   ensure(spec: object): Promise<DeviceHandle> {
-    if (this.handle) {
-      return Promise.resolve(this.handle);
-    }
-    if (!this.pending) {
-      this.pending = (async () => {
-        await ensureWasmInit();
-        const device = await startDevice(spec);
-        this.handle = { device, spec };
-        this.pending = null;
+    return this.enqueue(async () => {
+      if (this.handle) {
         return this.handle;
-      })();
-    }
-    return this.pending;
+      }
+      await ensureWasmInit();
+      const device = await startDevice(spec);
+      this.handle = { device, spec };
+      return this.handle;
+    });
   }
 
   /**
    * Replace the device's composed graph: snapshot the store (minus golden
    * keys), start a fresh device with `spec`, restore the snapshot, dispose
-   * the old device. No-op if the spec is identical by reference.
+   * the old device. No-op if the spec is identical by reference. Serialized
+   * behind any in-flight (re)start (see `opChain`) so device disposal never
+   * races another restart's snapshot/dispose of the same device.
    */
-  async restart(spec: object): Promise<DeviceHandle> {
-    const old = this.handle;
-    if (old && old.spec === spec) {
-      return old;
-    }
-    if (!old) {
-      return this.ensure(spec);
-    }
-
-    const carried: Record<string, ValueJSON> = {};
-    for (const [path, value] of Object.entries(old.device.snapshot())) {
-      if (!isGoldenPath(path)) {
-        carried[path] = value;
+  restart(spec: object): Promise<DeviceHandle> {
+    return this.enqueue(async () => {
+      const old = this.handle;
+      if (old && old.spec === spec) {
+        return old;
       }
-    }
+      // First live device: same path as `ensure`, inlined so it runs inside
+      // this queued op instead of enqueuing behind itself (which would deadlock).
+      if (!old) {
+        await ensureWasmInit();
+        const device = await startDevice(spec);
+        this.handle = { device, spec };
+        return this.handle;
+      }
 
-    const device = await startDevice(spec);
-    if (Object.keys(carried).length > 0) {
-      device.writeValues(carried);
-    }
-    this.handle = { device, spec };
-    old.device.dispose();
-    return this.handle;
+      const carried: Record<string, ValueJSON> = {};
+      for (const [path, value] of Object.entries(old.device.snapshot())) {
+        if (!isGoldenPath(path)) {
+          carried[path] = value;
+        }
+      }
+
+      const device = await startDevice(spec);
+      if (Object.keys(carried).length > 0) {
+        device.writeValues(carried);
+      }
+      this.handle = { device, spec };
+      old.device.dispose();
+      return this.handle;
+    });
   }
 }


### PR DESCRIPTION
Three independent fixes found while debugging the arora-engine face runtime under raw-GLB imports.

## `fix(runtime-react)`: serialize DeviceSlot (re)starts
`recomposeDevice()` calls `DeviceSlot.restart()` on every graph registration. The old `restart` read `old = this.handle`, awaited `startDevice()`, then disposed `old.device` — with no in-flight guard. When a bundle import fans out into several registrations in a burst (e.g. a raw rigged GLB producing 251 rig inputs), two restarts capture the same `old` handle and the second `snapshot()`/`dispose()` lands on an already-freed wasm device → **`null pointer passed to rust`**, killing the device mid-recompose ("contours then nothing").

Serialize `ensure`/`restart` through an `opChain` promise queue so device disposal never races another (re)start. First-boot is inlined into `restart()` rather than delegating to `ensure()` (which would enqueue behind itself and deadlock). Verified headless: the error went from ×11 → 0 and the device stays ready.

## `fix(demo-vizij-player)`: stop render loop on empty program/animation lists
`useProgramSnapshots`/`useAnimationSnapshots` keyed their polling effect on the `programIds`/`animationIds` **array**, which is a fresh reference every render (`assetBundle.programs/.animations` is rebuilt by `mergeAssetBundle`). When the list is empty, the effect ran `setSnapshots({})` — a new object each render → re-render → effect re-fires → **`Maximum update depth exceeded`** (×2176 on a GLB with no programs/animations). The non-empty branch escaped it because its interval/rAF updates are async.

Guard the empty branch with a functional update that bails when already empty, and key the effect by the value-stable `*IdsKey` string instead of the array (`getProgram/AnimationState` are stable `useCallback`s). Verified: loop ×2176 → 0, face still renders.

## `chore(vizij-authoring)`: drop stale `@vizij/animation-react` optimizeDeps entry
`@vizij/animation-react` isn't a dependency of vizij-authoring, isn't imported, and isn't in `node_modules`, so listing it in `optimizeDeps.include` logged `Failed to resolve dependency` on every `pnpm dev`. Animations run through `runtime-react`'s JS animationBridge now.

---
Note: `@vizij/runtime-react` `dist` is gitignored (build artifact) — CI rebuilds it. Depends on `@vizij/runtime-react` being republished (0.2.0 is now on npm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)