### PR TITLE
fix(utils): render rigged GLBs imported into authoring (arora record-form defaults + range)

### DIFF
--- a/apps/vizij-authoring/src/rig/autoInputs.test.ts
+++ b/apps/vizij-authoring/src/rig/autoInputs.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { AnimatableComponent, AnimatableValue } from "@vizij/utils";
+import { extractAnimatableComponents } from "@vizij/utils";
 import { buildAutoRigInputBlueprints } from "./autoInputs";
 
 describe("buildAutoRigInputBlueprints", () => {
@@ -65,5 +66,82 @@ describe("buildAutoRigInputBlueprints", () => {
 
     expect(generated).toBeDefined();
     expect(generated?.path.startsWith("/propsrig/")).toBe(true);
+  });
+
+  it("carries the GLB base (not 0) when a raw rig's defaults are arora record-encoded", () => {
+    // A raw rigged GLB, loaded through @vizij/render, marshals animatable base
+    // defaults in the arora Value record encoding: scalars as { f32 } and
+    // vectors as { struct: { fields } }. If extraction cannot decode these, the
+    // props-rig input defaults collapse to 0 and every driven scale/opacity shape
+    // (including the root group) renders blank. Drive extraction end-to-end here.
+    const world = {
+      face_group: {
+        id: "face_group",
+        name: "Face_Tran_Rot_C",
+        type: "group",
+        features: {
+          scale: { animated: true, value: "face_scale" },
+        },
+      },
+      face_mesh: {
+        id: "face_mesh",
+        name: "Face",
+        type: "shape",
+        features: {
+          opacity: { animated: true, value: "face_opacity" },
+        },
+      },
+    };
+
+    const animatables = {
+      face_scale: {
+        id: "face_scale",
+        name: "Face_Tran_Rot_C scale",
+        type: "vector3",
+        default: {
+          struct: {
+            id: "struct-id",
+            fields: [
+              { id: "f-x", value: { f32: 1 } },
+              { id: "f-y", value: { f32: 1 } },
+              { id: "f-z", value: { f32: 1 } },
+            ],
+          },
+        },
+        constraints: {},
+      },
+      face_opacity: {
+        id: "face_opacity",
+        name: "Face opacity",
+        type: "number",
+        default: { f32: 1 },
+        constraints: {},
+      },
+    } as unknown as Record<string, AnimatableValue>;
+
+    const components = extractAnimatableComponents(animatables);
+    const result = buildAutoRigInputBlueprints(
+      world,
+      animatables,
+      components,
+      {},
+    );
+
+    const scaleInputs = result.blueprints.filter((entry) =>
+      entry.path.includes("/scale/"),
+    );
+    const opacityInputs = result.blueprints.filter((entry) =>
+      entry.path.includes("/opacity/"),
+    );
+
+    expect(scaleInputs.length).toBeGreaterThan(0);
+    expect(opacityInputs.length).toBeGreaterThan(0);
+    // The regression: these were all 0 before the arora record-form decode fix.
+    scaleInputs.forEach((entry) => {
+      expect(entry.input.defaultValue).toBe(1);
+    });
+    opacityInputs.forEach((entry) => {
+      expect(entry.input.defaultValue).toBe(1);
+    });
   });
 });

--- a/packages/@vizij/utils/src/rig/animatable-metadata.test.ts
+++ b/packages/@vizij/utils/src/rig/animatable-metadata.test.ts
@@ -58,6 +58,39 @@ describe("extractAnimatableComponents – arora record-form defaults", () => {
     expect(byComponent.get("z")?.defaultValue).toBe(1);
   });
 
+  it("derives a range that spans a large struct-form scale base (no [0,2] clamp)", () => {
+    // A mask/occluder shape whose GLB base scale is 25. The fallback range must
+    // grow to include it; otherwise it clamps to the scale default [0,2] and the
+    // occluder shrinks, so masks stop masking.
+    const animatables = {
+      mask_scale: {
+        id: "mask_scale",
+        name: "background scale",
+        type: "vector3",
+        default: {
+          struct: {
+            id: "struct-id",
+            fields: [
+              { id: "f-x", value: { f32: 25 } },
+              { id: "f-y", value: { f32: 25 } },
+              { id: "f-z", value: { f32: 25 } },
+            ],
+          },
+        },
+        constraints: {},
+      },
+    } as unknown as Record<string, AnimatableValue>;
+
+    const x = extractAnimatableComponents(animatables).find(
+      (c) => c.component === "x",
+    );
+
+    expect(x?.defaultValue).toBe(25);
+    // Range must contain the base so downstream clamping preserves it.
+    expect(x!.range.max).toBeGreaterThanOrEqual(25);
+    expect(x!.defaultValue).toBeLessThanOrEqual(x!.range.max);
+  });
+
   it("still reads legacy plain-number and { x, y, z } defaults", () => {
     const animatables = {
       legacy_opacity: {

--- a/packages/@vizij/utils/src/rig/animatable-metadata.test.ts
+++ b/packages/@vizij/utils/src/rig/animatable-metadata.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import type { AnimatableValue } from "../animated-values";
+import { extractAnimatableComponents } from "./animatable-metadata";
+
+/**
+ * Regression: the arora wasm runtime marshals animatable defaults in the engine
+ * Value record encoding ({ f32: n } for scalars, { struct: { fields } } for
+ * vectors) rather than plain numbers / { x, y, z }. Reading these must yield the
+ * GLB base value, not fall back to 0 — otherwise every driven scale/opacity shape
+ * collapses to zero and the face renders blank.
+ */
+describe("extractAnimatableComponents – arora record-form defaults", () => {
+  it("decodes { f32 } scalar opacity defaults to the base value", () => {
+    const animatables = {
+      opacity_anim: {
+        id: "opacity_anim",
+        name: "Face opacity",
+        type: "number",
+        // Engine-emitted scalar Value wrapper, not a plain number.
+        default: { f32: 1 },
+        constraints: {},
+      },
+    } as unknown as Record<string, AnimatableValue>;
+
+    const [opacity] = extractAnimatableComponents(animatables);
+
+    expect(opacity?.defaultValue).toBe(1);
+  });
+
+  it("decodes { struct: { fields } } vector scale defaults per component", () => {
+    const animatables = {
+      scale_anim: {
+        id: "scale_anim",
+        name: "Face scale",
+        type: "vector3",
+        // Engine-emitted struct Value wrapper with ordered f32 fields.
+        default: {
+          struct: {
+            id: "struct-id",
+            fields: [
+              { id: "f-x", value: { f32: 1 } },
+              { id: "f-y", value: { f32: 1 } },
+              { id: "f-z", value: { f32: 1 } },
+            ],
+          },
+        },
+        constraints: {},
+      },
+    } as unknown as Record<string, AnimatableValue>;
+
+    const components = extractAnimatableComponents(animatables);
+    const byComponent = new Map(
+      components.map((component) => [component.component, component]),
+    );
+
+    expect(byComponent.get("x")?.defaultValue).toBe(1);
+    expect(byComponent.get("y")?.defaultValue).toBe(1);
+    expect(byComponent.get("z")?.defaultValue).toBe(1);
+  });
+
+  it("still reads legacy plain-number and { x, y, z } defaults", () => {
+    const animatables = {
+      legacy_opacity: {
+        id: "legacy_opacity",
+        name: "Legacy opacity",
+        type: "number",
+        default: 0.5,
+        constraints: {},
+      },
+      legacy_scale: {
+        id: "legacy_scale",
+        name: "Legacy scale",
+        type: "vector3",
+        default: { x: 2, y: 3, z: 4 },
+        constraints: {},
+      },
+    } as unknown as Record<string, AnimatableValue>;
+
+    const components = extractAnimatableComponents(animatables);
+    const opacity = components.find((c) => c.animatableId === "legacy_opacity");
+    const scaleX = components.find(
+      (c) => c.animatableId === "legacy_scale" && c.component === "x",
+    );
+    const scaleZ = components.find(
+      (c) => c.animatableId === "legacy_scale" && c.component === "z",
+    );
+
+    expect(opacity?.defaultValue).toBe(0.5);
+    expect(scaleX?.defaultValue).toBe(2);
+    expect(scaleZ?.defaultValue).toBe(4);
+  });
+});

--- a/packages/@vizij/utils/src/rig/animatable-metadata.ts
+++ b/packages/@vizij/utils/src/rig/animatable-metadata.ts
@@ -425,38 +425,25 @@ export function extractAnimatableComponents(
   return result.sort((a, b) => a.label.localeCompare(b.label));
 }
 
+// The clone helpers below feed the fallback range computation (computeVector*
+// Bounds) and buildAnimatableValue. They must decode the same forms the base
+// reader does — plain {x,y,z}/{r,g,b}, arrays, AND the arora struct encoding
+// ({ struct: { fields: [...] } }) — or a struct-form default reads as 0 and the
+// derived range collapses (e.g. a scale of 25 clamped to the [0,2] fallback,
+// shrinking mask/occluder shapes). getVectorComponentValue handles all forms.
 function cloneVector2(defaultValue: unknown): RawVector2 {
-  if (defaultValue && typeof defaultValue === "object") {
-    const value = defaultValue as Record<string, unknown>;
-    if (
-      Object.prototype.hasOwnProperty.call(value, "x") &&
-      Object.prototype.hasOwnProperty.call(value, "y")
-    ) {
-      return {
-        x: coerceNumber(value.x, 0),
-        y: coerceNumber(value.y, 0),
-      };
-    }
-  }
-  return { x: 0, y: 0 };
+  return {
+    x: getVectorComponentValue(defaultValue as RawVector2, "x", 0),
+    y: getVectorComponentValue(defaultValue as RawVector2, "y", 0),
+  };
 }
 
 function cloneVector3(defaultValue: unknown): RawVector3 {
-  if (defaultValue && typeof defaultValue === "object") {
-    const value = defaultValue as Record<string, unknown>;
-    if (
-      Object.prototype.hasOwnProperty.call(value, "x") &&
-      Object.prototype.hasOwnProperty.call(value, "y") &&
-      Object.prototype.hasOwnProperty.call(value, "z")
-    ) {
-      return {
-        x: coerceNumber(value.x, 0),
-        y: coerceNumber(value.y, 0),
-        z: coerceNumber(value.z, 0),
-      };
-    }
-  }
-  return { x: 0, y: 0, z: 0 };
+  return {
+    x: getVectorComponentValue(defaultValue as RawVector3, "x", 0),
+    y: getVectorComponentValue(defaultValue as RawVector3, "y", 0),
+    z: getVectorComponentValue(defaultValue as RawVector3, "z", 0),
+  };
 }
 
 function clamp01(value: number): number {
@@ -502,17 +489,6 @@ function cloneColor(defaultValue: unknown): RawRGB {
   if (defaultValue && typeof defaultValue === "object") {
     const value = defaultValue as Record<string, unknown>;
     if (
-      Object.prototype.hasOwnProperty.call(value, "r") &&
-      Object.prototype.hasOwnProperty.call(value, "g") &&
-      Object.prototype.hasOwnProperty.call(value, "b")
-    ) {
-      return {
-        r: coerceNumber(value.r, 0),
-        g: coerceNumber(value.g, 0),
-        b: coerceNumber(value.b, 0),
-      };
-    }
-    if (
       Object.prototype.hasOwnProperty.call(value, "h") &&
       Object.prototype.hasOwnProperty.call(value, "s") &&
       Object.prototype.hasOwnProperty.call(value, "l")
@@ -522,6 +498,12 @@ function cloneColor(defaultValue: unknown): RawRGB {
       const l = coerceNumber(value.l, 0);
       return hslToRgb(h, s, l);
     }
+    // Plain {r,g,b}, arrays, and the arora struct encoding all decode here.
+    return {
+      r: getVectorComponentValue(defaultValue as RawColor, "r", 0),
+      g: getVectorComponentValue(defaultValue as RawColor, "g", 0),
+      b: getVectorComponentValue(defaultValue as RawColor, "b", 0),
+    };
   }
   return { r: 0, g: 0, b: 0 };
 }

--- a/packages/@vizij/utils/src/rig/animatable-metadata.ts
+++ b/packages/@vizij/utils/src/rig/animatable-metadata.ts
@@ -59,11 +59,60 @@ function ensureUniqueSafeId(base: string, registry: Set<string>): string {
   return candidate;
 }
 
-function coerceNumber(value: unknown, fallback: number): number {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return value;
+// Arora engine-emitted scalar Value wrappers ({ f32: 1 }, { f64: 1 }, ...).
+// The wasm runtime marshals animatable defaults in this record encoding, so the
+// plain-number reader below must unwrap it before falling back to a default.
+const SCALAR_VALUE_KEYS = [
+  "f32",
+  "f64",
+  "i64",
+  "i32",
+  "u64",
+  "u32",
+  "float",
+] as const;
+
+function unwrapScalarValue(value: unknown): number | undefined {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : undefined;
   }
-  return fallback;
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const record = value as Record<string, unknown>;
+    for (const key of SCALAR_VALUE_KEYS) {
+      const candidate = record[key];
+      if (typeof candidate === "number" && Number.isFinite(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  return undefined;
+}
+
+// Arora struct Value encoding: { struct: { fields: [{ value: <scalar> }, ...] } }.
+// Vector animatable defaults arrive in this form; return the ordered field value
+// at the requested component index.
+function unwrapStructComponent(
+  value: unknown,
+  index: number,
+): number | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const struct = (value as { struct?: unknown }).struct;
+  if (!struct || typeof struct !== "object") {
+    return undefined;
+  }
+  const fields = (struct as { fields?: unknown }).fields;
+  if (!Array.isArray(fields)) {
+    return undefined;
+  }
+  const field = fields[index] as { value?: unknown } | undefined;
+  return unwrapScalarValue(field?.value);
+}
+
+function coerceNumber(value: unknown, fallback: number): number {
+  const scalar = unwrapScalarValue(value);
+  return scalar !== undefined ? scalar : fallback;
 }
 
 function resolveRangeFromConstraints(
@@ -164,15 +213,20 @@ function getVectorComponentValue(
   if (!vector) {
     return fallback;
   }
+  const index = componentToIndex(component);
   if (Array.isArray(vector)) {
-    const index = componentToIndex(component);
     return coerceNumber(vector[index], fallback);
   }
   if (typeof vector === "object") {
+    // Arora struct encoding ({ struct: { fields: [...] } }) has no x/y/z keys.
+    const structComponent = unwrapStructComponent(vector, index);
+    if (structComponent !== undefined) {
+      return structComponent;
+    }
     const record = vector as unknown as Record<string, unknown>;
     for (const key of componentKeys(component)) {
-      const candidate = record[key];
-      if (typeof candidate === "number" && Number.isFinite(candidate)) {
+      const candidate = unwrapScalarValue(record[key]);
+      if (candidate !== undefined) {
         return candidate;
       }
     }


### PR DESCRIPTION
## Problem

Importing a raw rigged GLB (e.g. `Quori_Latest_Rigged.glb`) into **vizij-authoring** via *Import File* rendered a **blank/black face**. The same GLB renders fine in `demo-vizij-player`.

## Root cause (two readers of the same encoding)

The arora wasm runtime marshals animatable defaults in the engine **Value record encoding** — scalars as `{ f32: 1 }`, vectors as `{ struct: { fields: [{ value: { f32: 1 } }, …] } }` — not plain numbers / `{x,y,z}`. `@vizij/utils` `extractAnimatableComponents` had two independent readers of this default, and both only understood the legacy plain forms:

1. **Base value** (`coerceNumber` / `getVectorComponentValue`) → silently fell back to **0**. Every driven scale/opacity base decoded to 0, so the rig graph drove every shape *and the root group* `face_tran_rot_c` to scale 0 → **black**. (The player reads three.js mesh transforms directly, never these decoded defaults, so it's unaffected.)
2. **Fallback range** (`cloneVector2/3` / `cloneColor` → `computeScaleBounds`) → also read the struct form as 0, producing the `[0,2]` scale fallback. After fixing (1), a real base of ~25 on the mask/occluder shapes got **clamped back to 2**, shrinking them so **masks stopped masking** (eye-socket occluders too small).

## Fix

`packages/@vizij/utils/src/rig/animatable-metadata.ts`:
- `unwrapScalarValue` (`{f32|f64|i64|…|float}` + plain) and `unwrapStructComponent` (`{struct:{fields}}` by index); `coerceNumber` / `getVectorComponentValue` decode the record forms (legacy plain / `{x,y,z}` / array paths preserved).
- `cloneVector2/3` / `cloneColor` route through `getVectorComponentValue` so the derived range spans the true base and downstream clamping preserves it.

## Verification

- New `animatable-metadata.test.ts` (record-form scalar + struct decode; struct scale base 25 → `range.max ≥ 25`); extended `autoInputs.test.ts` (record-encoded raw rig → props-rig scale/opacity defaults = base, were 0).
- `@vizij/utils` 36 tests + `vizij-authoring` suite green.
- **Confirmed end-to-end** (headless): runtime drives `face_tran_rot_c` scale 1,1,1 (was 0,0,0), 126 scale/opacity outputs nonzero; the raw Quori face renders with eye-socket masks masking correctly.

Rebased on current `main` (includes #48's DeviceSlot restart-race fix, which this pairs with for a clean raw import).

🤖 Generated with [Claude Code](https://claude.com/claude-code)