### PR TITLE
feat(vizij-authoring): interactive gaze/emotion/viseme demo in viewer empty state

### DIFF
--- a/apps/vizij-authoring/.env.local.example
+++ b/apps/vizij-authoring/.env.local.example
@@ -1,3 +1,4 @@
-VITE_API_URL="https://us-central1-semio-vizij.cloudfunctions.net/api"
+# Optional: defaults to the hosted Vizij API when unset
+#VITE_API_URL="https://us-central1-semio-vizij.cloudfunctions.net/api"
 #VITE_DEEPGRAM_API_KEY=<your_deepgram_api_key>
 #VITE_OPENAI_API_KEY=<your_openai_api_key>

--- a/apps/vizij-authoring/src/components/app/RuntimeFaceFrame.tsx
+++ b/apps/vizij-authoring/src/components/app/RuntimeFaceFrame.tsx
@@ -9,7 +9,7 @@ export type RuntimeFaceFrameProps = {
   subtitle?: string;
   footer?: ReactNode;
   overlay?: ReactNode;
-  pointerTargetRef?: React.RefObject<HTMLDivElement>;
+  pointerTargetRef?: React.RefObject<HTMLDivElement | null>;
   onCanvasClick?: () => void;
   skipBounds?: boolean;
 };

--- a/apps/vizij-authoring/src/components/app/Viewer.test.tsx
+++ b/apps/vizij-authoring/src/components/app/Viewer.test.tsx
@@ -98,6 +98,12 @@ vi.mock("@vizij/orchestrator-react", () => ({
   useOrchestrator: () => ({}),
 }));
 
+// The real demo mounts its own runtime provider and fetches a GLB, neither of
+// which works in jsdom.
+vi.mock("./emptyStateDemo/EmptyStateDemo", () => ({
+  EmptyStateDemo: () => <div data-testid="empty-state-demo" />,
+}));
+
 vi.mock("../../motiongraph/components/MotionGraphValueSampler", () => ({
   MotionGraphValueSampler: ({ active }: { active: boolean }) => {
     motionGraphValueSamplerSpy({ active });
@@ -182,7 +188,12 @@ describe("Viewer", () => {
       onLoadQuori: () => {},
     });
 
-    expect(container.textContent).toContain("Empty Scene");
+    expect(
+      container.querySelector('[data-testid="empty-state-demo"]'),
+    ).toBeTruthy();
+    expect(
+      container.querySelector('[data-testid="main-import-file-button"]'),
+    ).toBeTruthy();
     expect(container.querySelector('[data-testid="runtime-face"]')).toBeNull();
     unmount();
   });

--- a/apps/vizij-authoring/src/components/app/Viewer.tsx
+++ b/apps/vizij-authoring/src/components/app/Viewer.tsx
@@ -776,6 +776,9 @@ export function Viewer({
             </div>
             <EmptyStateDemo />
             <div className="flex w-full max-w-3xl flex-col items-center gap-3 border-t border-border-default/40 pt-4">
+              <p className="text-text-primary font-medium text-lg">
+                Get Started
+              </p>
               <Button
                 data-testid="main-import-file-button"
                 onClick={onImportClick}

--- a/apps/vizij-authoring/src/components/app/Viewer.tsx
+++ b/apps/vizij-authoring/src/components/app/Viewer.tsx
@@ -41,6 +41,7 @@ import {
   type RuntimeFaceOverlayAction,
 } from "./RuntimeFaceControlsOverlay";
 import { buildRuntimeInputCatalogFromConstraints } from "./runtimeInputsFromConstraints";
+import { EmptyStateDemo } from "./emptyStateDemo/EmptyStateDemo";
 import {
   applyLockedRuntimeOutputWrite,
   buildLockedRuntimeOutputIndex,
@@ -761,18 +762,20 @@ export function Viewer({
         ) : (
           <div
             data-testid="main-viewer-empty-state"
-            className="flex flex-col items-center justify-center h-full text-text-primary gap-6 p-8 text-center animate-in fade-in duration-700"
+            className="flex flex-col items-center h-full overflow-y-auto text-text-primary gap-5 p-6 text-center animate-in fade-in duration-700"
           >
             <div className="flex flex-col gap-2">
               <p className="text-text-primary font-medium text-lg">
-                Empty Scene
+                See What Vizij Can Do
               </p>
-              <p className="text-sm max-w-xs mx-auto text-text-muted">
-                Load a Vizij asset (.glb) to begin rigging and composing your
-                scene.
+              <p className="text-sm max-w-md mx-auto text-text-muted">
+                Move your cursor over the face, tap an emotion, or make it speak
+                — then load a Vizij asset (.glb) below to begin rigging and
+                composing your own scene.
               </p>
             </div>
-            <div className="flex w-full max-w-3xl flex-col items-center gap-3">
+            <EmptyStateDemo />
+            <div className="flex w-full max-w-3xl flex-col items-center gap-3 border-t border-border-default/40 pt-4">
               <Button
                 data-testid="main-import-file-button"
                 onClick={onImportClick}

--- a/apps/vizij-authoring/src/components/app/emptyStateDemo/DemoEmotionRow.test.tsx
+++ b/apps/vizij-authoring/src/components/app/emptyStateDemo/DemoEmotionRow.test.tsx
@@ -1,0 +1,114 @@
+import { act } from "react";
+import { fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { VizijAssetBundle } from "@vizij/runtime-react";
+import { DemoEmotionRow } from "./DemoEmotionRow";
+
+const animateValueSpy = vi.fn();
+const runtimeState: { ready: boolean; assetBundle: VizijAssetBundle } = {
+  ready: true,
+  assetBundle: {} as VizijAssetBundle,
+};
+
+vi.mock("@vizij/runtime-react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@vizij/runtime-react")>();
+  return {
+    ...actual,
+    useVizijRuntime: () => ({
+      ready: runtimeState.ready,
+      animateValue: animateValueSpy,
+      faceId: "face",
+      assetBundle: runtimeState.assetBundle,
+    }),
+  };
+});
+
+function makeBundle(poseNames: string[]): VizijAssetBundle {
+  return {
+    namespace: "empty-demo",
+    glb: { kind: "url", src: "/assets/demo.glb" },
+    pose: {
+      config: {
+        version: 1,
+        faceId: "face",
+        neutralInputs: {},
+        poses: poseNames.map((name) => ({
+          id: `pose_${name.toLowerCase()}`,
+          name,
+          values: {},
+        })),
+      },
+    },
+  } as VizijAssetBundle;
+}
+
+describe("DemoEmotionRow", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    animateValueSpy.mockReset();
+    runtimeState.ready = true;
+    runtimeState.assetBundle = makeBundle([
+      "Happy",
+      "Sad",
+      "Surprise",
+      "Angry",
+      "Concerned",
+      "Sleepy",
+      "Neutral",
+    ]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders emotion buttons in canonical order, excluding neutral", () => {
+    const { container } = render(<DemoEmotionRow />);
+    const buttons = Array.from(container.querySelectorAll("button"));
+    expect(buttons.map((button) => button.textContent)).toEqual([
+      "Concerned",
+      "Happy",
+      "Sad",
+      "Sleepy",
+      "Surprise",
+      "Angry",
+    ]);
+  });
+
+  it("animates the pose weight up and auto-releases it", () => {
+    const { container } = render(<DemoEmotionRow />);
+    const happy = container.querySelector(
+      '[data-testid="empty-state-demo-emotion-happy"]',
+    ) as HTMLButtonElement;
+    expect(happy).toBeTruthy();
+
+    fireEvent.click(happy);
+    expect(animateValueSpy).toHaveBeenCalledWith(
+      "rig/face/poses/pose_happy.weight",
+      { float: 0.75 },
+      { duration: 0.25 },
+    );
+
+    animateValueSpy.mockClear();
+    act(() => {
+      vi.advanceTimersByTime(650);
+    });
+    expect(animateValueSpy).toHaveBeenCalledWith(
+      "rig/face/poses/pose_happy.weight",
+      { float: 0 },
+      { duration: 0.35 },
+    );
+  });
+
+  it("renders nothing when the runtime is not ready", () => {
+    runtimeState.ready = false;
+    const { container } = render(<DemoEmotionRow />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when the bundle has no emotion poses", () => {
+    runtimeState.assetBundle = makeBundle([]);
+    const { container } = render(<DemoEmotionRow />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/apps/vizij-authoring/src/components/app/emptyStateDemo/DemoEmotionRow.tsx
+++ b/apps/vizij-authoring/src/components/app/emptyStateDemo/DemoEmotionRow.tsx
@@ -1,0 +1,127 @@
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import {
+  EMOTION_POSE_KEYS,
+  buildPoseWeightPathMap,
+  resolvePoseSemantics,
+  useVizijRuntime,
+} from "@vizij/runtime-react";
+import { Button } from "../../ui";
+
+const DEFAULT_POSE_WEIGHT = 0.75;
+const RELEASE_DELAY_MS = 650;
+
+type EmotionBinding = {
+  poseId: string;
+  label: string;
+  weightPath: string;
+  semanticKey: string;
+};
+
+function formatLabel(key: string): string {
+  return key
+    .split(/[_\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export function DemoEmotionRow() {
+  const { ready, animateValue, faceId, assetBundle } = useVizijRuntime();
+  const poseConfig = assetBundle.pose?.config ?? null;
+  const timeoutsRef = useRef<Map<string, number>>(new Map());
+
+  const bindings = useMemo((): EmotionBinding[] => {
+    if (!poseConfig) {
+      return [];
+    }
+    const weightPaths = buildPoseWeightPathMap(
+      poseConfig.poses,
+      poseConfig.faceId ?? faceId ?? "face",
+    );
+    const candidates: EmotionBinding[] = [];
+    for (const pose of poseConfig.poses) {
+      const semantics = resolvePoseSemantics(pose, poseConfig.poseGroups);
+      if (
+        semantics.kind !== "emotion" ||
+        !semantics.key ||
+        semantics.key === "neutral"
+      ) {
+        continue;
+      }
+      const weightPath = weightPaths.get(pose.id);
+      if (!weightPath) {
+        continue;
+      }
+      candidates.push({
+        poseId: pose.id,
+        label: formatLabel(semantics.key),
+        weightPath,
+        semanticKey: semantics.key,
+      });
+    }
+    const orderedKeys: readonly string[] = EMOTION_POSE_KEYS.filter(
+      (key) => key !== "neutral",
+    );
+    const byKey = new Map(
+      candidates.map((binding) => [binding.semanticKey, binding] as const),
+    );
+    const ordered = orderedKeys
+      .map((key) => byKey.get(key))
+      .filter((binding): binding is EmotionBinding => Boolean(binding));
+    const extras = candidates.filter(
+      (binding) => !orderedKeys.includes(binding.semanticKey),
+    );
+    return [...ordered, ...extras];
+  }, [faceId, poseConfig]);
+
+  const trigger = useCallback(
+    (binding: EmotionBinding) => {
+      void animateValue(
+        binding.weightPath,
+        { float: DEFAULT_POSE_WEIGHT },
+        { duration: 0.25 },
+      );
+      const existing = timeoutsRef.current.get(binding.poseId);
+      if (existing) {
+        window.clearTimeout(existing);
+      }
+      const timeout = window.setTimeout(() => {
+        void animateValue(binding.weightPath, { float: 0 }, { duration: 0.35 });
+        timeoutsRef.current.delete(binding.poseId);
+      }, RELEASE_DELAY_MS);
+      timeoutsRef.current.set(binding.poseId, timeout);
+    },
+    [animateValue],
+  );
+
+  useEffect(() => {
+    const timeouts = timeoutsRef.current;
+    return () => {
+      timeouts.forEach((id) => window.clearTimeout(id));
+      timeouts.clear();
+    };
+  }, []);
+
+  if (!ready || bindings.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      data-testid="empty-state-demo-emotions"
+      className="flex flex-wrap justify-center gap-2"
+    >
+      {bindings.map((binding) => (
+        <Button
+          key={binding.poseId}
+          data-testid={`empty-state-demo-emotion-${binding.semanticKey}`}
+          variant="secondary"
+          size="sm"
+          onClick={() => trigger(binding)}
+        >
+          {binding.label}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/apps/vizij-authoring/src/components/app/emptyStateDemo/DemoVoicePanel.test.tsx
+++ b/apps/vizij-authoring/src/components/app/emptyStateDemo/DemoVoicePanel.test.tsx
@@ -1,0 +1,108 @@
+import { createRef } from "react";
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { UseSpeechPlaybackReturn } from "../../../hooks/useSpeechPlayback";
+import { DemoVoicePanel } from "./DemoVoicePanel";
+
+const runtimeState = { ready: true };
+
+vi.mock("@vizij/runtime-react", () => ({
+  useVizijRuntime: () => ({
+    ready: runtimeState.ready,
+    setInput: vi.fn(),
+    animateValue: vi.fn(),
+    faceId: "face",
+    assetBundle: { namespace: "empty-demo", glb: { kind: "url", src: "x" } },
+  }),
+}));
+
+const speechState: UseSpeechPlaybackReturn = {} as UseSpeechPlaybackReturn;
+
+vi.mock("../../../hooks/useSpeechPlayback", () => ({
+  useSpeechPlayback: () => speechState,
+}));
+
+function resetSpeechState(overrides: Partial<UseSpeechPlaybackReturn> = {}) {
+  Object.assign(speechState, {
+    status: "idle",
+    script: "Hello",
+    setScript: vi.fn(),
+    selectedVoice: "Ruth",
+    setSelectedVoice: vi.fn(),
+    error: null,
+    isLoading: false,
+    words: [],
+    visemeLabels: [],
+    activeVisemeIndex: -1,
+    audioRef: createRef<HTMLAudioElement>(),
+    handleSpeak: vi.fn(),
+    handleStop: vi.fn(),
+    handleAudioPlay: vi.fn(),
+    handleAudioPause: vi.fn(),
+    handleAudioEnded: vi.fn(),
+    selectedGroupId: null,
+    setSelectedGroupId: vi.fn(),
+    groupOptions: [],
+    ...overrides,
+  } satisfies UseSpeechPlaybackReturn);
+}
+
+const speakButton = (container: HTMLElement) =>
+  container.querySelector(
+    '[data-testid="empty-state-demo-voice-speak"]',
+  ) as HTMLButtonElement;
+
+describe("DemoVoicePanel", () => {
+  beforeEach(() => {
+    runtimeState.ready = true;
+    resetSpeechState();
+  });
+
+  it("enables the speak button when the runtime is ready", () => {
+    const { container } = render(<DemoVoicePanel />);
+    expect(speakButton(container).disabled).toBe(false);
+  });
+
+  it("disables the speak button until the runtime is ready", () => {
+    runtimeState.ready = false;
+    const { container } = render(<DemoVoicePanel />);
+    expect(speakButton(container).disabled).toBe(true);
+  });
+
+  it("disables the speak button while speech is loading", () => {
+    resetSpeechState({ isLoading: true });
+    const { container } = render(<DemoVoicePanel />);
+    expect(speakButton(container).disabled).toBe(true);
+  });
+
+  it("shows the speech error inline", () => {
+    resetSpeechState({ error: "Polly unreachable" });
+    const { container } = render(<DemoVoicePanel />);
+    expect(
+      container.querySelector('[data-testid="empty-state-demo-voice-error"]')
+        ?.textContent,
+    ).toBe("Polly unreachable");
+  });
+
+  it("renders word and viseme chips with the active viseme highlighted", () => {
+    resetSpeechState({
+      words: [
+        { time: 0, type: "word", value: "Hello" },
+        { time: 200, type: "word", value: "world" },
+      ],
+      visemeLabels: ["p", "eh", "rest"],
+      activeVisemeIndex: 1,
+    });
+    const { container } = render(<DemoVoicePanel />);
+    expect(container.textContent).toContain("Hello");
+    expect(container.textContent).toContain("world");
+    const chips = Array.from(
+      container.querySelectorAll(
+        '[data-testid="empty-state-demo-viseme-chips"] span',
+      ),
+    );
+    expect(chips.map((chip) => chip.textContent)).toEqual(["p", "eh", "rest"]);
+    expect(chips[1].className).toContain("border-accent");
+    expect(chips[0].className).not.toContain("border-accent");
+  });
+});

--- a/apps/vizij-authoring/src/components/app/emptyStateDemo/DemoVoicePanel.tsx
+++ b/apps/vizij-authoring/src/components/app/emptyStateDemo/DemoVoicePanel.tsx
@@ -1,0 +1,151 @@
+import { useCallback, useMemo } from "react";
+import { useVizijRuntime } from "@vizij/runtime-react";
+import { Button, Select, TextArea, type SelectOption } from "../../ui";
+import { useSpeechPlayback } from "../../../hooks/useSpeechPlayback";
+import { POLLY_VOICES, type PollyVoice } from "../../../data/pollyVoices";
+import { cn } from "../../../utils/cn";
+
+const VOICE_OPTIONS: SelectOption[] = POLLY_VOICES.map((voice) => ({
+  value: voice,
+  label: voice,
+}));
+
+export function DemoVoicePanel() {
+  const { ready, setInput, animateValue, faceId, assetBundle } =
+    useVizijRuntime();
+  const poseConfig = assetBundle.pose?.config ?? null;
+
+  const stageRuntimeInput = useCallback(
+    (graphPath: string, value: number) => {
+      if (!ready) {
+        return;
+      }
+      setInput(graphPath, { float: value });
+    },
+    [ready, setInput],
+  );
+
+  const animateRuntimeValue = useCallback(
+    (graphPath: string, value: number, duration: number) => {
+      if (!ready) {
+        return;
+      }
+      void animateValue(graphPath, { float: value }, { duration });
+    },
+    [animateValue, ready],
+  );
+
+  const poses = useMemo(() => poseConfig?.poses ?? [], [poseConfig]);
+
+  const speech = useSpeechPlayback({
+    faceId: poseConfig?.faceId ?? faceId ?? "face",
+    poses,
+    poseGroups: poseConfig?.poseGroups,
+    stageRuntimeInput,
+    animateRuntimeValue,
+    runtimeReady: ready,
+  });
+
+  const busy = speech.isLoading || speech.status === "preparing";
+
+  return (
+    <div
+      data-testid="empty-state-demo-voice"
+      className="flex w-full flex-col gap-2 text-left"
+    >
+      <TextArea
+        data-testid="empty-state-demo-voice-script"
+        rows={2}
+        value={speech.script}
+        onChange={(event) => speech.setScript(event.target.value)}
+        placeholder="Type something for the face to say…"
+      />
+      <div className="flex items-center gap-2">
+        <Select
+          className="w-36 shrink-0"
+          size="sm"
+          value={speech.selectedVoice}
+          onChange={(voice) => speech.setSelectedVoice(voice as PollyVoice)}
+          options={VOICE_OPTIONS}
+        />
+        <Button
+          data-testid="empty-state-demo-voice-speak"
+          variant="primary"
+          size="sm"
+          disabled={!ready || busy}
+          onClick={() => void speech.handleSpeak()}
+        >
+          {busy ? "Preparing…" : "Speak"}
+        </Button>
+        {speech.status === "speaking" ? (
+          <Button
+            data-testid="empty-state-demo-voice-stop"
+            variant="subtle"
+            size="sm"
+            onClick={speech.handleStop}
+          >
+            Stop
+          </Button>
+        ) : null}
+        <audio
+          ref={speech.audioRef}
+          controls
+          className="h-8 min-w-0 flex-1"
+          onPlay={speech.handleAudioPlay}
+          onPause={speech.handleAudioPause}
+          onEnded={speech.handleAudioEnded}
+        />
+      </div>
+      {speech.error ? (
+        <p
+          data-testid="empty-state-demo-voice-error"
+          className="text-xs text-red-400"
+        >
+          {speech.error}
+        </p>
+      ) : null}
+      {speech.words.length > 0 ? (
+        <div className="flex flex-col gap-1">
+          <p className="text-[10px] font-medium uppercase tracking-widest text-text-muted">
+            Words
+          </p>
+          <div className="flex flex-wrap gap-1">
+            {speech.words.map((word, index) => (
+              <span
+                key={`${word.value}-${index}`}
+                className="rounded border border-border-default bg-bg-panel px-1.5 py-0.5 text-[11px] text-text-muted"
+              >
+                {word.value}
+              </span>
+            ))}
+          </div>
+        </div>
+      ) : null}
+      {speech.visemeLabels.length > 0 ? (
+        <div className="flex flex-col gap-1">
+          <p className="text-[10px] font-medium uppercase tracking-widest text-text-muted">
+            Visemes
+          </p>
+          <div
+            data-testid="empty-state-demo-viseme-chips"
+            className="flex flex-wrap gap-1"
+          >
+            {speech.visemeLabels.map((label, index) => (
+              <span
+                key={`${label}-${index}`}
+                className={cn(
+                  "rounded border px-1.5 py-0.5 text-[11px] transition-colors",
+                  index === speech.activeVisemeIndex
+                    ? "border-accent bg-accent/20 text-text-primary"
+                    : "border-border-default bg-bg-panel text-text-muted",
+                )}
+              >
+                {label}
+              </span>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/vizij-authoring/src/components/app/emptyStateDemo/EmptyStateDemo.tsx
+++ b/apps/vizij-authoring/src/components/app/emptyStateDemo/EmptyStateDemo.tsx
@@ -1,0 +1,47 @@
+import {
+  VizijRuntimeProvider,
+  type VizijAssetBundle,
+} from "@vizij/runtime-react";
+import { RuntimeFaceFrame } from "../RuntimeFaceFrame";
+import { DemoEmotionRow } from "./DemoEmotionRow";
+import { DemoVoicePanel } from "./DemoVoicePanel";
+import { useDemoMouseGaze } from "./useDemoMouseGaze";
+import { useDemoIdleGaze } from "./useDemoIdleGaze";
+
+const DEMO_BUNDLE: VizijAssetBundle = {
+  namespace: "empty-demo",
+  glb: {
+    kind: "url",
+    src: "/assets/Quori_Current_Extended.glb",
+    aggressiveImport: true,
+  },
+  pose: {
+    stageNeutralFilter: (_id, path) => !path.includes("/color/"),
+  },
+};
+
+export function EmptyStateDemo() {
+  return (
+    <VizijRuntimeProvider assetBundle={DEMO_BUNDLE} autostart>
+      <EmptyStateDemoBody />
+    </VizijRuntimeProvider>
+  );
+}
+
+function EmptyStateDemoBody() {
+  const gaze = useDemoMouseGaze(true);
+  useDemoIdleGaze({ enabled: true, pointerActive: gaze.isPointerActive });
+
+  return (
+    <div
+      data-testid="empty-state-demo"
+      className="flex w-full max-w-xl flex-col items-center gap-3"
+    >
+      <div className="h-52 w-full sm:h-60">
+        <RuntimeFaceFrame variant="fill" pointerTargetRef={gaze.ref} />
+      </div>
+      <DemoEmotionRow />
+      <DemoVoicePanel />
+    </div>
+  );
+}

--- a/apps/vizij-authoring/src/components/app/emptyStateDemo/useDemoIdleGaze.ts
+++ b/apps/vizij-authoring/src/components/app/emptyStateDemo/useDemoIdleGaze.ts
@@ -1,0 +1,170 @@
+import { useEffect, useMemo } from "react";
+import {
+  mapNormalizedControlValue,
+  mapUnitControlValue,
+  resolveFaceControls,
+  useVizijRuntime,
+} from "@vizij/runtime-react";
+
+const GLANCE_DELAY_RANGE = [1600, 4200] as const;
+const BLINK_DELAY_RANGE = [2200, 5200] as const;
+
+export type DemoIdleGazeOptions = {
+  enabled: boolean;
+  pointerActive: boolean;
+};
+
+export function useDemoIdleGaze({
+  enabled,
+  pointerActive,
+}: DemoIdleGazeOptions) {
+  const {
+    animateValue,
+    faceId: runtimeFaceId,
+    assetBundle,
+    inputConstraints,
+  } = useVizijRuntime();
+  const controls = useMemo(
+    () => resolveFaceControls(assetBundle, runtimeFaceId, inputConstraints),
+    [assetBundle, inputConstraints, runtimeFaceId],
+  );
+
+  useEffect(() => {
+    if (!enabled || pointerActive) {
+      return;
+    }
+
+    let glanceTimer: number | null = null;
+    let blinkTimer: number | null = null;
+    let blinkResetTimer: number | null = null;
+
+    const clearTimers = () => {
+      if (glanceTimer) {
+        window.clearTimeout(glanceTimer);
+        glanceTimer = null;
+      }
+      if (blinkTimer) {
+        window.clearTimeout(blinkTimer);
+        blinkTimer = null;
+      }
+      if (blinkResetTimer) {
+        window.clearTimeout(blinkResetTimer);
+        blinkResetTimer = null;
+      }
+    };
+
+    const animateSigned = (
+      control: (typeof controls.eyes)[keyof typeof controls.eyes],
+      value: number,
+      duration: number,
+      easing: "easeIn" | "easeOut" | "linear" | "easeInOut",
+    ) => {
+      if (!control) {
+        return;
+      }
+      void animateValue(
+        control.path,
+        { float: mapNormalizedControlValue(control, value) },
+        { duration, easing },
+      );
+    };
+
+    const animateUnit = (
+      control:
+        | (typeof controls.eyelids)[keyof typeof controls.eyelids]
+        | typeof controls.blink,
+      value: number,
+      duration: number,
+      easing: "easeIn" | "easeOut" | "linear" | "easeInOut",
+    ) => {
+      if (!control) {
+        return;
+      }
+      void animateValue(
+        control.path,
+        { float: mapUnitControlValue(control, value) },
+        { duration, easing },
+      );
+    };
+
+    const scheduleGlance = () => {
+      const delay = randomBetween(...GLANCE_DELAY_RANGE);
+      glanceTimer = window.setTimeout(() => {
+        performGlance();
+        scheduleGlance();
+      }, delay);
+    };
+
+    const scheduleBlink = () => {
+      const delay = randomBetween(...BLINK_DELAY_RANGE);
+      blinkTimer = window.setTimeout(() => {
+        performBlink();
+        scheduleBlink();
+      }, delay);
+    };
+
+    const performGlance = () => {
+      const x = randomBetween(-0.45, 0.45);
+      const y = randomBetween(-0.2, 0.35);
+      const offset = randomBetween(-0.05, 0.05);
+      const duration = randomBetween(0.45, 0.8);
+
+      animateSigned(
+        controls.eyes.leftX,
+        clamp(x - offset),
+        duration,
+        "easeInOut",
+      );
+      animateSigned(
+        controls.eyes.rightX,
+        clamp(x + offset),
+        duration,
+        "easeInOut",
+      );
+      animateSigned(controls.eyes.leftY, clamp(y), duration, "easeInOut");
+      animateSigned(
+        controls.eyes.rightY,
+        clamp(y + randomBetween(-0.05, 0.05)),
+        duration,
+        "easeInOut",
+      );
+    };
+
+    const animateBlinkStage = (
+      value: number,
+      duration: number,
+      easing: "easeIn" | "easeOut" | "linear" | "easeInOut",
+    ) => {
+      animateUnit(controls.blink, value, duration, easing);
+      animateUnit(controls.eyelids.leftUpper, value, duration, easing);
+      animateUnit(controls.eyelids.rightUpper, value, duration, easing);
+    };
+
+    const performBlink = () => {
+      const closed = randomBetween(0.7, 0.95);
+      animateBlinkStage(closed, 0.08, "easeIn");
+      if (blinkResetTimer) {
+        window.clearTimeout(blinkResetTimer);
+      }
+      blinkResetTimer = window.setTimeout(() => {
+        animateBlinkStage(0, 0.12, "easeOut");
+      }, 100);
+    };
+
+    scheduleGlance();
+    scheduleBlink();
+
+    return () => {
+      clearTimers();
+      animateBlinkStage(0, 0.12, "easeOut");
+    };
+  }, [animateValue, controls, enabled, pointerActive]);
+}
+
+function randomBetween(min: number, max: number) {
+  return Math.random() * (max - min) + min;
+}
+
+function clamp(value: number, min = -1, max = 1) {
+  return Math.min(Math.max(value, min), max);
+}

--- a/apps/vizij-authoring/src/components/app/emptyStateDemo/useDemoMouseGaze.ts
+++ b/apps/vizij-authoring/src/components/app/emptyStateDemo/useDemoMouseGaze.ts
@@ -1,0 +1,134 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { RefObject } from "react";
+import {
+  mapNormalizedControlValue,
+  resolveFaceControls,
+  useVizijRuntime,
+} from "@vizij/runtime-react";
+
+const POINTER_IDLE_TIMEOUT_MS = 1400;
+// The demo face area is short and wide, so vertical pointer travel is
+// amplified to keep the eyes expressive across the full frame height.
+const POINTER_Y_SCALE = 3;
+
+function clamp(value: number, min = -1, max = 1) {
+  return Math.min(Math.max(value, min), max);
+}
+
+export type DemoMouseGazeHandle = {
+  ref: RefObject<HTMLDivElement | null>;
+  isPointerActive: boolean;
+};
+
+export function useDemoMouseGaze(enabled: boolean): DemoMouseGazeHandle {
+  const {
+    setInput,
+    faceId: runtimeFaceId,
+    assetBundle,
+    inputConstraints,
+  } = useVizijRuntime();
+  const ref = useRef<HTMLDivElement>(null);
+  const [isPointerActive, setPointerActive] = useState(false);
+  const pointerActiveRef = useRef(false);
+  const idleTimeoutRef = useRef<number | null>(null);
+  const controls = useMemo(
+    () => resolveFaceControls(assetBundle, runtimeFaceId, inputConstraints),
+    [assetBundle, inputConstraints, runtimeFaceId],
+  );
+
+  const updatePointerActive = (next: boolean) => {
+    if (pointerActiveRef.current === next) {
+      return;
+    }
+    pointerActiveRef.current = next;
+    setPointerActive(next);
+  };
+
+  const setEye = useCallback(
+    (path: keyof typeof controls.eyes, value: number) => {
+      const control = controls.eyes[path];
+      if (!control) {
+        return;
+      }
+      setInput(control.path, {
+        float: mapNormalizedControlValue(control, clamp(value)),
+      });
+    },
+    [controls, setInput],
+  );
+
+  const resetEyes = useCallback(() => {
+    setEye("leftX", 0);
+    setEye("leftY", 0);
+    setEye("rightX", 0);
+    setEye("rightY", 0);
+  }, [setEye]);
+
+  useEffect(() => {
+    if (!enabled) {
+      resetEyes();
+      updatePointerActive(false);
+      return;
+    }
+    const target = ref.current;
+    if (!target) {
+      return;
+    }
+
+    const clearIdleTimeout = () => {
+      if (idleTimeoutRef.current) {
+        window.clearTimeout(idleTimeoutRef.current);
+        idleTimeoutRef.current = null;
+      }
+    };
+
+    const scheduleIdleTimeout = () => {
+      clearIdleTimeout();
+      idleTimeoutRef.current = window.setTimeout(() => {
+        updatePointerActive(false);
+        idleTimeoutRef.current = null;
+      }, POINTER_IDLE_TIMEOUT_MS);
+    };
+
+    const handlePointer = (event: PointerEvent) => {
+      const rect = target.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) {
+        return;
+      }
+      const xRatio = (event.clientX - rect.left) / rect.width;
+      const yRatio = (event.clientY - rect.top) / rect.height;
+      const normalizedX = clamp(xRatio * 2 - 1);
+      const normalizedY = clamp(((1 - yRatio) * 2 - 1) * POINTER_Y_SCALE);
+
+      setEye("leftX", normalizedX);
+      setEye("rightX", normalizedX);
+      setEye("leftY", normalizedY);
+      setEye("rightY", normalizedY);
+      updatePointerActive(true);
+      scheduleIdleTimeout();
+    };
+
+    const reset = () => {
+      resetEyes();
+      updatePointerActive(false);
+      clearIdleTimeout();
+    };
+
+    target.addEventListener("pointermove", handlePointer);
+    target.addEventListener("pointerdown", handlePointer);
+    target.addEventListener("pointerleave", reset);
+    target.addEventListener("pointerup", reset);
+
+    return () => {
+      target.removeEventListener("pointermove", handlePointer);
+      target.removeEventListener("pointerdown", handlePointer);
+      target.removeEventListener("pointerleave", reset);
+      target.removeEventListener("pointerup", reset);
+      clearIdleTimeout();
+      resetEyes();
+      updatePointerActive(false);
+    };
+  }, [enabled, resetEyes, setEye]);
+
+  return { ref, isPointerActive };
+}

--- a/apps/vizij-authoring/src/hooks/__tests__/createVisemeTimeline.test.ts
+++ b/apps/vizij-authoring/src/hooks/__tests__/createVisemeTimeline.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { createVisemeTimeline } from "../useSpeechPlayback";
+import type { SpeechMark } from "../../types/polly";
+
+const viseme = (time: number, value: string): SpeechMark => ({
+  time,
+  type: "viseme",
+  value,
+});
+
+const resolveSegmentPath = (segment: string): string | null =>
+  `rig/face/poses/${segment}.weight`;
+
+describe("createVisemeTimeline", () => {
+  it("returns an empty timeline for no visemes", () => {
+    expect(createVisemeTimeline([], resolveSegmentPath)).toEqual([]);
+  });
+
+  it("appends a trailing rest entry after the last viseme", () => {
+    const timeline = createVisemeTimeline(
+      [viseme(100, "p")],
+      resolveSegmentPath,
+    );
+    expect(timeline).toHaveLength(2);
+    const rest = timeline[timeline.length - 1];
+    expect(rest.path).toBeNull();
+    expect(rest.isSilence).toBe(true);
+    expect(rest.displayLabel).toBe("rest");
+    expect(rest.start).toBeGreaterThan(timeline[0].start);
+  });
+
+  it("sorts entries by start time and keeps end greater than start", () => {
+    const timeline = createVisemeTimeline(
+      [viseme(300, "t"), viseme(100, "p"), viseme(300, "s")],
+      resolveSegmentPath,
+    );
+    for (let i = 0; i < timeline.length; i += 1) {
+      expect(timeline[i].end).toBeGreaterThan(timeline[i].start);
+      if (i > 0) {
+        expect(timeline[i].start).toBeGreaterThanOrEqual(timeline[i - 1].start);
+      }
+    }
+  });
+
+  it("clamps the transition ramp between 45 and 320 ms", () => {
+    const timeline = createVisemeTimeline(
+      [viseme(0, "p"), viseme(10, "t"), viseme(2000, "s")],
+      resolveSegmentPath,
+    );
+    for (const entry of timeline) {
+      const ramp = entry.start - entry.transitionStart;
+      expect(ramp).toBeGreaterThanOrEqual(45);
+      expect(ramp).toBeLessThanOrEqual(320);
+    }
+  });
+
+  it("marks silence codes and unresolvable segments as silence", () => {
+    const timeline = createVisemeTimeline(
+      [viseme(0, "sil"), viseme(100, "p")],
+      resolveSegmentPath,
+    );
+    expect(timeline[0].isSilence).toBe(true);
+    expect(timeline[0].path).toBeNull();
+    expect(timeline[1].isSilence).toBe(false);
+    expect(timeline[1].path).toBe("rig/face/poses/p.weight");
+
+    const unresolved = createVisemeTimeline([viseme(0, "p")], () => null);
+    expect(unresolved[0].isSilence).toBe(true);
+    expect(unresolved[0].path).toBeNull();
+  });
+
+  it("maps polly viseme codes to display labels", () => {
+    const timeline = createVisemeTimeline(
+      [viseme(0, "@"), viseme(100, "T"), viseme(200, "u")],
+      resolveSegmentPath,
+    );
+    expect(timeline.map((entry) => entry.displayLabel)).toEqual([
+      "@",
+      "th",
+      "oo",
+      "rest",
+    ]);
+  });
+});

--- a/apps/vizij-authoring/src/hooks/useSpeechPlayback.ts
+++ b/apps/vizij-authoring/src/hooks/useSpeechPlayback.ts
@@ -30,7 +30,7 @@ type CachedSpeech = {
 };
 
 const DEFAULT_SCRIPT =
-  "With Vizij your avatar mirrors every beat of the conversation.";
+  "Vizij is a framework for defining, animating, and deploying expressive rendered robot faces";
 const MIN_VISEME_SPAN_MS = 45;
 const MAX_VISEME_SPAN_MS = 320;
 const RELEASE_TO_NEUTRAL_MS = 120;

--- a/apps/vizij-authoring/src/hooks/useSpeechPlayback.ts
+++ b/apps/vizij-authoring/src/hooks/useSpeechPlayback.ts
@@ -14,7 +14,7 @@ import {
 
 export type SpeechStatus = "idle" | "preparing" | "speaking";
 
-type VisemeTimelineEntry = {
+export type VisemeTimelineEntry = {
   start: number;
   end: number;
   transitionStart: number;
@@ -57,6 +57,10 @@ export interface UseSpeechPlaybackReturn {
   selectedVoice: PollyVoice;
   setSelectedVoice: (voice: PollyVoice) => void;
   error: string | null;
+  isLoading: boolean;
+  words: VisemeData["words"];
+  visemeLabels: string[];
+  activeVisemeIndex: number;
   audioRef: React.RefObject<HTMLAudioElement | null>;
   handleSpeak: (textOverride?: string) => Promise<void>;
   handleStop: () => void;
@@ -83,6 +87,10 @@ export function useSpeechPlayback({
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
+  const [words, setWords] = useState<VisemeData["words"]>([]);
+  const [visemeLabels, setVisemeLabels] = useState<string[]>([]);
+  const [activeVisemeIndex, setActiveVisemeIndex] = useState(-1);
+  const activeVisemeIndexRef = useRef(-1);
 
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const rafRef = useRef<number | null>(null);
@@ -281,8 +289,17 @@ export function useSpeechPlayback({
     }
   }, []);
 
+  const applyActiveVisemeIndex = useCallback((index: number) => {
+    if (activeVisemeIndexRef.current === index) {
+      return;
+    }
+    activeVisemeIndexRef.current = index;
+    setActiveVisemeIndex(index);
+  }, []);
+
+  // Keep the timeline so replaying the same audio (e.g. via the native
+  // controls) re-syncs the mouth from the start; only the cursor resets.
   const resetVisemeState = useCallback(() => {
-    visemeTimelineRef.current = [];
     transitionCursorRef.current = 0;
     lastVisemePathRef.current = null;
   }, []);
@@ -307,11 +324,13 @@ export function useSpeechPlayback({
       resetVisemeState();
       revokeAudioSrc();
       autoplayRef.current = false;
+      applyActiveVisemeIndex(-1);
       if (resetStatus) {
         setStatus("idle");
       }
     },
     [
+      applyActiveVisemeIndex,
       clearVisemeInputs,
       resetVisemeState,
       revokeAudioSrc,
@@ -330,8 +349,9 @@ export function useSpeechPlayback({
     }
     const timeMs = audioRef.current.currentTime * 1000;
     triggerTransitionsUpToTime(timeMs);
+    applyActiveVisemeIndex(findVisemeIndex(visemeTimelineRef.current, timeMs));
     rafRef.current = requestAnimationFrame(syncFromAudio);
-  }, [triggerTransitionsUpToTime]);
+  }, [applyActiveVisemeIndex, triggerTransitionsUpToTime]);
 
   const startRAF = useCallback(() => {
     if (rafRef.current != null) {
@@ -353,11 +373,18 @@ export function useSpeechPlayback({
       visemePathsRef.current = merged;
       transitionCursorRef.current = 0;
       lastVisemePathRef.current = null;
+      setVisemeLabels(timeline.map((entry) => entry.displayLabel));
+      applyActiveVisemeIndex(-1);
       if (timeline.length > 0) {
         triggerTransitionsUpToTime(0);
       }
     },
-    [defaultVisemePaths, resolveSegmentPath, triggerTransitionsUpToTime],
+    [
+      applyActiveVisemeIndex,
+      defaultVisemePaths,
+      resolveSegmentPath,
+      triggerTransitionsUpToTime,
+    ],
   );
 
   const handleSpeak = useCallback(
@@ -380,6 +407,7 @@ export function useSpeechPlayback({
       if (cached) {
         const audioUrl = URL.createObjectURL(cached.audioBlob);
         audioSrcRef.current = audioUrl;
+        setWords(cached.visemeData.words ?? []);
         updateTimeline(cached.visemeData.visemes);
         if (audioRef.current) {
           audioRef.current.src = audioUrl;
@@ -399,6 +427,7 @@ export function useSpeechPlayback({
         speechCacheRef.current.set(cacheKey, { visemeData, audioBlob });
         const audioUrl = URL.createObjectURL(audioBlob);
         audioSrcRef.current = audioUrl;
+        setWords(visemeData.words ?? []);
         updateTimeline(visemeData.visemes);
         if (audioRef.current) {
           audioRef.current.src = audioUrl;
@@ -458,6 +487,10 @@ export function useSpeechPlayback({
     selectedVoice,
     setSelectedVoice,
     error,
+    isLoading,
+    words,
+    visemeLabels,
+    activeVisemeIndex,
     audioRef,
     handleSpeak,
     handleStop,
@@ -470,7 +503,20 @@ export function useSpeechPlayback({
   };
 }
 
-const createVisemeTimeline = (
+const findVisemeIndex = (
+  timeline: VisemeTimelineEntry[],
+  timeMs: number,
+): number => {
+  for (let i = timeline.length - 1; i >= 0; i -= 1) {
+    const entry = timeline[i];
+    if (timeMs >= entry.start && timeMs < entry.end) {
+      return i;
+    }
+  }
+  return -1;
+};
+
+export const createVisemeTimeline = (
   visemes: VisemeData["visemes"],
   resolveSegmentPath: (segment: string) => string | null,
 ): VisemeTimelineEntry[] => {

--- a/apps/vizij-authoring/src/services/apiBase.ts
+++ b/apps/vizij-authoring/src/services/apiBase.ts
@@ -1,12 +1,14 @@
 const ENV_KEY = "VITE_API_URL";
+const DEFAULT_API_BASE =
+  "https://us-central1-semio-vizij.cloudfunctions.net/api";
 
 export const getApiBase = (): string | undefined => {
   const value = import.meta.env.VITE_API_URL;
   if (typeof value !== "string") {
-    return undefined;
+    return DEFAULT_API_BASE;
   }
   const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
+  return trimmed.length > 0 ? trimmed : DEFAULT_API_BASE;
 };
 
 export const requireApiBase = (): string => {


### PR DESCRIPTION
## Summary

Replaces the static "Empty Scene" placeholder in vizij-authoring's main viewer with a live interactive demo that combines the vizij.ai site's gaze, expressions, and voice demos on a single face/runtime — so first-time users immediately see what the tool can do before loading an asset.

When no scene is loaded, the viewer now shows:

- **Gaze** — the bundled Quori face's eyes follow the cursor over the demo area; after ~1.4s of pointer inactivity, ambient random glances and blinks take over.
- **Emotions** — a row of buttons (Concerned, Happy, Sad, Sleepy, Surprise, Anger — discovered from the rig's pose config) that animate the pose weight to 0.75 and auto-release after 650ms.
- **Visemes** — a text box + Polly voice picker; "Speak" fetches audio + viseme marks from the TTS backend, plays the audio while cross-fading mouth poses in sync, and shows a breakdown of word chips and viseme chips with the active viseme highlighted during playback.

The Import File and preset-load buttons remain below the demo, and the demo runs in its own runtime namespace (`empty-demo`) so it unmounts cleanly the moment a scene loads.

## Implementation notes

- **No new dependencies.** The demo reuses the app's existing Polly/viseme stack (`services/pollyApi.ts`, `hooks/useSpeechPlayback.ts`, `lib/visemeMapping.ts`) and `@vizij/runtime-react`'s exported gaze/pose utilities. Gaze hooks are ports of the vizij-showcase / tutorial-agent-face versions (apps can't import from apps).
- `useSpeechPlayback` gains additive returns (`words`, `visemeLabels`, `activeVisemeIndex`, `isLoading`) for the breakdown UI; the existing SpeechPanel is unaffected.
- **Bug fix:** the viseme timeline is no longer wiped when playback ends, so replaying the same audio via the native controls re-syncs the mouth (previously the replay was silent-faced).
- **Bug fix:** `requireApiBase()` threw when `VITE_API_URL` was unset; it now falls back to the hosted cloud-functions API (matching vizij-showcase), so speech works on a fresh checkout.

## Testing

- `pnpm --filter vizij-authoring validate` — lint, typecheck, and all 729 tests pass.
- New tests: `createVisemeTimeline` unit tests (sorting, span clamping, silence handling, trailing rest), `DemoEmotionRow` (button order, 0.75 → auto-release-to-0 timing), `DemoVoicePanel` (disabled states, error display, chip rendering/highlight).
- Verified live in the browser: cursor tracking + idle glances/blinks, emotion trigger and release, the two Polly POSTs, audio-synced mouth animation, active-chip highlighting, replay after end, and that Import File / preset loading still swap to the main runtime cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
