### PR TITLE
feat(vizij-standalone): endpoints panel + per-model background

### DIFF
--- a/apps/vizij-standalone/src-tauri/src/lib.rs
+++ b/apps/vizij-standalone/src-tauri/src/lib.rs
@@ -70,6 +70,12 @@ struct StudioBridgeState {
     owners_tx: tokio::sync::watch::Sender<Vec<String>>,
     needs_prompt: StdMutex<bool>,
     owners: StdMutex<Vec<String>>,
+    /// The stable `vizij-<random>` name this device registers with Studio under
+    /// (generated once at startup). Reported to the UI by [`get_endpoints`].
+    device_name: String,
+    /// Display string for the bridge router endpoint: the `STUDIO_BRIDGE_ENDPOINT`
+    /// override, or a label for the baked-in production bridge when unset.
+    endpoint: String,
 }
 
 /// Reported to the frontend by `studio_bridge_owner_status`. `active` = the app
@@ -80,6 +86,47 @@ struct StudioBridgeState {
 struct StudioOwnerStatus {
     active: bool,
     needs_prompt: bool,
+    owners: Vec<String>,
+}
+
+/// A snapshot of every endpoint this app exposes, reported to the frontend by
+/// [`get_endpoints`] so the UI can list where the device is reachable. `ros2`
+/// and `studio` are `None` when their feature is compiled out.
+#[derive(Debug, Clone, Serialize)]
+struct EndpointsInfo {
+    ws: WsEndpoint,
+    ros2: Option<Ros2Endpoint>,
+    studio: Option<StudioEndpoint>,
+}
+
+/// The WebSocket bridge (`arora-bridge-ws`): the local control socket and, when
+/// enabled, the browser control panel served on the same port.
+#[derive(Debug, Clone, Serialize)]
+struct WsEndpoint {
+    url: String,
+    web_control_url: Option<String>,
+    running: bool,
+}
+
+/// The ROS 2 data-topic bridge (`arora-bridge-ros2`): keys are published under
+/// `/{namespace}/keys/{path}` on the given DDS domain.
+#[derive(Debug, Clone, Serialize)]
+struct Ros2Endpoint {
+    domain_id: u16,
+    namespace: String,
+}
+
+/// The Semio Studio bridge: how this device registers with Studio (the device
+/// info) and which Zenoh endpoint it reaches the bridge router over.
+#[derive(Debug, Clone, Serialize)]
+struct StudioEndpoint {
+    device_name: String,
+    model_family: Option<String>,
+    software_version: Option<String>,
+    /// The Zenoh endpoint of the bridge router (an override, or the baked-in
+    /// production bridge when unset).
+    endpoint: String,
+    /// Studio user IDs that see/claim this device; empty means unclaimed.
     owners: Vec<String>,
 }
 
@@ -830,6 +877,7 @@ fn spawn_studio_bridge(
     app: AppHandle,
     owners_rx: tokio::sync::watch::Receiver<Vec<String>>,
     initial_owners: Vec<String>,
+    device_name: String,
 ) {
     use arora_studio_bridge_client::firestore_support::options::{
         FirebaseEmulatorOptions, FirebaseOptions,
@@ -895,7 +943,6 @@ fn spawn_studio_bridge(
                     }
                 };
                 let bridge: Box<dyn Bridge> = Box::new(client);
-                let device_name = format!("vizij-{}", random_device_suffix());
                 run_studio_pump(store, app, bridge, owners_rx, device_name, initial_owners).await;
             });
         })
@@ -1116,6 +1163,40 @@ fn studio_bridge_set_owners(app_handle: AppHandle, owners: Vec<String>) -> Resul
     }
 }
 
+/// Report every endpoint this app exposes so the UI can list them. `ros2` and
+/// `studio` are populated only when their feature is compiled in.
+#[tauri::command]
+fn get_endpoints(app_handle: AppHandle) -> EndpointsInfo {
+    let state = app_handle.state::<AppState>();
+    let running = state.cancel_token.lock().unwrap().is_some();
+    let ws = WsEndpoint {
+        url: format!("ws://localhost:{}", state.port),
+        web_control_url: state.web_port.map(|p| format!("http://localhost:{p}")),
+        running,
+    };
+
+    #[cfg(feature = "ros2")]
+    let ros2 = Some(Ros2Endpoint {
+        domain_id: state.ros2_domain_id,
+        namespace: state.ros2_namespace.clone(),
+    });
+    #[cfg(not(feature = "ros2"))]
+    let ros2 = None;
+
+    #[cfg(feature = "studio-bridge")]
+    let studio = Some(StudioEndpoint {
+        device_name: state.studio.device_name.clone(),
+        model_family: Some("Vizij".to_string()),
+        software_version: Some(concat!("vizij-standalone-", env!("CARGO_PKG_VERSION")).to_string()),
+        endpoint: state.studio.endpoint.clone(),
+        owners: state.studio.owners.lock().unwrap().clone(),
+    });
+    #[cfg(not(feature = "studio-bridge"))]
+    let studio = None;
+
+    EndpointsInfo { ws, ros2, studio }
+}
+
 #[tauri::command]
 async fn set_transport_catalog(
     app_handle: AppHandle,
@@ -1221,7 +1302,7 @@ pub fn run() {
             // set up the channel the in-UI owner prompt uses to re-register live.
             // Precedence: `DEVICE_OWNERS` env → a persisted choice → empty + prompt.
             #[cfg(feature = "studio-bridge")]
-            let (studio_state, studio_owners_rx, studio_initial_owners) = {
+            let (studio_state, studio_owners_rx, studio_initial_owners, studio_device_name) = {
                 let handle = app.handle();
                 let env_owners = std::env::var("DEVICE_OWNERS")
                     .ok()
@@ -1236,14 +1317,25 @@ pub fn run() {
                 };
                 let (owners_tx, owners_rx) =
                     tokio::sync::watch::channel::<Vec<String>>(initial_owners.clone());
+                // Generate the device name once (stable across re-registrations)
+                // and resolve the endpoint label the UI shows.
+                let device_name = format!("vizij-{}", random_device_suffix());
+                let endpoint = std::env::var("STUDIO_BRIDGE_ENDPOINT")
+                    .ok()
+                    .and_then(|v| v.split(',').next().map(|s| s.trim().to_string()))
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or_else(|| "Semio Studio (baked-in bridge)".to_string());
                 (
                     StudioBridgeState {
                         owners_tx,
                         needs_prompt: StdMutex::new(needs_prompt),
                         owners: StdMutex::new(initial_owners.clone()),
+                        device_name: device_name.clone(),
+                        endpoint,
                     },
                     owners_rx,
                     initial_owners,
+                    device_name,
                 )
             };
 
@@ -1298,6 +1390,7 @@ pub fn run() {
                 app.handle().clone(),
                 studio_owners_rx,
                 studio_initial_owners,
+                studio_device_name,
             );
 
             info!("Vizij Standalone App initialized with WS port {}", port);
@@ -1417,6 +1510,7 @@ pub fn run() {
             set_transport_catalog,
             studio_bridge_owner_status,
             studio_bridge_set_owners,
+            get_endpoints,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/vizij-standalone/src/App.tsx
+++ b/apps/vizij-standalone/src/App.tsx
@@ -12,10 +12,33 @@ import {
 import type { VizijSpeechConfig } from "@vizij/render";
 import { useWebSocketSync } from "./hooks/useWebSocketSync";
 import { useSpeechController } from "./hooks/useSpeechController";
+import { EndpointsPanel } from "./components/EndpointsPanel";
 import { saveModel, loadSavedModel, getSavedModelMeta } from "./lib/modelStore";
 
-const DEFAULT_PORT = 9000;
 const NAMESPACE = "vizij-standalone";
+
+// Persist the background color chosen for a given model, keyed by its identity
+// (file name or URL), so reopening the same GLB restores its background.
+const BG_STORAGE_PREFIX = "vizij-standalone:bg:";
+const DEFAULT_BG_COLOR = "#737373";
+
+function loadStoredBgColor(modelKey: string | null): string | null {
+  if (!modelKey) return null;
+  try {
+    return localStorage.getItem(BG_STORAGE_PREFIX + modelKey);
+  } catch {
+    return null;
+  }
+}
+
+function storeBgColor(modelKey: string | null, color: string): void {
+  if (!modelKey) return;
+  try {
+    localStorage.setItem(BG_STORAGE_PREFIX + modelKey, color);
+  } catch {
+    // Storage unavailable/full — the color just won't be remembered.
+  }
+}
 
 type StandaloneTransportEntry = {
   id: string;
@@ -42,10 +65,23 @@ function App() {
   const [assetBundle, setAssetBundle] = useState<VizijAssetBundle | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [bgColor, setBgColor] = useState("#737373");
-  const [wsConnected, setWsConnected] = useState(false);
-  const [port, setPort] = useState(DEFAULT_PORT);
+  const [bgColor, setBgColor] = useState(DEFAULT_BG_COLOR);
   const [modelName, setModelName] = useState<string | null>(null);
+
+  // Restore the background remembered for the active model (or the default when
+  // none was saved). Runs whenever the model changes.
+  useEffect(() => {
+    setBgColor(loadStoredBgColor(modelName) ?? DEFAULT_BG_COLOR);
+  }, [modelName]);
+
+  // Change the background AND remember it for the active model.
+  const handleSetBgColor = useCallback(
+    (color: string) => {
+      setBgColor(color);
+      storeBgColor(modelName, color);
+    },
+    [modelName],
+  );
   const hasCheckedCliSource = useRef(false);
 
   // Load GLB from URL
@@ -129,17 +165,19 @@ function App() {
         if (source) {
           console.log("[vizij-standalone] Loading from CLI source:", source);
           if (source.startsWith("http://") || source.startsWith("https://")) {
+            setModelName(source);
             await loadFromUrl(source);
           } else {
-            const fileContents = await readFile(source);
             const fileName =
               source.split("/").pop() ||
               source.split("\\").pop() ||
               "model.glb";
+            const fileContents = await readFile(source);
             const mimeType = fileName.toLowerCase().endsWith(".glb")
               ? "model/gltf-binary"
               : "model/gltf+json";
             const file = new File([fileContents], fileName, { type: mimeType });
+            setModelName(fileName);
             await loadFromFile(file);
           }
         } else {
@@ -162,48 +200,23 @@ function App() {
     checkCliSource();
   }, [loadFromFile, loadFromUrl]);
 
-  // Start WebSocket server
+  // Ensure the WebSocket server is running (the Rust setup starts it too; this
+  // is a fallback). Its address and live status are shown by <EndpointsPanel>,
+  // which polls the Rust side directly.
   useEffect(() => {
-    let mounted = true;
-
     const startServer = async () => {
       try {
-        invoke<number>("get_port")
-          .then((resolvedPort) => {
-            if (mounted) setPort(resolvedPort);
-          })
-          .catch(() => {
-            if (mounted) setPort(DEFAULT_PORT);
-          });
-
         const running = await invoke<boolean>("is_ws_running");
-        if (mounted) setWsConnected(running);
-
         if (!running) {
           console.log("[vizij-standalone] Starting WebSocket server...");
           await invoke("start_ws_server");
-          if (mounted) setWsConnected(true);
         }
       } catch (err) {
         console.error("[vizij-standalone] WebSocket server error:", err);
-        if (mounted) setWsConnected(false);
       }
     };
 
     startServer();
-    const interval = setInterval(async () => {
-      try {
-        const running = await invoke<boolean>("is_ws_running");
-        if (mounted) setWsConnected(running);
-      } catch {
-        if (mounted) setWsConnected(false);
-      }
-    }, 2000);
-
-    return () => {
-      mounted = false;
-      clearInterval(interval);
-    };
   }, []);
 
   // Loading state
@@ -247,17 +260,7 @@ function App() {
         >
           Open GLB/GLTF File
         </button>
-        <div className="mt-8 text-sm text-neutral-500">
-          <p>WebSocket server: ws://localhost:{port}</p>
-          <p>
-            Status:{" "}
-            <span
-              className={wsConnected ? "text-green-400" : "text-yellow-400"}
-            >
-              {wsConnected ? "Running" : "Starting..."}
-            </span>
-          </p>
-        </div>
+        <EndpointsPanel className="mt-8 max-w-md text-sm text-neutral-500" />
         <p className="mt-4 text-xs text-neutral-600">
           Tip: Use --glb &lt;path-or-url&gt; to load a model on startup
         </p>
@@ -275,9 +278,7 @@ function App() {
     >
       <AppContent
         bgColor={bgColor}
-        setBgColor={setBgColor}
-        wsConnected={wsConnected}
-        port={port}
+        setBgColor={handleSetBgColor}
         onBack={() => setAssetBundle(null)}
         onSwitchModel={handleOpenFile}
         modelName={modelName}
@@ -289,8 +290,6 @@ function App() {
 interface AppContentProps {
   bgColor: string;
   setBgColor: (color: string) => void;
-  wsConnected: boolean;
-  port: number;
   onBack: () => void;
   onSwitchModel: () => void | Promise<void>;
   modelName: string | null;
@@ -299,8 +298,6 @@ interface AppContentProps {
 function AppContent({
   bgColor,
   setBgColor,
-  wsConnected,
-  port,
   onBack,
   onSwitchModel,
   modelName,
@@ -674,11 +671,8 @@ function AppContent({
             />
           </div>
           <div className="text-xs text-neutral-400">
-            <p>WS: ws://localhost:{port}</p>
-            <p className={wsConnected ? "text-green-400" : "text-yellow-400"}>
-              {wsConnected ? "Connected" : "Connecting..."}
-            </p>
-            <p className="mt-1">
+            <EndpointsPanel className="max-w-xs" />
+            <p className="mt-2">
               Runtime:{" "}
               <span
                 className={

--- a/apps/vizij-standalone/src/components/EndpointsPanel.tsx
+++ b/apps/vizij-standalone/src/components/EndpointsPanel.tsx
@@ -1,0 +1,123 @@
+// Lists every endpoint this standalone exposes: the WebSocket control socket
+// (and browser control panel), the optional ROS 2 data-topic bridge, and the
+// optional Semio Studio bridge. It reads the snapshot from the Rust side
+// (`get_endpoints`) and re-polls periodically so the WS running state and the
+// Studio owners (which the owner prompt can change live) stay current.
+//
+// `ros2`/`studio` are present only when the app was built with those features;
+// when absent, their sections simply don't render.
+
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+interface WsEndpoint {
+  url: string;
+  web_control_url: string | null;
+  running: boolean;
+}
+
+interface Ros2Endpoint {
+  domain_id: number;
+  namespace: string;
+}
+
+interface StudioEndpoint {
+  device_name: string;
+  model_family: string | null;
+  software_version: string | null;
+  endpoint: string;
+  owners: string[];
+}
+
+interface EndpointsInfo {
+  ws: WsEndpoint;
+  ros2: Ros2Endpoint | null;
+  studio: StudioEndpoint | null;
+}
+
+export function EndpointsPanel({ className }: { className?: string }) {
+  const [info, setInfo] = useState<EndpointsInfo | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    const refresh = () => {
+      invoke<EndpointsInfo>("get_endpoints")
+        .then((next) => {
+          if (mounted) setInfo(next);
+        })
+        .catch(() => {
+          // Command unavailable (older shell) — leave the panel empty.
+        });
+    };
+    refresh();
+    const id = setInterval(refresh, 3000);
+    return () => {
+      mounted = false;
+      clearInterval(id);
+    };
+  }, []);
+
+  if (!info) return null;
+
+  const { ws, ros2, studio } = info;
+
+  return (
+    <div className={className}>
+      <div>
+        <span className="font-medium text-neutral-300">WebSocket</span>{" "}
+        <span className={ws.running ? "text-green-400" : "text-yellow-400"}>
+          {ws.running ? "running" : "starting…"}
+        </span>
+        <div className="text-neutral-400">{ws.url}</div>
+        {ws.web_control_url && (
+          <div className="text-neutral-400">
+            control panel: {ws.web_control_url}
+          </div>
+        )}
+      </div>
+
+      {ros2 && (
+        <div className="mt-2">
+          <span className="font-medium text-neutral-300">ROS 2 (DDS)</span>
+          <div className="text-neutral-400">
+            domain {ros2.domain_id}, namespace <code>/{ros2.namespace}</code>
+          </div>
+          <div className="text-neutral-500">
+            keys published under{" "}
+            <code>/{ros2.namespace}/keys/&lt;path&gt;</code>
+          </div>
+        </div>
+      )}
+
+      {studio && (
+        <div className="mt-2">
+          <span className="font-medium text-neutral-300">Semio Studio</span>
+          <div className="text-neutral-400">
+            connected via Zenoh to {studio.endpoint}
+          </div>
+          <p className="mt-1 text-neutral-400">
+            Registered as device{" "}
+            <span className="text-neutral-200">“{studio.device_name}”</span>
+            {studio.model_family && <> (model family {studio.model_family})</>}
+            {studio.software_version && <>, {studio.software_version}</>}.{" "}
+            {studio.owners.length > 0 ? (
+              <>
+                Owned by{" "}
+                <span className="text-neutral-200">
+                  {studio.owners.join(", ")}
+                </span>{" "}
+                — only those Studio account(s) can see and drive it.
+              </>
+            ) : (
+              <span className="text-yellow-400">
+                Unclaimed — no Studio account sees it yet until an owner is set.
+              </span>
+            )}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default EndpointsPanel;


### PR DESCRIPTION
## Summary

Two standalone-app improvements.

### 1. List every endpoint, not just the WS URL
The app previously showed only `WS: ws://localhost:<port>`. A new `get_endpoints` Tauri command now reports all three bridge seams, rendered by a new React `EndpointsPanel` (in both the no-model empty state and the DEV overlay):

- **WebSocket** — socket URL, running/starting status, and the browser control-panel URL when served.
- **ROS 2 (DDS)** — DDS domain + namespace, with the `/{ns}/keys/<path>` topic convention. Feature-gated (`ros2`); absent when compiled out.
- **Semio Studio** — the Zenoh bridge endpoint (the `STUDIO_BRIDGE_ENDPOINT` override, or a label for the baked-in production bridge), plus a **device-information paragraph**: the registered device name, model family, software version, and **owners** ("Owned by …", or a highlighted "Unclaimed" note when none). Feature-gated (`studio-bridge`).

The panel polls every 3 s so WS status and live owner changes (via the existing owner prompt) stay current. The Studio device name is now generated once at startup and lifted into `AppState` so it can be reported (it was previously generated inside the bridge thread).

Because the panel fetches and polls its own data, the old `port` / `wsConnected` React state and their prop-plumbing through `AppContent` were removed; the WS-start effect is kept as a fallback.

### 2. Remember the background per model
The background color is persisted in `localStorage` keyed by the model's identity (file name, or URL for CLI/remote loads) and restored whenever that model is (re)opened. Changing the color persists it; opening a model with no saved color falls back to the default.

## Verification
- `cargo check` passes for all three feature configs: `--features studio-bridge` (with default `ros2`), default (`ros2` only), and `--no-default-features`.
- `pnpm vite build` succeeds. (The bare-`tsc` `import.meta.env` errors are pre-existing/environmental — vite supplies those types at real build time — and this change adds none.)
- prettier + rustfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)