### PR TITLE
ci(android): deflake emulator smoke test with fresh-emulator retry

### DIFF
--- a/.github/scripts/run-android-smoke.sh
+++ b/.github/scripts/run-android-smoke.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Runs the vizij-standalone instrumented launch smoke test against an already
+# booted emulator. Invoked by the reactivecircus/android-emulator-runner
+# `script:` step, which boots the emulator (and waits for boot) before calling us.
+#
+# Two things make the smoke test flaky in CI, both rooted in the headless
+# software GPU (`-gpu swiftshader_indirect`):
+#   1. A transient `adb: device offline` right at install / test start while the
+#      emulator is still settling. This we recover from HERE with a short adb
+#      recycle + inner retry, cheaper than a full emulator reboot.
+#   2. A swiftshader surface-allocation crash ("Failed to find ColorBuffer: N")
+#      that takes the whole emulator process down. That is unrecoverable from
+#      inside this script — the caller re-runs the entire action step (a fresh
+#      emulator boot) when we exit non-zero.
+set -uo pipefail
+
+ANDROID_DIR="${ANDROID_DIR:-apps/vizij-standalone/src-tauri/gen/android}"
+
+# Belt-and-suspenders boot settle. The action already waits for boot, but
+# disable-animations and the emulator console can race the first adb call.
+timeout 180 adb wait-for-device || true
+for _ in $(seq 1 60); do
+  [ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" = "1" ] && break
+  sleep 2
+done
+adb shell input keyevent 82 >/dev/null 2>&1 || true # dismiss the keyguard
+
+run_gradle() {
+  ( cd "$ANDROID_DIR" && ./gradlew :app:connectedUniversalDebugAndroidTest \
+      -x rustBuildArm64Debug -x rustBuildArmDebug \
+      -x rustBuildX86Debug -x rustBuildX86_64Debug )
+}
+
+attempts=2
+for i in $(seq 1 "$attempts"); do
+  echo "::group::connectedUniversalDebugAndroidTest (inner attempt ${i}/${attempts})"
+  if run_gradle; then
+    echo "::endgroup::"
+    exit 0
+  fi
+  echo "::endgroup::"
+  if [ "$i" -lt "$attempts" ]; then
+    echo "::warning::instrumented test attempt ${i} failed; recycling adb before retry"
+    adb kill-server || true
+    adb start-server || true
+    timeout 120 adb wait-for-device || true
+    sleep 5
+  fi
+done
+
+# All inner attempts failed. Signal the caller to spin up a fresh emulator.
+exit 1

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -103,29 +103,60 @@ jobs:
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           script: echo "Generated AVD snapshot."
 
+      # The smoke test is genuinely flaky on the headless software GPU: the
+      # emulator intermittently dies with `Failed to find ColorBuffer: N`
+      # (swiftshader surface-allocation failure), taking adb offline with it.
+      # It is not an app regression, so we retry the emulator up to two times.
+      #
+      # The retry re-invokes the whole action (a FRESH emulator boot), because a
+      # ColorBuffer crash kills the emulator process — retrying against the same
+      # dead emulator cannot recover. The per-invocation script
+      # (.github/scripts/run-android-smoke.sh) additionally absorbs a transient
+      # `adb: device offline` at test start without paying for a full reboot.
+      #
+      # Shared action inputs (both attempts):
+      # - :app scope so only our AppLaunchTest runs (the bundled tauri plugin
+      #   libraries ship their own failing ExampleInstrumentedTest).
+      # - Universal flavor: it bundles x86_64 and installs on the x86_64 emulator.
+      # - The rustBuild* tasks are excluded inside the script (they need a parent
+      #   `tauri android build`/`dev` process); the prior "Build debug APK" step
+      #   already produced the .so, so the test reuses them.
       - name: Run instrumented smoke test
+        id: smoke-1
+        continue-on-error: true
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 34
           arch: x86_64
           target: google_apis
           force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none -no-metrics
           disable-animations: true
-          # The action's `script` runs from the repo root, so cd into the Gradle project.
-          # - :app scope so only our AppLaunchTest runs (the bundled tauri plugin
-          #   libraries ship their own failing ExampleInstrumentedTest).
-          # - Universal flavor: it bundles x86_64 and installs on the x86_64 emulator.
-          # - Exclude the rustBuild* tasks: they shell out to `tauri android
-          #   android-studio-script`, which only works when driven by a parent
-          #   `tauri android build`/`dev` (it connects back to that process over a
-          #   socket). The prior "Build debug APK" step already produced the .so,
-          #   so the test reuses them instead of rebuilding.
-          script: >-
-            cd ${{ env.ANDROID_DIR }} &&
-            ./gradlew :app:connectedUniversalDebugAndroidTest
-            -x rustBuildArm64Debug -x rustBuildArmDebug
-            -x rustBuildX86Debug -x rustBuildX86_64Debug
+          script: bash .github/scripts/run-android-smoke.sh
+
+      - name: Run instrumented smoke test (fresh-emulator retry)
+        id: smoke-2
+        if: steps.smoke-1.outcome == 'failure'
+        continue-on-error: true
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          arch: x86_64
+          target: google_apis
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none -no-metrics
+          disable-animations: true
+          script: bash .github/scripts/run-android-smoke.sh
+
+      - name: Assert smoke test passed
+        if: always()
+        run: |
+          if [ "${{ steps.smoke-1.outcome }}" = "success" ] || [ "${{ steps.smoke-2.outcome }}" = "success" ]; then
+            echo "Emulator smoke test passed (attempt-1=${{ steps.smoke-1.outcome }}, attempt-2=${{ steps.smoke-2.outcome }})."
+            exit 0
+          fi
+          echo "::error::Emulator smoke test failed on all attempts (attempt-1=${{ steps.smoke-1.outcome }}, attempt-2=${{ steps.smoke-2.outcome }})."
+          exit 1
 
   # Pushes to main: build a RELEASE APK. It is signed when the keystore secrets
   # are present, otherwise produced unsigned (the build never fails for lack of


### PR DESCRIPTION
## Problem (confirmed flake, not an app regression)

The `Debug APK + emulator smoke test` job (`AppLaunchTest > appLaunchesAndRendersWebView`, API 34 x86_64 google_apis under `-gpu swiftshader_indirect`) is intermittently red. Across PRs #53/#54 the failures share one signature:

- `ERROR | Failed to find ColorBuffer: 108` / `113` — swiftshader software-GPU failing to allocate a rendering surface
- `adb: device offline`, `[EmulatorConsole]: Failed to start Emulator console for 5554`
- then `appLaunchesAndRendersWebView FAILED` + `Test run failed to complete. Instrumentation run failed due to Process crashed.`

It passes on other runs. The ColorBuffer crash takes down the **whole emulator process** (which is why adb/console/instrumentation all fail after it). It is an emulator/GPU-environment flake, not the app.

## Fix (CI/test-harness reliability only — no app or test-assertion changes)

**Layer 1 — fresh-emulator retry (the load-bearing fix).** The single smoke step becomes two invocations of `reactivecircus/android-emulator-runner`:
- attempt 1 runs with `continue-on-error: true`
- attempt 2 runs only `if: steps.smoke-1.outcome == 'failure'` — a brand-new emulator boot
- a final `Assert smoke test passed` step fails the job **iff both attempts failed**

A ColorBuffer crash kills the emulator, so only a full re-boot can recover — retrying gradle against the dead emulator cannot. Bounded to 2 attempts, so a genuine launch failure still fails (just once retried) and never masks a real non-launch.

**Layer 2 — inner adb recycle.** The per-invocation logic moves to `.github/scripts/run-android-smoke.sh`, which waits for `sys.boot_completed`, dismisses the keyguard, then runs `connectedUniversalDebugAndroidTest` (same task + same `rustBuild*` exclusions as before) with one cheap `adb kill/start` retry to absorb a transient `adb: device offline` at install/test start **without** paying for a full reboot. All adb waits are `timeout`-guarded so a crashed emulator fails fast to the outer retry instead of hanging.

Also adds `-camera-front none -no-metrics` to `emulator-options` (minor hardening).

## What is unchanged
- `AppLaunchTest.kt` and its assertions (window foreground + WebView renders, 30s each)
- The gradle task, flavor, and `rustBuild*` exclusions
- App build/behavior

## Verification
No Android emulator is available in the dev environment, so this was validated statically: `bash -n` on the script, `yaml.safe_load` on the workflow, and confirming `gradlew` + the `Universal` variant task are unchanged from the previously-working config. **Final verification is the CI run on this PR itself** — the retry only shows its value across repeated runs given the flake is non-deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)