### PR TITLE
fix(standalone): normalize store keys (no empty path chunks)

### DIFF
--- a/apps/vizij-standalone/src/hooks/useWebSocketSync.ts
+++ b/apps/vizij-standalone/src/hooks/useWebSocketSync.ts
@@ -215,10 +215,19 @@ export function useWebSocketSync() {
     const constraintKeys = Object.keys(inputConstraints);
     if (constraintKeys.length === 0) return;
 
-    const nodes: NodeInfo[] = constraintKeys.map((path) => {
+    // Register each input under its canonical store key. The constraint map
+    // holds ~4 aliases per input (raw, namespaced, and slash-prefixed variants);
+    // normalizeSlotPath collapses them to one clean key, so the seeded catalog
+    // matches what pushValues publishes and carries no empty chunks.
+    const seenPaths = new Set<string>();
+    const nodes: NodeInfo[] = [];
+    for (const path of constraintKeys) {
+      const cleanPath = normalizeSlotPath(path);
+      if (seenPaths.has(cleanPath)) continue;
+      seenPaths.add(cleanPath);
       const constraint = inputConstraints[path];
-      return {
-        path,
+      nodes.push({
+        path: cleanPath,
         kind: "input" as const,
         value_type: "f64" as AroraType, // Current nodes are all f64
         min: constraint?.min,
@@ -227,8 +236,8 @@ export function useWebSocketSync() {
           constraint?.defaultValue != null
             ? f64(constraint.defaultValue)
             : undefined,
-      };
-    });
+      });
+    }
 
     invoke("set_slots", { slots: nodes })
       .then(() => {
@@ -240,7 +249,7 @@ export function useWebSocketSync() {
       .catch((err) => {
         console.error("[vizij-standalone] Failed to sync slots:", err);
       });
-  }, [ready, inputConstraints]);
+  }, [ready, inputConstraints, normalizeSlotPath]);
 
   // Listen for WebSocket updates
   useEffect(() => {
@@ -327,7 +336,14 @@ export function useWebSocketSync() {
       for (const path of constraintKeys) {
         const currentValue = getRigValue(path);
         if (currentValue !== undefined) {
-          values[path] = f64(currentValue);
+          // Publish under the canonical store key, not the raw constraint-map
+          // alias. Rig input paths are stored with a leading slash (e.g.
+          // "/rblid/translation/z") and the map also holds namespaced variants;
+          // publishing those verbatim yields empty Zenoh chunks once the bridge
+          // prepends "state/{uid}/" ("state/<uid>//rblid/..."). normalizeSlotPath
+          // strips the leading slash, collapses "//", and drops the namespace,
+          // which also collapses the ~4 aliases of each input to one key.
+          values[normalizeSlotPath(path)] = f64(currentValue);
         }
       }
       if (Object.keys(values).length > 0) {
@@ -341,7 +357,7 @@ export function useWebSocketSync() {
     pushValues();
     const interval = window.setInterval(pushValues, 100);
     return () => window.clearInterval(interval);
-  }, [ready, inputConstraints, getRigValue]);
+  }, [ready, inputConstraints, getRigValue, normalizeSlotPath]);
 
   return {
     ready,


### PR DESCRIPTION
## Root cause

The standalone app published store keys with empty path segments — e.g. `/rblid/translation/z` (leading slash) and `namespace//rblid/translation/z` (`//`). Downstream consumers that use these as hierarchical keys reject empty segments, producing a tight error/log flood.

Rig input paths are canonically stored **with a leading slash** (`normalizeStandardRigInputPath` forces `/rblid/translation/z`), and the constraint map holds ~4 aliases per input (raw, namespaced, and slash-prefixed variants). Both publish sites in `useWebSocketSync.ts` emitted those keys **verbatim**:

- `pushValues` (10 Hz live-value push) → published each alias as-is (up to 4× per value).
- the `set_slots` catalog sync → seeded the same malformed keys.

## Fix

Run every published key through the **existing** `normalizeSlotPath` helper (strips leading slashes, collapses `//`, drops the namespace prefix). This removes the empty segments at the source and collapses the ~4 aliases to one canonical key (e.g. `rblid/translation/z`). `set_slots` dedupes the collapsed keys so the seeded catalog matches what `pushValues` publishes.

No behavior change to rig value lookup — values are still looked up by the original constraint-map key; only the **published** key is normalized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)