### PR TITLE
docs: fix stale/broken references

### DIFF
--- a/packages/@vizij/animation-react/README.md
+++ b/packages/@vizij/animation-react/README.md
@@ -44,7 +44,7 @@ npm install @vizij/animation-react @vizij/animation-wasm react react-dom
 yarn add @vizij/animation-react @vizij/animation-wasm react react-dom
 ```
 
-During local development with linked WASM packages, ensure your bundler preserves symlinks and excludes `@vizij/animation-wasm` from pre-bundling (see the [`vizij-web` README](../../README.md#local-wasm-development) for a Vite example).
+During local development with linked WASM packages, ensure your bundler preserves symlinks and excludes `@vizij/animation-wasm` from pre-bundling (see the [`vizij-web` README](../../../README.md#local-wasm-development) for a Vite example).
 
 > **Bundler note:** `@vizij/animation-react` depends on `@vizij/animation-wasm`, which emits a `.wasm` artefact. Enable async WebAssembly and treat `.wasm` files as emitted assets in your bundler. For Next.js:
 >
@@ -242,6 +242,6 @@ The workflow builds with the latest linked dependencies, runs tests, and publish
 
 - [`@vizij/animation-wasm`](../../../vizij-rs/npm/@vizij/animation-wasm/README.md) – WASM binding used internally.
 - [`vizij-animation-core`](../../../vizij-rs/crates/animation/vizij-animation-core/README.md) – underlying animation engine.
-- [`@vizij/node-graph-react`](../@vizij/node-graph-react/README.md) / [`@vizij/orchestrator-react`](../@vizij/orchestrator-react/README.md) – complementary React bindings.
+- [`@vizij/node-graph-react`](../node-graph-react/README.md) / [`@vizij/orchestrator-react`](../orchestrator-react/README.md) – complementary React bindings.
 
 Questions or feature requests? Open an issue—smooth React integration keeps Vizij animations easy to use. 🎬

--- a/packages/@vizij/node-graph-react/README.md
+++ b/packages/@vizij/node-graph-react/README.md
@@ -43,7 +43,7 @@ npm install @vizij/node-graph-react @vizij/node-graph-wasm react react-dom
 yarn add @vizij/node-graph-react @vizij/node-graph-wasm react react-dom
 ```
 
-When consuming linked WASM packages during development, configure Vite (or your bundler) to preserve symlinks and exclude the wasm shim from prebundling. See the [vizij-web README](../../README.md#local-wasm-development) for details.
+When consuming linked WASM packages during development, configure Vite (or your bundler) to preserve symlinks and exclude the wasm shim from prebundling. See the [vizij-web README](../../../README.md#local-wasm-development) for details.
 
 > **Bundler note:** The underlying `@vizij/node-graph-wasm` package emits a `.wasm` binary. Enable async WebAssembly and emit `.wasm` assets in your bundler. For Next.js:
 >
@@ -211,7 +211,7 @@ pnpm --filter "@vizij/node-graph-react" build
 pnpm --filter "@vizij/node-graph-react" typecheck
 ```
 
-Tests run under Vitest with the wasm layer mocked to keep CI fast. To exercise the real WASM runtime end-to-end, rebuild the wrapper in `vizij-rs` and run one of the demo apps (e.g., `apps/demo-graph`).
+Tests run under Vitest with the wasm layer mocked to keep CI fast. To exercise the real WASM runtime end-to-end, rebuild the wrapper in `vizij-rs` and run one of the demo apps (e.g., `apps/demo-graph-studio`).
 
 ---
 
@@ -252,6 +252,6 @@ The action will build, test, and publish the package with provenance metadata.
 - [`@vizij/node-graph-wasm`](../../../vizij-rs/npm/@vizij/node-graph-wasm/README.md) – wasm wrapper consumed by this package.
 - [`vizij-graph-wasm`](../../../vizij-rs/crates/node-graph/vizij-graph-wasm/README.md) – Rust crate providing the wasm binding.
 - [`vizij-graph-core`](../../../vizij-rs/crates/node-graph/vizij-graph-core/README.md) – Core evaluator that ultimately runs the graph.
-- [`@vizij/orchestrator-react`](../@vizij/orchestrator-react/README.md) – React provider for coordinating graphs and animations together.
+- [`@vizij/orchestrator-react`](../orchestrator-react/README.md) – React provider for coordinating graphs and animations together.
 
 Need help or spot something missing? File an issue in the Vizij repo—consistent docs keep our integration story sharp. ⚙️

--- a/packages/@vizij/orchestrator-react/README.md
+++ b/packages/@vizij/orchestrator-react/README.md
@@ -198,7 +198,7 @@ pnpm --filter "@vizij/orchestrator-react" build
 pnpm --filter "@vizij/orchestrator-react" typecheck
 ```
 
-Vitest tests mock the wasm binding to keep execution fast. When you want end-to-end coverage against the real `vizij-orchestrator-wasm` build, rebuild the WASM package in `vizij-rs` (`pnpm run build:wasm:orchestrator`) and launch the `apps/demo-orchestrator` workspace.
+Vitest tests mock the wasm binding to keep execution fast. When you want end-to-end coverage against the real `vizij-orchestrator-wasm` build, rebuild the WASM package in `vizij-rs` (`pnpm run build:wasm:orchestrator`) and launch the `apps/minimal-demo-orchestrator` workspace.
 
 ---
 
@@ -238,7 +238,7 @@ Successful runs publish with provenance metadata using `NODE_AUTH_TOKEN`.
 
 - [`@vizij/orchestrator-wasm`](../../../vizij-rs/npm/@vizij/orchestrator-wasm/README.md) – wasm wrapper consumed by this package.
 - [`vizij-orchestrator-core`](../../../vizij-rs/crates/orchestrator/vizij-orchestrator-core/README.md) – Rust crate providing orchestrator logic.
-- [`@vizij/node-graph-react`](../@vizij/node-graph-react/README.md) & [`@vizij/animation-react`](../@vizij/animation-react/README.md) – React bindings for the other Vizij stacks.
-- `apps/demo-orchestrator` – Minimal showcase using this package end-to-end.
+- [`@vizij/node-graph-react`](../node-graph-react/README.md) & [`@vizij/animation-react`](../animation-react/README.md) – React bindings for the other Vizij stacks.
+- `apps/minimal-demo-orchestrator` – Minimal showcase using this package end-to-end.
 
 Questions or feedback? Open an issue in Vizij’s main repo—great documentation keeps orchestration predictable. 🔄

--- a/packages/@vizij/render/AGENTS.md
+++ b/packages/@vizij/render/AGENTS.md
@@ -1,7 +1,7 @@
 # Agent Notes · @vizij/render
 
 - Run tasks with `pnpm --filter "@vizij/render"` (`build`, `test`, `typecheck`, `lint`, `clean`). Builds run through `tsup`; keep outputs confined to `dist/`.
-- Coordinate changes with consuming apps (`apps/demo-vizij-authoring`, `apps/demo-vizij-player`, `apps/demo-vizij-rigging`) and `@vizij/utils`. Keep README snapshots and component docs aligned when APIs move.
+- Coordinate changes with consuming apps (`apps/vizij-authoring`, `apps/demo-vizij-player`, `apps/vizij-showcase`) and `@vizij/utils`. Keep README snapshots and component docs aligned when APIs move.
 - Dependencies like `three`, `@react-three/fiber`, and `zustand` must stay in sync with the demo apps. If you bump them, run the apps locally to confirm nothing regresses.
 - Before publishing, generate a changeset and then execute:
 

--- a/packages/@vizij/render/README.md
+++ b/packages/@vizij/render/README.md
@@ -96,7 +96,7 @@ The store tracks world graph entries, controllers, debug overlays, and renderabl
 ## Controllers & Helpers
 
 - Controllers under `src/controllers` encapsulate input handling, camera logic, and other behaviours. Compose them with your own React components.
-- `loadGLTF` / `loadGLTFBlob` simplify loading rig assets and extract animatable metadata used by `@vizij/rig`.
+- `loadGLTF` / `loadGLTFBlob` simplify loading rig assets and extract animatable metadata used by `@vizij/runtime-react`.
 - `export` helpers produce snapshots of the current scene (useful for tooling or exporting frames).
 
 All exports are re-exported through `src/index.tsx`, so a simple `import { loadGLTF } from "@vizij/render"` works.
@@ -132,7 +132,7 @@ pnpm --filter "@vizij/render" size
 
 ## Publishing
 
-Use the shared workflow at [`.github/workflows/publish-npm.yml`](../../.github/workflows/publish-npm.yml).
+Use the shared workflow at [`.github/workflows/publish-npm.yml`](../../../.github/workflows/publish-npm.yml).
 
 1. Align dependency versions (`three`, `@react-three/*`, `zustand`, Vizij packages) and generate a changeset:
 
@@ -158,7 +158,7 @@ Use the shared workflow at [`.github/workflows/publish-npm.yml`](../../.github/w
 
 ## Related Packages
 
-- [`@vizij/rig`](../@vizij/rig/README.md) – Hooks that consume the renderer to load rigged models.
-- [`@vizij/animation-react`](../@vizij/animation-react/README.md) – React bindings that feed animation values back into the renderer.
+- [`@vizij/runtime-react`](../runtime-react/README.md) – Hooks that consume the renderer to load rigged models.
+- [`@vizij/animation-react`](../animation-react/README.md) – React bindings that feed animation values back into the renderer.
 
 Questions or contributions? Open an issue so we can keep the renderer API and docs sharp for the whole Vizij ecosystem. 🎨

--- a/packages/@vizij/runtime-react/README.md
+++ b/packages/@vizij/runtime-react/README.md
@@ -388,18 +388,18 @@ Mount one `VizijRuntimeProvider` per face; each owns its device. Give hidden or 
 
 ### Bundle-first player
 
-See [`apps/demo-vizij-player`](../../apps/demo-vizij-player/README.md) for the reference “one bundled GLB in, runtime UI out” flow.
+See [`apps/demo-vizij-player`](../../../apps/demo-vizij-player/README.md) for the reference “one bundled GLB in, runtime UI out” flow.
 
 ### Fullscreen face tutorials
 
 See:
 
-- [`apps/tutorial-fullscreen-face/tutorial.md`](../../apps/tutorial-fullscreen-face/tutorial.md)
-- [`apps/tutorial-agent-face/tutorial.md`](../../apps/tutorial-agent-face/tutorial.md)
+- [`apps/tutorial-fullscreen-face/tutorial.md`](../../../apps/tutorial-fullscreen-face/tutorial.md)
+- [`apps/tutorial-agent-face/tutorial.md`](../../../apps/tutorial-agent-face/tutorial.md)
 
 ### Runtime-truthful authoring
 
-See [`apps/vizij-authoring/README.md`](../../apps/vizij-authoring/README.md) for the `setGraphBundle()` and `transformOutputWrite()` tooling workflow.
+See [`apps/vizij-authoring/README.md`](../../../apps/vizij-authoring/README.md) for the `setGraphBundle()` and `transformOutputWrite()` tooling workflow.
 
 ## Development
 

--- a/packages/@vizij/speech-react/README.md
+++ b/packages/@vizij/speech-react/README.md
@@ -118,4 +118,4 @@ pnpm --filter "@vizij/speech-react" build
 pnpm --filter "@vizij/speech-react" typecheck
 ```
 
-For an end-to-end validation target, use [`apps/vizij-standalone`](../../apps/vizij-standalone/README.md), which exercises STT, LLM, TTS, viseme playback, and runtime-react integration together.
+For an end-to-end validation target, use [`apps/vizij-standalone`](../../../apps/vizij-standalone/README.md), which exercises STT, LLM, TTS, viseme playback, and runtime-react integration together.

--- a/packages/@vizij/utils/README.md
+++ b/packages/@vizij/utils/README.md
@@ -86,7 +86,7 @@ pnpm --filter "@vizij/utils" typecheck
 
 ## Publishing
 
-Releases flow through [`.github/workflows/publish-npm.yml`](../../.github/workflows/publish-npm.yml).
+Releases flow through [`.github/workflows/publish-npm.yml`](../../../.github/workflows/publish-npm.yml).
 
 1. Record a changeset and apply the version bump:
 
@@ -111,7 +111,7 @@ Releases flow through [`.github/workflows/publish-npm.yml`](../../.github/workfl
 
 ## Related Packages
 
-- [`@vizij/animation-react`](../@vizij/animation-react/README.md) – Re-exports value helpers for React consumers.
+- [`@vizij/animation-react`](../animation-react/README.md) – Re-exports value helpers for React consumers.
 - [`@vizij/render`](../render/README.md) – Uses the namespace helpers to manage store ids.
 
 Have ideas for additional shared helpers? Open a PR and document the changes here to keep the ecosystem aligned. 🧰


### PR DESCRIPTION
Surgical fix of stale/broken references in package documentation. No code, test, or config logic changes.

## What changed
- **`@vizij/rig` is gone** — `packages/@vizij/render/README.md` now points its rig-hook references at `@vizij/runtime-react` (the actual consumer; `useRigInput` lives there), replacing a dead `../@vizij/rig/README.md` link.
- **Sibling-package links** — removed a spurious `@vizij/` path segment from links between `packages/@vizij/*` READMEs (e.g. `../@vizij/animation-react/README.md` → `../animation-react/README.md`). Confirmed against the one already-correct link in `utils/README.md`.
- **Off-by-one relative links** — root-README, `apps/`, and workflow links were one directory level short after packages moved under `packages/@vizij/` (`../../` → `../../../`).
- **Stale app names** — `apps/demo-orchestrator` → `apps/minimal-demo-orchestrator`, `apps/demo-graph` → `apps/demo-graph-studio`, and `apps/demo-vizij-authoring` / `apps/demo-vizij-rigging` → real render consumers `apps/vizij-authoring` / `apps/vizij-showcase`.

## Deliberately left (not stale)
- Cross-repo links to `../../../vizij-rs/...`, `../vizij-docs`, `../vizij-ai.github.io` — an intentional sibling-repo convention (matches the root README "Related Repositories" section).
- `@vizij/*-wasm`, `@vizij/value-json`, `@vizij/arora-web-wasm` — real published npm dependencies, not local packages.
- Generated `CHANGELOG.md` changeset-header links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)