### PR TITLE
feat(vizij-authoring): FBX-in-GLB pose extraction (WIP)

### DIFF
--- a/apps/vizij-authoring/src/App.tsx
+++ b/apps/vizij-authoring/src/App.tsx
@@ -23,6 +23,7 @@ import {
   type SurfaceTab,
 } from "./components/panels/VariablesPanel";
 import { AnimationPanel } from "./components/panels/AnimationPanel";
+import { useFbxPoseExtraction, PoseExtractionPanel } from "./poseExtraction";
 import {
   Viewer,
   type RuntimeExportBodiesSnapshot,
@@ -614,6 +615,8 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
     sourceName,
     isLoading,
     exportSceneRoot,
+    sceneRoot,
+    rawClips,
     faceLoadSessionToken,
     faceLoadMilestones,
     faceLoadInFlightOperationCount,
@@ -774,6 +777,13 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
   );
   const runtimeWorld = useVizijStore((state) => state.world);
   const runtimeAnimatables = useVizijStore((state) => state.animatables);
+
+  const fbxPoseExtraction = useFbxPoseExtraction({
+    world: runtimeWorld,
+    animatables: runtimeAnimatables,
+    rawClips,
+    scene: sceneRoot,
+  });
 
   const [viewerSplitVertical, setViewerSplitVertical] = useState(false);
   const [motionGraphSplitVertical, setMotionGraphSplitVertical] =
@@ -3299,6 +3309,9 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
   const animationPanelVisible = useWorkspaceStore(
     (state) => state.panels.animation.isVisible,
   );
+  const poseExtractionPanelVisible = useWorkspaceStore(
+    (state) => state.panels.poseExtraction.isVisible,
+  );
   const motionGraphPanelVisible = useWorkspaceStore(
     (state) => state.panels.motiongraph.isVisible,
   );
@@ -3631,6 +3644,29 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
   const handleHideAnimationPanel = useCallback(() => {
     setWorkspacePanelVisibility("animation", false);
   }, [setWorkspacePanelVisibility]);
+  const handleHidePoseExtractionPanel = useCallback(() => {
+    setWorkspacePanelVisibility("poseExtraction", false);
+  }, [setWorkspacePanelVisibility]);
+  // Auto-open the Pose Extraction panel once when a GLB with raw FBX clips loads;
+  // re-arm the latch when the clips go away so the next such load re-opens it.
+  const autoOpenedFbxExtractionRef = useRef(false);
+  useEffect(() => {
+    if (fbxPoseExtraction.isAvailable) {
+      if (!autoOpenedFbxExtractionRef.current) {
+        autoOpenedFbxExtractionRef.current = true;
+        setWorkspacePanelVisibility("poseExtraction", true);
+      }
+      return;
+    }
+    autoOpenedFbxExtractionRef.current = false;
+    if (poseExtractionPanelVisible) {
+      setWorkspacePanelVisibility("poseExtraction", false);
+    }
+  }, [
+    fbxPoseExtraction.isAvailable,
+    poseExtractionPanelVisible,
+    setWorkspacePanelVisibility,
+  ]);
   const handleHideMotionGraphPanel = useCallback(() => {
     setWorkspacePanelVisibility("motiongraph", false);
   }, [setWorkspacePanelVisibility]);
@@ -4232,6 +4268,8 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
   const effectiveControlAuthoringPanelVisible =
     sceneLoaded && controlAuthoringPanelVisible;
   const effectiveAnimationPanelVisible = sceneLoaded && animationPanelVisible;
+  const effectivePoseExtractionPanelVisible =
+    sceneLoaded && poseExtractionPanelVisible;
   const effectiveMotionGraphPanelVisible =
     sceneLoaded && motionGraphPanelVisible;
   const effectiveMotionGraphPalettePanelVisible =
@@ -4484,29 +4522,39 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
           }
           leftBottomVisible={effectiveControlAuthoringPanelVisible}
           viewport={viewportContent}
-          bottomVisible={effectiveAnimationPanelVisible}
+          bottomVisible={
+            effectiveAnimationPanelVisible ||
+            effectivePoseExtractionPanelVisible
+          }
           bottomPanel={
-            <AnimationPanel
-              onClosePanel={handleHideAnimationPanel}
-              onInspectTrack={handleInspectAnimationTrackFromTimeline}
-              playbackState={selectedAnimationPanelPlaybackState}
-              onPlayTransport={
-                resolvedSelectedAnimationTargetId
-                  ? handlePlayAnimationRuntime
-                  : undefined
-              }
-              onPauseTransport={
-                selectedAnimationCanPauseOrStop
-                  ? handlePauseAnimationRuntime
-                  : undefined
-              }
-              onStopTransport={
-                selectedAnimationCanPauseOrStop
-                  ? handleStopAnimationRuntime
-                  : undefined
-              }
-              statusMessage={animationPanelStatusMessage}
-            />
+            effectivePoseExtractionPanelVisible ? (
+              <PoseExtractionPanel
+                api={fbxPoseExtraction}
+                onClose={handleHidePoseExtractionPanel}
+              />
+            ) : (
+              <AnimationPanel
+                onClosePanel={handleHideAnimationPanel}
+                onInspectTrack={handleInspectAnimationTrackFromTimeline}
+                playbackState={selectedAnimationPanelPlaybackState}
+                onPlayTransport={
+                  resolvedSelectedAnimationTargetId
+                    ? handlePlayAnimationRuntime
+                    : undefined
+                }
+                onPauseTransport={
+                  selectedAnimationCanPauseOrStop
+                    ? handlePauseAnimationRuntime
+                    : undefined
+                }
+                onStopTransport={
+                  selectedAnimationCanPauseOrStop
+                    ? handleStopAnimationRuntime
+                    : undefined
+                }
+                statusMessage={animationPanelStatusMessage}
+              />
+            )
           }
           centerPanelDefaultSize={centerPanelDefaultSize}
           // Right

--- a/apps/vizij-authoring/src/components/app/AppMenuBar.tsx
+++ b/apps/vizij-authoring/src/components/app/AppMenuBar.tsx
@@ -95,6 +95,9 @@ export function AppMenuBar({
   const referenceFacePanelVisible = useWorkspaceStore(
     (state) => state.panels.referenceFace.isVisible,
   );
+  const poseExtractionPanelVisible = useWorkspaceStore(
+    (state) => state.panels.poseExtraction.isVisible,
+  );
   const setPanelVisibility = useWorkspaceStore(
     (state) => state.setPanelVisibility,
   );
@@ -119,7 +122,7 @@ export function AppMenuBar({
     onSelectAuthoringSurface(surface);
   };
   const setCenterPanelVisibility = (
-    panel: "animation" | "motiongraph" | "referenceFace",
+    panel: "animation" | "motiongraph" | "referenceFace" | "poseExtraction",
     isVisible: boolean,
   ) => {
     setPanelVisibility(panel, isVisible);
@@ -139,7 +142,11 @@ export function AppMenuBar({
       onSelectEditFocus("procedural-animation-programming");
       return;
     }
-    onSelectEditFocus("reference-face");
+    if (panel === "referenceFace") {
+      onSelectEditFocus("reference-face");
+      return;
+    }
+    // poseExtraction has no dedicated edit focus; leave the current focus intact.
   };
 
   return (
@@ -358,6 +365,15 @@ export function AppMenuBar({
           }
         >
           Reference Face
+        </MenuCheckboxItem>
+        <MenuCheckboxItem
+          testId="app-menu-view-center-pose-extraction"
+          checked={poseExtractionPanelVisible}
+          onCheckedChange={(checked) =>
+            setCenterPanelVisibility("poseExtraction", checked)
+          }
+        >
+          Pose Extraction
         </MenuCheckboxItem>
         <MenuSeparator />
         <MenuLabel>Right Panel</MenuLabel>

--- a/apps/vizij-authoring/src/hooks/useVizijAssetLoader.ts
+++ b/apps/vizij-authoring/src/hooks/useVizijAssetLoader.ts
@@ -1,6 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { LoadedVizijAsset, VizijBundleExtension } from "@vizij/render";
+import type {
+  LoadedVizijAsset,
+  VizijAnimationClipData,
+  VizijBundleExtension,
+} from "@vizij/render";
 import { useVizijStore, useVizijStoreSetter } from "@vizij/render";
+import type {
+  AnimationClipLike,
+  Object3DLike,
+} from "../poseExtraction/fbxFrameExtraction";
 import { findRootId } from "../utils/world";
 import { waitForNextFrame } from "../utils/frame";
 
@@ -329,6 +337,10 @@ export function useVizijAssetLoader() {
   const [error, setError] = useState<string | null>(null);
   const [bundle, setBundle] = useState<VizijBundleExtension | null>(null);
   const [exportSceneRoot, setExportSceneRoot] = useState<unknown>(null);
+  const [rawClips, setRawClips] = useState<AnimationClipLike[]>([]);
+  const [importedAnimations, setImportedAnimations] = useState<
+    VizijAnimationClipData[]
+  >([]);
   const [faceLoadProgress, setFaceLoadProgress] = useState(0);
   const [faceLoadSteps, setFaceLoadSteps] = useState<FaceLoadStep[]>(
     createDefaultFaceLoadSteps,
@@ -864,6 +876,8 @@ export function useVizijAssetLoader() {
           animatables,
           bundle: loadedBundle,
           scene,
+          rawClips: loadedRawClips,
+          animations: loadedAnimations,
         } = await loader();
         assertCurrentLoad();
         await waitForNextFrame();
@@ -986,6 +1000,8 @@ export function useVizijAssetLoader() {
         setSourceName(label);
         setBundle(loadedBundle ?? null);
         setExportSceneRoot(scene ?? null);
+        setRawClips(loadedRawClips ?? []);
+        setImportedAnimations(loadedAnimations ?? []);
         await waitForNextFrame();
         assertCurrentLoad();
 
@@ -1015,6 +1031,8 @@ export function useVizijAssetLoader() {
         console.error("demo-vizij-render: failed to load Vizij", err);
         setBundle(null);
         setExportSceneRoot(null);
+        setRawClips([]);
+        setImportedAnimations([]);
         markImportFlowError(activeStepId, { sessionToken });
       } finally {
         if (
@@ -1074,6 +1092,8 @@ export function useVizijAssetLoader() {
     setError(null);
     setBundle(null);
     setExportSceneRoot(null);
+    setRawClips([]);
+    setImportedAnimations([]);
     setFaceLoadProgress(0);
     setFaceLoadSteps(createDefaultFaceLoadSteps());
     setIsImportFlowActive(false);
@@ -1151,6 +1171,9 @@ export function useVizijAssetLoader() {
     loadFromUrl,
     bundle,
     exportSceneRoot,
+    sceneRoot: exportSceneRoot as Object3DLike | null,
+    rawClips,
+    importedAnimations,
     updateBundle,
   };
 }

--- a/apps/vizij-authoring/src/poseExtraction/components/PoseExtractionPanel.tsx
+++ b/apps/vizij-authoring/src/poseExtraction/components/PoseExtractionPanel.tsx
@@ -1,5 +1,13 @@
 import { useEffect, useMemo, useState, type ChangeEvent } from "react";
-import { Camera, Film, Trash2, AlertTriangle, Play, Pause } from "lucide-react";
+import {
+  Camera,
+  Film,
+  Trash2,
+  AlertTriangle,
+  Play,
+  Pause,
+  Clapperboard,
+} from "lucide-react";
 import { Panel } from "../../components/ui/Panel";
 import { Button } from "../../components/ui/Button";
 import { Input } from "../../components/ui/Input";
@@ -54,6 +62,7 @@ export function PoseExtractionPanel({
     seek,
     togglePlay,
     captureFrame,
+    bakeActiveClip,
     channelCount,
     unmappedChannels,
   } = api;
@@ -64,12 +73,14 @@ export function PoseExtractionPanel({
   const [captured, setCaptured] = useState<CapturedFrame[]>([]);
   const [group, setGroup] = useState("");
   const [poseName, setPoseName] = useState("");
+  const [bakeStatus, setBakeStatus] = useState<string | null>(null);
 
   // Default the group to `fbx/<clip>` whenever the active clip changes.
   useEffect(() => {
     if (activeClip) {
       setGroup(`fbx/${sanitizeGroupSegment(activeClip.name)}`);
     }
+    setBakeStatus(null);
   }, [activeClipId, activeClip]);
 
   const defaultPoseName = useMemo(() => {
@@ -102,6 +113,21 @@ export function PoseExtractionPanel({
       { poseId, name, time, clipId: activeClipId ?? "" },
     ]);
     setPoseName("");
+  };
+
+  const handleBake = () => {
+    const result = bakeActiveClip();
+    if (!result) {
+      setBakeStatus(null);
+      return;
+    }
+    if (result.inputCount === 0) {
+      setBakeStatus("No mappable channels to bake.");
+      return;
+    }
+    setBakeStatus(
+      `Baked ${result.inputCount} input${result.inputCount === 1 ? "" : "s"} · ${result.keyframeCount} keyframe${result.keyframeCount === 1 ? "" : "s"} to the timeline.`,
+    );
   };
 
   const handleRename = (poseId: string, nextName: string) => {
@@ -200,7 +226,7 @@ export function PoseExtractionPanel({
             <span>
               {unmappedChannels.length} channel
               {unmappedChannels.length === 1 ? "" : "s"} couldn&apos;t be mapped
-              to a rig input (bones or morph weights) and will be skipped on
+              to a rig input (e.g. skeleton bones) and will be skipped on
               capture.
             </span>
           </div>
@@ -237,6 +263,21 @@ export function PoseExtractionPanel({
             >
               <Camera className="mr-1.5 h-3.5 w-3.5" />
               Capture frame
+            </Button>
+          </div>
+          <div className="mt-1 flex items-center justify-between gap-2 border-t border-border-default/60 pt-2">
+            <span className="text-[11px] text-text-muted">
+              {bakeStatus ?? "Bake the whole clip into the animation timeline."}
+            </span>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={handleBake}
+              disabled={!activeClipId || channelCount === 0}
+              title="Sample every keyframe of this clip into the animation timeline"
+            >
+              <Clapperboard className="mr-1.5 h-3.5 w-3.5" />
+              Bake clip → timeline
             </Button>
           </div>
         </div>

--- a/apps/vizij-authoring/src/poseExtraction/components/PoseExtractionPanel.tsx
+++ b/apps/vizij-authoring/src/poseExtraction/components/PoseExtractionPanel.tsx
@@ -1,0 +1,294 @@
+import { useEffect, useMemo, useState, type ChangeEvent } from "react";
+import { Camera, Film, Trash2, AlertTriangle, Play, Pause } from "lucide-react";
+import { Panel } from "../../components/ui/Panel";
+import { Button } from "../../components/ui/Button";
+import { Input } from "../../components/ui/Input";
+import { Select } from "../../components/ui/Select";
+import { RowSlider } from "../../components/ui/RowSlider";
+import { ListRow } from "../../components/ui/ListRow";
+import { usePoseRigStore } from "../../poseRig/store";
+import type { FbxPoseExtractionApi } from "../useFbxPoseExtraction";
+
+interface CapturedFrame {
+  poseId: string;
+  name: string;
+  time: number;
+  clipId: string;
+}
+
+function formatSeconds(value: number): string {
+  return `${value.toFixed(2)}s`;
+}
+
+function sanitizeGroupSegment(value: string): string {
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return normalized || "clip";
+}
+
+export interface PoseExtractionPanelProps {
+  api: FbxPoseExtractionApi;
+  onClose?: () => void;
+}
+
+/**
+ * Docked panel for extracting poses from raw (FBX-derived) animation clips:
+ * pick a clip, scrub to a frame (live preview in the viewport), and capture the
+ * frame as a named pose. Captured poses land in the pose-rig store and can be
+ * renamed inline or removed here before export.
+ */
+export function PoseExtractionPanel({
+  api,
+  onClose,
+}: PoseExtractionPanelProps) {
+  const {
+    clips,
+    activeClip,
+    activeClipId,
+    time,
+    isPlaying,
+    setActiveClip,
+    seek,
+    togglePlay,
+    captureFrame,
+    channelCount,
+    unmappedChannels,
+  } = api;
+
+  const updatePoseName = usePoseRigStore((state) => state.updatePoseName);
+  const deletePose = usePoseRigStore((state) => state.deletePose);
+
+  const [captured, setCaptured] = useState<CapturedFrame[]>([]);
+  const [group, setGroup] = useState("");
+  const [poseName, setPoseName] = useState("");
+
+  // Default the group to `fbx/<clip>` whenever the active clip changes.
+  useEffect(() => {
+    if (activeClip) {
+      setGroup(`fbx/${sanitizeGroupSegment(activeClip.name)}`);
+    }
+  }, [activeClipId, activeClip]);
+
+  const defaultPoseName = useMemo(() => {
+    if (!activeClip) {
+      return "";
+    }
+    return `${activeClip.name} @ ${formatSeconds(time)}`;
+  }, [activeClip, time]);
+
+  const clipOptions = useMemo(
+    () => clips.map((clip) => ({ value: clip.id, label: clip.name })),
+    [clips],
+  );
+
+  const duration = activeClip?.duration ?? 0;
+  const sliderStep = duration > 0 ? Math.max(duration / 240, 0.001) : 0.01;
+
+  const handleCapture = () => {
+    const name = (poseName.trim() || defaultPoseName).trim();
+    const trimmedGroup = group.trim();
+    const poseId = captureFrame({
+      name,
+      group: trimmedGroup.length > 0 ? trimmedGroup : null,
+    });
+    if (!poseId) {
+      return;
+    }
+    setCaptured((previous) => [
+      ...previous,
+      { poseId, name, time, clipId: activeClipId ?? "" },
+    ]);
+    setPoseName("");
+  };
+
+  const handleRename = (poseId: string, nextName: string) => {
+    setCaptured((previous) =>
+      previous.map((frame) =>
+        frame.poseId === poseId ? { ...frame, name: nextName } : frame,
+      ),
+    );
+    updatePoseName(poseId, nextName);
+  };
+
+  const handleRemove = (poseId: string) => {
+    setCaptured((previous) =>
+      previous.filter((frame) => frame.poseId !== poseId),
+    );
+    deletePose(poseId);
+  };
+
+  const capturedForClip = useMemo(
+    () => captured.filter((frame) => frame.clipId === activeClipId),
+    [captured, activeClipId],
+  );
+
+  return (
+    <Panel
+      title="Pose Extraction"
+      description="Scrub a loaded animation and capture frames as poses."
+      actions={
+        onClose ? (
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            Hide
+          </Button>
+        ) : undefined
+      }
+      className="h-full overflow-y-auto"
+    >
+      <div className="flex flex-col gap-4 p-1">
+        <div className="flex items-end gap-3">
+          <div className="min-w-[12rem] flex-1">
+            <Select
+              label="Animation clip"
+              value={activeClipId ?? ""}
+              onChange={setActiveClip}
+              options={clipOptions}
+              placeholder="Select a clip…"
+            />
+          </div>
+          <div className="flex items-center gap-1.5 text-[11px] text-text-secondary">
+            <Film className="h-3.5 w-3.5" />
+            <span>
+              {channelCount} channel{channelCount === 1 ? "" : "s"}
+            </span>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center justify-between px-1">
+            <label className="text-[10px] font-black uppercase tracking-widest text-text-secondary">
+              Frame
+            </label>
+            <span className="font-mono text-[11px] text-text-secondary">
+              {formatSeconds(time)} / {formatSeconds(duration)}
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="secondary"
+              size="icon"
+              onClick={togglePlay}
+              disabled={!activeClipId || duration <= 0}
+              aria-label={isPlaying ? "Pause clip" : "Play clip"}
+              title={isPlaying ? "Pause clip" : "Play clip"}
+            >
+              {isPlaying ? (
+                <Pause className="h-3.5 w-3.5" />
+              ) : (
+                <Play className="h-3.5 w-3.5" />
+              )}
+            </Button>
+            <div className="flex-1">
+              <RowSlider
+                value={time}
+                min={0}
+                max={duration > 0 ? duration : 1}
+                step={sliderStep}
+                onChange={seek}
+                disabled={!activeClipId || duration <= 0}
+              />
+            </div>
+          </div>
+        </div>
+
+        {unmappedChannels.length > 0 ? (
+          <div className="flex items-start gap-2 rounded-lg border border-warning/40 bg-warning-subtle px-3 py-2 text-[11px] text-text-secondary">
+            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-warning" />
+            <span>
+              {unmappedChannels.length} channel
+              {unmappedChannels.length === 1 ? "" : "s"} couldn&apos;t be mapped
+              to a rig input (bones or morph weights) and will be skipped on
+              capture.
+            </span>
+          </div>
+        ) : null}
+
+        <div className="flex flex-col gap-2 rounded-lg border border-border-default bg-bg-card p-3">
+          <Input
+            size="sm"
+            value={poseName}
+            onChange={(event: ChangeEvent<HTMLInputElement>) =>
+              setPoseName(event.target.value)
+            }
+            placeholder={defaultPoseName || "Pose name"}
+          />
+          <div className="flex items-center gap-2">
+            <Input
+              size="sm"
+              value={group}
+              onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                setGroup(event.target.value)
+              }
+              placeholder="Pose group (path)"
+              startContent={
+                <span className="text-[10px] uppercase tracking-widest">
+                  Group
+                </span>
+              }
+            />
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={handleCapture}
+              disabled={!activeClipId || channelCount === 0}
+            >
+              <Camera className="mr-1.5 h-3.5 w-3.5" />
+              Capture frame
+            </Button>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center justify-between px-1">
+            <span className="text-[10px] font-black uppercase tracking-widest text-text-secondary">
+              Captured poses
+            </span>
+            <span className="text-[11px] text-text-muted">
+              {capturedForClip.length}
+            </span>
+          </div>
+          {capturedForClip.length === 0 ? (
+            <p className="px-1 text-[11px] text-text-muted">
+              No poses captured yet. Scrub to a frame and capture it.
+            </p>
+          ) : (
+            <div className="flex flex-col gap-1.5">
+              {capturedForClip.map((frame) => (
+                <ListRow
+                  key={frame.poseId}
+                  title={
+                    <Input
+                      size="sm"
+                      value={frame.name}
+                      onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                        handleRename(frame.poseId, event.target.value)
+                      }
+                    />
+                  }
+                  meta={
+                    <span className="font-mono text-[10px] text-text-muted">
+                      {formatSeconds(frame.time)}
+                    </span>
+                  }
+                  actions={
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => handleRemove(frame.poseId)}
+                      aria-label="Remove pose"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
+                  }
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </Panel>
+  );
+}

--- a/apps/vizij-authoring/src/poseExtraction/fbxFrameExtraction.test.ts
+++ b/apps/vizij-authoring/src/poseExtraction/fbxFrameExtraction.test.ts
@@ -3,6 +3,8 @@ import {
   AnimationClip,
   Euler,
   Group,
+  Mesh,
+  NumberKeyframeTrack,
   Object3D,
   Quaternion,
   QuaternionKeyframeTrack,
@@ -11,7 +13,9 @@ import {
 import type { World } from "@vizij/render";
 import {
   channelSampleToRawValue,
+  collectClipFrameTimes,
   indexRawChannels,
+  isChannelMapped,
   sampleFrameToInputValues,
   sampleFrameToRenderWrites,
   sampleRawTrackAtTime,
@@ -42,6 +46,41 @@ function buildFixture() {
   } as unknown as World;
 
   return { node, scene, world };
+}
+
+// A mesh with morph targets, mirroring how `import-geometry.ts` records
+// `Shape.morphTargets` (ordered featureKeys) + per-morph number features.
+function buildMorphFixture() {
+  const mesh = new Mesh();
+  mesh.name = "Mouth";
+  mesh.morphTargetDictionary = { ltsneer: 0, jawud: 1, sidewide: 2 };
+  mesh.morphTargetInfluences = [0, 0, 0];
+  const scene = new Group();
+  scene.add(mesh);
+
+  const world = {
+    [mesh.uuid]: {
+      id: mesh.uuid,
+      name: "Mouth",
+      type: "shape",
+      morphTargets: ["ltsneer", "jawud", "sidewide"],
+      features: {
+        translation: { animated: true, value: "anim-translation" },
+        ltsneer: { animated: true, value: "anim-m0" },
+        jawud: { animated: true, value: "anim-m1" },
+        sidewide: { animated: true, value: "anim-m2" },
+      },
+    },
+  } as unknown as World;
+
+  // Flat weights track: 3 morphs × 2 keyframes (t=0 all zero, t=1 ramp).
+  const track = new NumberKeyframeTrack(
+    "Mouth.morphTargetInfluences",
+    [0, 1],
+    [0, 0, 0, 1, 0.5, 0.25],
+  );
+  const clip = new AnimationClip("smile", 1, [track]);
+  return { scene, world, clip };
 }
 
 describe("sampleRawTrackAtTime", () => {
@@ -211,5 +250,54 @@ describe("summarizeClips", () => {
     const [a, b] = summarizeClips([named, unnamed]);
     expect(a).toMatchObject({ id: "wave", name: "wave", duration: 2 });
     expect(b).toMatchObject({ id: "fbx-animation-1", name: "Animation 2" });
+  });
+});
+
+describe("morph weights", () => {
+  it("indexes a weights channel to the mesh's ordered per-morph animatables", () => {
+    const { scene, world, clip } = buildMorphFixture();
+    const [binding] = indexRawChannels([clip], scene, world);
+    expect(binding.property).toBe("weights");
+    expect(binding.animatableId).toBeNull();
+    expect(binding.morphTargets).toEqual(["anim-m0", "anim-m1", "anim-m2"]);
+    expect(isChannelMapped(binding)).toBe(true);
+  });
+
+  it("splits the flat weights sample into per-morph render writes", () => {
+    const { scene, world, clip } = buildMorphFixture();
+    const bindings = indexRawChannels([clip], scene, world);
+    const writes = sampleFrameToRenderWrites(bindings, "smile", 0.5, "default");
+    expect(writes).toEqual([
+      { id: "anim-m0", namespace: "default", value: 0.5 },
+      { id: "anim-m1", namespace: "default", value: 0.25 },
+      { id: "anim-m2", namespace: "default", value: 0.125 },
+    ]);
+  });
+
+  it("maps each morph to its scalar input id", () => {
+    const { scene, world, clip } = buildMorphFixture();
+    const bindings = indexRawChannels([clip], scene, world);
+    const resolveInputId = (componentId: string): string | null =>
+      ({ "anim-m0": "in0", "anim-m1": "in1", "anim-m2": "in2" })[componentId] ??
+      null;
+    const values = sampleFrameToInputValues(
+      bindings,
+      "smile",
+      1,
+      resolveInputId,
+    );
+    expect(values).toEqual({ in0: 1, in1: 0.5, in2: 0.25 });
+  });
+});
+
+describe("collectClipFrameTimes", () => {
+  it("returns the sorted union of track keyframe times", () => {
+    const { scene, world, clip } = buildMorphFixture();
+    const bindings = indexRawChannels([clip], scene, world);
+    expect(collectClipFrameTimes(bindings, "smile")).toEqual([0, 1]);
+  });
+
+  it("falls back to [0] when no times are present", () => {
+    expect(collectClipFrameTimes([], "missing")).toEqual([0]);
   });
 });

--- a/apps/vizij-authoring/src/poseExtraction/fbxFrameExtraction.test.ts
+++ b/apps/vizij-authoring/src/poseExtraction/fbxFrameExtraction.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+import {
+  AnimationClip,
+  Euler,
+  Group,
+  Object3D,
+  Quaternion,
+  QuaternionKeyframeTrack,
+  VectorKeyframeTrack,
+} from "three";
+import type { World } from "@vizij/render";
+import {
+  channelSampleToRawValue,
+  indexRawChannels,
+  sampleFrameToInputValues,
+  sampleFrameToRenderWrites,
+  sampleRawTrackAtTime,
+  summarizeClips,
+  type RawChannelBinding,
+} from "./fbxFrameExtraction";
+
+// Build a minimal scene + Vizij world mirroring how `@vizij/render` imports a
+// GLB node: a named Object3D whose uuid keys a renderable with translation /
+// rotation / scale features referencing animatable ids.
+function buildFixture() {
+  const node = new Object3D();
+  node.name = "Head";
+  const scene = new Group();
+  scene.add(node);
+
+  const world = {
+    [node.uuid]: {
+      id: node.uuid,
+      name: "Head",
+      type: "group",
+      features: {
+        translation: { animated: true, value: "anim-translation" },
+        rotation: { animated: true, value: "anim-rotation" },
+        scale: { animated: true, value: "anim-scale" },
+      },
+    },
+  } as unknown as World;
+
+  return { node, scene, world };
+}
+
+describe("sampleRawTrackAtTime", () => {
+  it("interpolates a vector track linearly", () => {
+    const track = new VectorKeyframeTrack(
+      "Head.position",
+      [0, 1],
+      [0, 0, 0, 10, 20, 30],
+    );
+    expect(sampleRawTrackAtTime(track, 0)).toEqual([0, 0, 0]);
+    expect(sampleRawTrackAtTime(track, 0.5)).toEqual([5, 10, 15]);
+    expect(sampleRawTrackAtTime(track, 1)).toEqual([10, 20, 30]);
+  });
+
+  it("slerps a quaternion track", () => {
+    const qa = new Quaternion().setFromEuler(new Euler(0, 0, 0));
+    const qb = new Quaternion().setFromEuler(new Euler(0, 0, Math.PI / 2));
+    const track = new QuaternionKeyframeTrack(
+      "Head.quaternion",
+      [0, 1],
+      [qa.x, qa.y, qa.z, qa.w, qb.x, qb.y, qb.z, qb.w],
+    );
+    const mid = sampleRawTrackAtTime(track, 0.5);
+    expect(mid).toHaveLength(4);
+    const q = new Quaternion(mid[0], mid[1], mid[2], mid[3]);
+    const euler = new Euler().setFromQuaternion(q, "XYZ");
+    // Halfway between 0 and 90 degrees about Z.
+    expect(euler.z).toBeCloseTo(Math.PI / 4, 5);
+  });
+});
+
+describe("channelSampleToRawValue", () => {
+  const base: RawChannelBinding = {
+    clipId: "clip",
+    trackIndex: 0,
+    trackName: "Head.position",
+    track: new VectorKeyframeTrack("Head.position", [0], [0, 0, 0]),
+    nodeName: "Head",
+    nodeUuid: "uuid",
+    property: "translation",
+    animatableId: "anim-translation",
+    animatableType: "vector3",
+    valueSize: 3,
+  };
+
+  it("maps translation samples to a vector3", () => {
+    expect(channelSampleToRawValue(base, [1, 2, 3])).toEqual({
+      x: 1,
+      y: 2,
+      z: 3,
+    });
+  });
+
+  it("converts a quaternion sample to an XYZ euler matching the renderer", () => {
+    const q = new Quaternion().setFromEuler(new Euler(0.1, 0.2, 0.3, "XYZ"));
+    const value = channelSampleToRawValue(
+      { ...base, property: "rotation", animatableType: "euler", valueSize: 4 },
+      [q.x, q.y, q.z, q.w],
+    );
+    expect(value).toBeDefined();
+    const euler = value as { x: number; y: number; z: number };
+    expect(euler.x).toBeCloseTo(0.1, 5);
+    expect(euler.y).toBeCloseTo(0.2, 5);
+    expect(euler.z).toBeCloseTo(0.3, 5);
+  });
+
+  it("returns undefined for unmapped weights channels", () => {
+    expect(
+      channelSampleToRawValue({ ...base, property: "weights" }, [0.5]),
+    ).toBeUndefined();
+  });
+});
+
+describe("indexRawChannels", () => {
+  it("resolves tracks to the owning renderable animatables", () => {
+    const { node, scene, world } = buildFixture();
+    const track = new VectorKeyframeTrack(
+      "Head.position",
+      [0, 1],
+      [0, 0, 0, 1, 1, 1],
+    );
+    const clip = new AnimationClip("wave", 1, [track]);
+
+    const bindings = indexRawChannels([clip], scene, world);
+    expect(bindings).toHaveLength(1);
+    const [binding] = bindings;
+    expect(binding.clipId).toBe("wave");
+    expect(binding.property).toBe("translation");
+    expect(binding.nodeUuid).toBe(node.uuid);
+    expect(binding.animatableId).toBe("anim-translation");
+    expect(binding.animatableType).toBe("vector3");
+  });
+
+  it("marks tracks for unknown nodes as unmapped", () => {
+    const { scene, world } = buildFixture();
+    const track = new VectorKeyframeTrack(
+      "Bone_01.position",
+      [0, 1],
+      [0, 0, 0, 1, 1, 1],
+    );
+    const clip = new AnimationClip("bones", 1, [track]);
+
+    const [binding] = indexRawChannels([clip], scene, world);
+    expect(binding.animatableId).toBeNull();
+  });
+});
+
+describe("sampleFrame helpers", () => {
+  function buildClipAndBindings() {
+    const { scene, world } = buildFixture();
+    const posTrack = new VectorKeyframeTrack(
+      "Head.position",
+      [0, 1],
+      [0, 0, 0, 2, 4, 6],
+    );
+    const clip = new AnimationClip("wave", 1, [posTrack]);
+    const bindings = indexRawChannels([clip], scene, world);
+    return { bindings };
+  }
+
+  it("produces render-store writes for mapped channels", () => {
+    const { bindings } = buildClipAndBindings();
+    const writes = sampleFrameToRenderWrites(bindings, "wave", 0.5, "default");
+    expect(writes).toEqual([
+      {
+        id: "anim-translation",
+        namespace: "default",
+        value: { x: 1, y: 2, z: 3 },
+      },
+    ]);
+  });
+
+  it("maps sampled components onto resolved input ids", () => {
+    const { bindings } = buildClipAndBindings();
+    const resolveInputId = (componentId: string): string | null => {
+      const map: Record<string, string> = {
+        "anim-translation:x": "input-x",
+        "anim-translation:y": "input-y",
+        "anim-translation:z": "input-z",
+      };
+      return map[componentId] ?? null;
+    };
+    const values = sampleFrameToInputValues(
+      bindings,
+      "wave",
+      0.5,
+      resolveInputId,
+    );
+    expect(values).toEqual({
+      "input-x": 1,
+      "input-y": 2,
+      "input-z": 3,
+    });
+  });
+
+  it("skips components without a resolved input", () => {
+    const { bindings } = buildClipAndBindings();
+    const values = sampleFrameToInputValues(bindings, "wave", 1, () => null);
+    expect(values).toEqual({});
+  });
+});
+
+describe("summarizeClips", () => {
+  it("derives stable ids and names", () => {
+    const named = new AnimationClip("wave", 2, []);
+    const unnamed = new AnimationClip("", 1.5, []);
+    const [a, b] = summarizeClips([named, unnamed]);
+    expect(a).toMatchObject({ id: "wave", name: "wave", duration: 2 });
+    expect(b).toMatchObject({ id: "fbx-animation-1", name: "Animation 2" });
+  });
+});

--- a/apps/vizij-authoring/src/poseExtraction/fbxFrameExtraction.ts
+++ b/apps/vizij-authoring/src/poseExtraction/fbxFrameExtraction.ts
@@ -10,6 +10,8 @@ export interface KeyframeTrackLike {
   name: string;
   getValueSize?: () => number;
   createInterpolant: () => { evaluate: (time: number) => ArrayLike<number> };
+  /** Keyframe times (seconds); used to bake a clip at its native keyframes. */
+  times?: ArrayLike<number>;
 }
 
 /** Minimal shape of a THREE.AnimationClip we rely on. */
@@ -71,8 +73,14 @@ export interface RawChannelBinding {
   nodeUuid: string | null;
   /** Mapped renderable feature. */
   property: RawChannelProperty;
-  /** Vizij animatable id owning this channel. Null when unmapped (e.g. weights, bones). */
+  /** Vizij animatable id owning this channel. Null for weights/bones (see morphTargets). */
   animatableId: string | null;
+  /**
+   * For `weights` channels: the per-morph scalar animatable ids in glTF morph
+   * index order (index j corresponds to sample slot j). `null` at a slot means
+   * that morph had no resolvable animatable. Undefined for non-weights channels.
+   */
+  morphTargets?: Array<string | null>;
   /** Animatable value type inferred from the feature. */
   animatableType: AnimatableValue["type"] | null;
   /** Numeric entries per keyframe in the source track. */
@@ -133,6 +141,42 @@ function readFeatureAnimatableId(
   return null;
 }
 
+/**
+ * Read a mesh renderable's per-morph scalar animatable ids in morph-target
+ * order. The renderer stores `Shape.morphTargets` as featureKeys in
+ * `morphTargetDictionary` (i.e. glTF morph index) order, and each featureKey
+ * maps to an `AnimatableNumber` via `features[featureKey].value` — so slot j
+ * here lines up with slot j of a flat glTF `weights` sampler track. Slots whose
+ * feature can't be resolved are kept as `null` to preserve index alignment.
+ */
+function readMorphAnimatableIds(renderable: unknown): Array<string | null> {
+  if (!renderable || typeof renderable !== "object") {
+    return [];
+  }
+  const record = renderable as {
+    morphTargets?: unknown;
+    features?: Record<string, unknown>;
+  };
+  const keys = Array.isArray(record.morphTargets)
+    ? (record.morphTargets as unknown[])
+    : [];
+  const features = record.features ?? {};
+  return keys.map((key) => {
+    if (typeof key !== "string") {
+      return null;
+    }
+    const feature = features[key];
+    if (!feature || typeof feature !== "object") {
+      return null;
+    }
+    const { animated, value } = feature as {
+      animated?: boolean;
+      value?: unknown;
+    };
+    return animated === true && typeof value === "string" ? value : null;
+  });
+}
+
 function inferAnimatableType(
   property: RawChannelProperty,
 ): AnimatableValue["type"] | null {
@@ -150,11 +194,12 @@ function inferAnimatableType(
 }
 
 /**
- * Resolve every track of every clip to a render-store animatable. Tracks whose
+ * Resolve every track of every clip to render targets. Transform channels
+ * resolve to a single animatable (`animatableId`); `weights` channels resolve to
+ * the target mesh's ordered per-morph animatables (`morphTargets`). Tracks whose
  * target node isn't a Vizij renderable (e.g. skeleton bones, which the importer
- * skips) or whose property has no animatable (morph weights) resolve with
- * `animatableId: null` so callers can surface them as unmapped rather than
- * silently dropping them.
+ * skips) resolve unmapped so callers can surface them rather than silently
+ * dropping them.
  */
 export function indexRawChannels(
   clips: AnimationClipLike[],
@@ -177,10 +222,13 @@ export function indexRawChannels(
 
       let nodeUuid: string | null = null;
       let animatableId: string | null = null;
+      let morphTargets: Array<string | null> | undefined;
       if (nodeName) {
         const node = findSceneNode(scene, nodeName);
         nodeUuid = node?.uuid ?? null;
-        if (nodeUuid && property && property !== "weights") {
+        if (nodeUuid && property === "weights") {
+          morphTargets = readMorphAnimatableIds(world[nodeUuid]);
+        } else if (nodeUuid && property) {
           animatableId = readFeatureAnimatableId(world[nodeUuid], property);
         }
       }
@@ -201,6 +249,7 @@ export function indexRawChannels(
         nodeUuid,
         property: property ?? "weights",
         animatableId,
+        morphTargets,
         animatableType: property ? inferAnimatableType(property) : null,
         valueSize,
       });
@@ -299,6 +348,18 @@ function isVectorRawValue(
 }
 
 /**
+ * A channel is mapped when we can drive a rig target from it: a transform
+ * channel with a resolved animatable, or a weights channel with at least one
+ * resolved per-morph animatable.
+ */
+export function isChannelMapped(binding: RawChannelBinding): boolean {
+  if (binding.property === "weights") {
+    return Boolean(binding.morphTargets?.some((id) => id));
+  }
+  return Boolean(binding.animatableId);
+}
+
+/**
  * Sample every mapped channel of a clip at `timeSeconds` into render-store
  * writes (`setValues`). `namespace` is the render namespace the viewport uses.
  */
@@ -310,7 +371,24 @@ export function sampleFrameToRenderWrites(
 ): Array<{ id: string; namespace: string; value: RawValue }> {
   const writes: Array<{ id: string; namespace: string; value: RawValue }> = [];
   bindings.forEach((binding) => {
-    if (binding.clipId !== clipId || !binding.animatableId) {
+    if (binding.clipId !== clipId) {
+      return;
+    }
+    if (binding.property === "weights") {
+      const ids = binding.morphTargets;
+      if (!ids || ids.length === 0) {
+        return;
+      }
+      const sample = sampleRawTrackAtTime(binding.track, timeSeconds);
+      ids.forEach((id, index) => {
+        const value = sample[index];
+        if (id && typeof value === "number") {
+          writes.push({ id, namespace, value });
+        }
+      });
+      return;
+    }
+    if (!binding.animatableId) {
       return;
     }
     const sample = sampleRawTrackAtTime(binding.track, timeSeconds);
@@ -337,7 +415,29 @@ export function sampleFrameToInputValues(
 ): Record<string, number> {
   const values: Record<string, number> = {};
   bindings.forEach((binding) => {
-    if (binding.clipId !== clipId || !binding.animatableId) {
+    if (binding.clipId !== clipId) {
+      return;
+    }
+    if (binding.property === "weights") {
+      const ids = binding.morphTargets;
+      if (!ids || ids.length === 0) {
+        return;
+      }
+      const sample = sampleRawTrackAtTime(binding.track, timeSeconds);
+      ids.forEach((animatableId, index) => {
+        const value = sample[index];
+        if (!animatableId || typeof value !== "number") {
+          return;
+        }
+        // A morph is a scalar animatable: its componentId is the animatable id.
+        const inputId = resolveInputId(animatableId);
+        if (inputId) {
+          values[inputId] = value;
+        }
+      });
+      return;
+    }
+    if (!binding.animatableId) {
       return;
     }
     const sample = sampleRawTrackAtTime(binding.track, timeSeconds);
@@ -361,4 +461,31 @@ export function sampleFrameToInputValues(
     }
   });
   return values;
+}
+
+/**
+ * Collect the sorted, de-duplicated union of keyframe times across a clip's
+ * tracks — the native sample points for baking the clip into a timeline. Falls
+ * back to `[0]` when no track exposes times.
+ */
+export function collectClipFrameTimes(
+  bindings: RawChannelBinding[],
+  clipId: string,
+): number[] {
+  const times = new Set<number>();
+  bindings.forEach((binding) => {
+    if (binding.clipId !== clipId || !binding.track.times) {
+      return;
+    }
+    for (let i = 0; i < binding.track.times.length; i += 1) {
+      const t = binding.track.times[i];
+      if (typeof t === "number" && Number.isFinite(t)) {
+        times.add(t);
+      }
+    }
+  });
+  if (times.size === 0) {
+    return [0];
+  }
+  return Array.from(times).sort((a, b) => a - b);
 }

--- a/apps/vizij-authoring/src/poseExtraction/fbxFrameExtraction.ts
+++ b/apps/vizij-authoring/src/poseExtraction/fbxFrameExtraction.ts
@@ -1,0 +1,364 @@
+// `three` is declared as an untyped ambient module in this app
+// (`src/types/three.d.ts`), so we import its runtime helpers as values and model
+// only the minimal shapes we consume as local interfaces.
+import { Euler, Quaternion, PropertyBinding } from "three";
+import type { AnimatableValue, RawValue } from "@vizij/utils";
+import type { World } from "@vizij/render";
+
+/** Minimal shape of a THREE.KeyframeTrack we rely on. */
+export interface KeyframeTrackLike {
+  name: string;
+  getValueSize?: () => number;
+  createInterpolant: () => { evaluate: (time: number) => ArrayLike<number> };
+}
+
+/** Minimal shape of a THREE.AnimationClip we rely on. */
+export interface AnimationClipLike {
+  name?: string;
+  duration: number;
+  tracks: KeyframeTrackLike[];
+}
+
+/** Minimal shape of a THREE.Object3D we rely on. */
+export interface Object3DLike {
+  uuid: string;
+  name?: string;
+  getObjectByName: (name: string) => Object3DLike | undefined;
+}
+
+/**
+ * Pure, framework-free helpers for turning arbitrary (FBX-derived) THREE
+ * animation clips into pose snapshots. Nothing here touches React or a store —
+ * the orchestration hook (`useFbxPoseExtraction`) wires these into the render
+ * store (preview) and the pose-rig store (capture).
+ *
+ * The renderer imports each glTF node as a Vizij renderable keyed by the
+ * THREE `Object3D.uuid` (see `@vizij/render` `import-group.ts` / `import-mesh.ts`),
+ * exposing `features.translation` (vector3), `features.rotation` (euler), and
+ * `features.scale` (vector3). We resolve each clip track back to that renderable
+ * so a sampled frame can be written straight to the render store's animatables.
+ */
+
+export type RawChannelProperty =
+  | "translation"
+  | "rotation"
+  | "scale"
+  | "weights";
+
+/** THREE track property name -> Vizij renderable feature key. */
+const PROPERTY_TO_FEATURE: Record<string, RawChannelProperty> = {
+  position: "translation",
+  quaternion: "rotation",
+  scale: "scale",
+  morphTargetInfluences: "weights",
+};
+
+const VECTOR_AXES = ["x", "y", "z"] as const;
+type VectorAxis = (typeof VECTOR_AXES)[number];
+
+export interface RawChannelBinding {
+  /** Owning clip id (matches the id assigned by `summarizeClips`). */
+  clipId: string;
+  /** Index of the track within the clip. */
+  trackIndex: number;
+  /** Original THREE track name (e.g. `Head.quaternion`). */
+  trackName: string;
+  /** The THREE keyframe track, kept for sampling. */
+  track: KeyframeTrackLike;
+  /** Node name parsed from the track, if any. */
+  nodeName: string | null;
+  /** Resolved THREE Object3D uuid == Vizij World key. Null when unresolved. */
+  nodeUuid: string | null;
+  /** Mapped renderable feature. */
+  property: RawChannelProperty;
+  /** Vizij animatable id owning this channel. Null when unmapped (e.g. weights, bones). */
+  animatableId: string | null;
+  /** Animatable value type inferred from the feature. */
+  animatableType: AnimatableValue["type"] | null;
+  /** Numeric entries per keyframe in the source track. */
+  valueSize: number;
+}
+
+export interface RawClipSummary {
+  id: string;
+  name: string;
+  duration: number;
+  index: number;
+  trackCount: number;
+}
+
+/**
+ * Assign each clip a stable, human-facing id/name. Mirrors the fallback logic in
+ * `extract-animations.ts` `resolveClipId` so ids are consistent across surfaces.
+ */
+export function summarizeClips(clips: AnimationClipLike[]): RawClipSummary[] {
+  return clips.map((clip, index) => ({
+    id:
+      clip.name && clip.name.length > 0 ? clip.name : `fbx-animation-${index}`,
+    name:
+      clip.name && clip.name.length > 0 ? clip.name : `Animation ${index + 1}`,
+    duration: Number.isFinite(clip.duration) ? clip.duration : 0,
+    index,
+    trackCount: clip.tracks.length,
+  }));
+}
+
+function resolveClipId(clip: AnimationClipLike, index: number): string {
+  return clip.name && clip.name.length > 0
+    ? clip.name
+    : `fbx-animation-${index}`;
+}
+
+/** Read the animatable id for a renderable feature, tolerating the union of World types. */
+function readFeatureAnimatableId(
+  renderable: unknown,
+  featureKey: RawChannelProperty,
+): string | null {
+  if (!renderable || typeof renderable !== "object") {
+    return null;
+  }
+  const features = (renderable as { features?: Record<string, unknown> })
+    .features;
+  const feature = features?.[featureKey];
+  if (!feature || typeof feature !== "object") {
+    return null;
+  }
+  const { animated, value } = feature as {
+    animated?: boolean;
+    value?: unknown;
+  };
+  if (animated === true && typeof value === "string") {
+    return value;
+  }
+  return null;
+}
+
+function inferAnimatableType(
+  property: RawChannelProperty,
+): AnimatableValue["type"] | null {
+  switch (property) {
+    case "rotation":
+      return "euler";
+    case "translation":
+    case "scale":
+      return "vector3";
+    case "weights":
+      return "number";
+    default:
+      return null;
+  }
+}
+
+/**
+ * Resolve every track of every clip to a render-store animatable. Tracks whose
+ * target node isn't a Vizij renderable (e.g. skeleton bones, which the importer
+ * skips) or whose property has no animatable (morph weights) resolve with
+ * `animatableId: null` so callers can surface them as unmapped rather than
+ * silently dropping them.
+ */
+export function indexRawChannels(
+  clips: AnimationClipLike[],
+  scene: Object3DLike | null | undefined,
+  world: World,
+): RawChannelBinding[] {
+  const bindings: RawChannelBinding[] = [];
+  if (!scene) {
+    return bindings;
+  }
+  clips.forEach((clip, clipIndex) => {
+    const clipId = resolveClipId(clip, clipIndex);
+    clip.tracks.forEach((track, trackIndex) => {
+      const parsed = safeParseTrackName(track.name);
+      const propertyName = parsed?.propertyName;
+      const property = propertyName
+        ? PROPERTY_TO_FEATURE[propertyName]
+        : undefined;
+      const nodeName = parsed?.nodeName ?? null;
+
+      let nodeUuid: string | null = null;
+      let animatableId: string | null = null;
+      if (nodeName) {
+        const node = findSceneNode(scene, nodeName);
+        nodeUuid = node?.uuid ?? null;
+        if (nodeUuid && property && property !== "weights") {
+          animatableId = readFeatureAnimatableId(world[nodeUuid], property);
+        }
+      }
+
+      const valueSize =
+        typeof track.getValueSize === "function"
+          ? track.getValueSize()
+          : property === "rotation"
+            ? 4
+            : 3;
+
+      bindings.push({
+        clipId,
+        trackIndex,
+        trackName: track.name,
+        track,
+        nodeName,
+        nodeUuid,
+        property: property ?? "weights",
+        animatableId,
+        animatableType: property ? inferAnimatableType(property) : null,
+        valueSize,
+      });
+    });
+  });
+  return bindings;
+}
+
+function safeParseTrackName(
+  name: string,
+): { nodeName: string; propertyName: string } | null {
+  try {
+    const parsed = PropertyBinding.parseTrackName(name);
+    return {
+      nodeName: parsed.nodeName ?? "",
+      propertyName: parsed.propertyName ?? "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+function findSceneNode(
+  scene: Object3DLike,
+  nodeName: string,
+): Object3DLike | null {
+  try {
+    const node = PropertyBinding.findNode(scene, nodeName);
+    if (node) {
+      return node as Object3DLike;
+    }
+  } catch {
+    // fall through to name lookup
+  }
+  return scene.getObjectByName(nodeName) ?? null;
+}
+
+/**
+ * Sample one track at `timeSeconds` into a fixed-length numeric vector using
+ * THREE's own interpolant, which handles LINEAR/STEP/CUBICSPLINE and quaternion
+ * slerp correctly.
+ */
+export function sampleRawTrackAtTime(
+  track: KeyframeTrackLike,
+  timeSeconds: number,
+): number[] {
+  const interpolant = track.createInterpolant();
+  const result = interpolant.evaluate(timeSeconds);
+  return Array.from(result as ArrayLike<number>);
+}
+
+/**
+ * Convert a sampled channel to the `RawValue` shape expected by the target
+ * animatable. Rotations arrive as quaternions and are converted to Euler using
+ * the same order/up-axis the renderer imports with (`XYZ`, DEFAULT_UP=(0,0,1)).
+ * Returns `undefined` for unmapped channels (e.g. morph weights).
+ */
+export function channelSampleToRawValue(
+  binding: RawChannelBinding,
+  sample: number[],
+): RawValue | undefined {
+  switch (binding.property) {
+    case "translation":
+    case "scale":
+      return { x: sample[0] ?? 0, y: sample[1] ?? 0, z: sample[2] ?? 0 };
+    case "rotation": {
+      if (sample.length >= 4) {
+        const q = new Quaternion(
+          sample[0] ?? 0,
+          sample[1] ?? 0,
+          sample[2] ?? 0,
+          sample[3] ?? 1,
+        );
+        const euler = new Euler().setFromQuaternion(q, "XYZ");
+        return { x: euler.x, y: euler.y, z: euler.z };
+      }
+      // Rare: an already-euler rotation track.
+      return { x: sample[0] ?? 0, y: sample[1] ?? 0, z: sample[2] ?? 0 };
+    }
+    case "weights":
+    default:
+      return undefined;
+  }
+}
+
+function isVectorRawValue(
+  value: RawValue,
+): value is { x: number; y: number; z: number } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "x" in value &&
+    "y" in value &&
+    "z" in value
+  );
+}
+
+/**
+ * Sample every mapped channel of a clip at `timeSeconds` into render-store
+ * writes (`setValues`). `namespace` is the render namespace the viewport uses.
+ */
+export function sampleFrameToRenderWrites(
+  bindings: RawChannelBinding[],
+  clipId: string,
+  timeSeconds: number,
+  namespace: string,
+): Array<{ id: string; namespace: string; value: RawValue }> {
+  const writes: Array<{ id: string; namespace: string; value: RawValue }> = [];
+  bindings.forEach((binding) => {
+    if (binding.clipId !== clipId || !binding.animatableId) {
+      return;
+    }
+    const sample = sampleRawTrackAtTime(binding.track, timeSeconds);
+    const value = channelSampleToRawValue(binding, sample);
+    if (value !== undefined) {
+      writes.push({ id: binding.animatableId, namespace, value });
+    }
+  });
+  return writes;
+}
+
+/**
+ * Sample every mapped channel of a clip at `timeSeconds` into a StandardInput
+ * value map. `resolveInputId` maps an animatable component id
+ * (`<animatableId>:<axis>` for vectors/eulers, `<animatableId>` for scalars) to
+ * the standard-input id captured by the pose store. Unresolved components are
+ * skipped.
+ */
+export function sampleFrameToInputValues(
+  bindings: RawChannelBinding[],
+  clipId: string,
+  timeSeconds: number,
+  resolveInputId: (componentId: string) => string | null,
+): Record<string, number> {
+  const values: Record<string, number> = {};
+  bindings.forEach((binding) => {
+    if (binding.clipId !== clipId || !binding.animatableId) {
+      return;
+    }
+    const sample = sampleRawTrackAtTime(binding.track, timeSeconds);
+    const raw = channelSampleToRawValue(binding, sample);
+    if (raw === undefined) {
+      return;
+    }
+    if (isVectorRawValue(raw)) {
+      VECTOR_AXES.forEach((axis: VectorAxis) => {
+        const componentId = `${binding.animatableId}:${axis}`;
+        const inputId = resolveInputId(componentId);
+        if (inputId) {
+          values[inputId] = raw[axis];
+        }
+      });
+    } else if (typeof raw === "number") {
+      const inputId = resolveInputId(binding.animatableId);
+      if (inputId) {
+        values[inputId] = raw;
+      }
+    }
+  });
+  return values;
+}

--- a/apps/vizij-authoring/src/poseExtraction/index.ts
+++ b/apps/vizij-authoring/src/poseExtraction/index.ts
@@ -1,0 +1,17 @@
+export {
+  useFbxPoseExtraction,
+  type FbxPoseExtractionApi,
+  type UseFbxPoseExtractionArgs,
+} from "./useFbxPoseExtraction";
+export { PoseExtractionPanel } from "./components/PoseExtractionPanel";
+export {
+  indexRawChannels,
+  sampleRawTrackAtTime,
+  channelSampleToRawValue,
+  sampleFrameToRenderWrites,
+  sampleFrameToInputValues,
+  summarizeClips,
+  type RawChannelBinding,
+  type RawClipSummary,
+  type RawChannelProperty,
+} from "./fbxFrameExtraction";

--- a/apps/vizij-authoring/src/poseExtraction/index.ts
+++ b/apps/vizij-authoring/src/poseExtraction/index.ts
@@ -2,6 +2,7 @@ export {
   useFbxPoseExtraction,
   type FbxPoseExtractionApi,
   type UseFbxPoseExtractionArgs,
+  type BakeResult,
 } from "./useFbxPoseExtraction";
 export { PoseExtractionPanel } from "./components/PoseExtractionPanel";
 export {
@@ -10,6 +11,8 @@ export {
   channelSampleToRawValue,
   sampleFrameToRenderWrites,
   sampleFrameToInputValues,
+  collectClipFrameTimes,
+  isChannelMapped,
   summarizeClips,
   type RawChannelBinding,
   type RawClipSummary,

--- a/apps/vizij-authoring/src/poseExtraction/useFbxPoseExtraction.ts
+++ b/apps/vizij-authoring/src/poseExtraction/useFbxPoseExtraction.ts
@@ -5,9 +5,19 @@ import { useBindingAuthoring } from "../state/RigControllerProvider";
 import { usePoseRigStore, NEUTRAL_POSE_ID } from "../poseRig/store";
 import { PoseSnapshotService } from "../poseRig/services/poseSnapshotService";
 import { resolveDeterministicPoseId } from "../poseRig/utils";
+import { useAnimationStore } from "../state/animationStore";
+import {
+  ANIMATION_CLIP_IR_SCHEMA_VERSION,
+  AUTHORED_TIMELINE_CLIP_ID,
+  type AnimationClipIR,
+  type AnimationKeyframeIR,
+  type AnimationTrackIR,
+} from "../types/animationClipIr";
 import { DEFAULT_NAMESPACE } from "../utils/constants";
 import {
+  collectClipFrameTimes,
   indexRawChannels,
+  isChannelMapped,
   sampleFrameToInputValues,
   sampleFrameToRenderWrites,
   summarizeClips,
@@ -16,6 +26,11 @@ import {
   type RawChannelBinding,
   type RawClipSummary,
 } from "./fbxFrameExtraction";
+
+export interface BakeResult {
+  inputCount: number;
+  keyframeCount: number;
+}
 
 export interface FbxPoseExtractionApi {
   /** True when raw (FBX-derived) clips are present to extract from. */
@@ -36,6 +51,12 @@ export interface FbxPoseExtractionApi {
     name: string;
     group?: string | null;
   }) => string | null;
+  /**
+   * Bake the whole active clip into the authored animation timeline (sampling
+   * every native keyframe into per-input tracks). Returns a summary, or null if
+   * nothing could be baked.
+   */
+  bakeActiveClip: () => BakeResult | null;
   /** Number of channels in the active clip that map to a rig input. */
   channelCount: number;
   /** Active-clip channels that couldn't be mapped (bones, morph weights, …). */
@@ -114,11 +135,11 @@ export function useFbxPoseExtraction(
     [bindings, activeClipId],
   );
   const mappedChannelCount = useMemo(
-    () => activeBindings.filter((binding) => binding.animatableId).length,
+    () => activeBindings.filter(isChannelMapped).length,
     [activeBindings],
   );
   const unmappedChannels = useMemo(
-    () => activeBindings.filter((binding) => !binding.animatableId),
+    () => activeBindings.filter((binding) => !isChannelMapped(binding)),
     [activeBindings],
   );
 
@@ -132,6 +153,15 @@ export function useFbxPoseExtraction(
       }
     });
     return (componentId: string): string | null => map.get(componentId) ?? null;
+  }, [managedStandardInputs]);
+
+  // standard-input id -> its typed path, so baked tracks bind to the right input.
+  const inputPathById = useMemo(() => {
+    const map = new Map<string, string>();
+    managedStandardInputs.forEach((entry) => {
+      map.set(entry.input.id, entry.input.path);
+    });
+    return map;
   }, [managedStandardInputs]);
 
   const seek = useCallback(
@@ -279,6 +309,67 @@ export function useFbxPoseExtraction(
     ],
   );
 
+  const bakeActiveClip = useCallback((): BakeResult | null => {
+    if (!activeClipId || !activeClip) {
+      return null;
+    }
+    setIsPlaying(false);
+    const times = collectClipFrameTimes(bindings, activeClipId);
+    const keyframesByInput = new Map<string, AnimationKeyframeIR[]>();
+    times.forEach((t, frameIndex) => {
+      const values = sampleFrameToInputValues(
+        bindings,
+        activeClipId,
+        t,
+        resolveInputId,
+      );
+      Object.entries(values).forEach(([inputId, value]) => {
+        let keyframes = keyframesByInput.get(inputId);
+        if (!keyframes) {
+          keyframes = [];
+          keyframesByInput.set(inputId, keyframes);
+        }
+        keyframes.push({
+          id: `${inputId}-${frameIndex}`,
+          time: t,
+          value,
+          interpolation: "linear",
+        });
+      });
+    });
+
+    if (keyframesByInput.size === 0) {
+      return { inputCount: 0, keyframeCount: 0 };
+    }
+
+    let keyframeCount = 0;
+    let trackIndex = 0;
+    const tracks: AnimationTrackIR[] = [];
+    keyframesByInput.forEach((keyframes, inputId) => {
+      keyframeCount += keyframes.length;
+      tracks.push({
+        id: `fbx-bake-${trackIndex}`,
+        variableId: inputId,
+        channel: inputPathById.get(inputId) ?? inputId,
+        interpolation: "linear",
+        keyframes,
+      });
+      trackIndex += 1;
+    });
+
+    const lastTime = times[times.length - 1] ?? 0;
+    const clip: AnimationClipIR = {
+      schemaVersion: ANIMATION_CLIP_IR_SCHEMA_VERSION,
+      id: AUTHORED_TIMELINE_CLIP_ID,
+      name: activeClip.name,
+      duration: activeClip.duration > 0 ? activeClip.duration : lastTime,
+      tracks,
+    };
+
+    useAnimationStore.getState().importClipIr(clip);
+    return { inputCount: keyframesByInput.size, keyframeCount };
+  }, [activeClip, activeClipId, bindings, inputPathById, resolveInputId]);
+
   return {
     isAvailable: clips.length > 0,
     clips,
@@ -290,6 +381,7 @@ export function useFbxPoseExtraction(
     seek,
     togglePlay,
     captureFrame,
+    bakeActiveClip,
     channelCount: mappedChannelCount,
     unmappedChannels,
   };

--- a/apps/vizij-authoring/src/poseExtraction/useFbxPoseExtraction.ts
+++ b/apps/vizij-authoring/src/poseExtraction/useFbxPoseExtraction.ts
@@ -1,0 +1,296 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { AnimatableValue } from "@vizij/utils";
+import { useVizijStore, type World } from "@vizij/render";
+import { useBindingAuthoring } from "../state/RigControllerProvider";
+import { usePoseRigStore, NEUTRAL_POSE_ID } from "../poseRig/store";
+import { PoseSnapshotService } from "../poseRig/services/poseSnapshotService";
+import { resolveDeterministicPoseId } from "../poseRig/utils";
+import { DEFAULT_NAMESPACE } from "../utils/constants";
+import {
+  indexRawChannels,
+  sampleFrameToInputValues,
+  sampleFrameToRenderWrites,
+  summarizeClips,
+  type AnimationClipLike,
+  type Object3DLike,
+  type RawChannelBinding,
+  type RawClipSummary,
+} from "./fbxFrameExtraction";
+
+export interface FbxPoseExtractionApi {
+  /** True when raw (FBX-derived) clips are present to extract from. */
+  isAvailable: boolean;
+  clips: RawClipSummary[];
+  activeClipId: string | null;
+  activeClip: RawClipSummary | null;
+  time: number;
+  /** True while the active clip is playing back in the viewport. */
+  isPlaying: boolean;
+  setActiveClip: (clipId: string) => void;
+  /** Seek the active clip to `t` seconds and preview the frame in the viewport. */
+  seek: (t: number) => void;
+  /** Start/stop looped playback of the active clip in the viewport. */
+  togglePlay: () => void;
+  /** Capture the current frame as a pose in the pose-rig store. Returns the pose id. */
+  captureFrame: (opts: {
+    name: string;
+    group?: string | null;
+  }) => string | null;
+  /** Number of channels in the active clip that map to a rig input. */
+  channelCount: number;
+  /** Active-clip channels that couldn't be mapped (bones, morph weights, …). */
+  unmappedChannels: RawChannelBinding[];
+}
+
+export interface UseFbxPoseExtractionArgs {
+  world: World;
+  animatables: Record<string, AnimatableValue>;
+  rawClips: AnimationClipLike[];
+  scene: Object3DLike | null;
+  /** Render namespace the viewport uses (defaults to the app default). */
+  namespace?: string;
+}
+
+/**
+ * Orchestrates scrub-and-capture pose extraction from raw FBX-derived clips.
+ *
+ * The renderer auto-generates a StandardInput per animatable component on load
+ * (see `useRigController` `rebuildAutoInputs`), and those managed inputs carry a
+ * `componentId` matching the `<animatableId>:<axis>` ids our sampler emits. So
+ * capture needs no bespoke binding — it maps sampled components onto the
+ * existing auto-inputs and reuses `PoseSnapshotService.capture` unchanged.
+ */
+export function useFbxPoseExtraction(
+  args: UseFbxPoseExtractionArgs,
+): FbxPoseExtractionApi {
+  const { world, rawClips, scene, namespace = DEFAULT_NAMESPACE } = args;
+
+  const setValues = useVizijStore((state) => state.setValues);
+  const managedStandardInputs = useBindingAuthoring(
+    (state) => state.managedStandardInputs,
+  );
+  const neutralInputs = usePoseRigStore((state) => state.neutralInputs);
+  const poses = usePoseRigStore((state) => state.poses);
+  const addPose = usePoseRigStore((state) => state.addPose);
+  const createPoseGroup = usePoseRigStore((state) => state.createPoseGroup);
+  const addPoseToGroup = usePoseRigStore((state) => state.addPoseToGroup);
+
+  const clips = useMemo(() => summarizeClips(rawClips), [rawClips]);
+  const bindings = useMemo(
+    () => indexRawChannels(rawClips, scene, world),
+    [rawClips, scene, world],
+  );
+
+  const [activeClipId, setActiveClipId] = useState<string | null>(null);
+  const [time, setTime] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const timeRef = useRef(time);
+  useEffect(() => {
+    timeRef.current = time;
+  }, [time]);
+
+  // Default the active clip to the first available one and reset when clips change.
+  useEffect(() => {
+    if (clips.length === 0) {
+      if (activeClipId !== null) {
+        setActiveClipId(null);
+        setTime(0);
+      }
+      return;
+    }
+    if (!activeClipId || !clips.some((clip) => clip.id === activeClipId)) {
+      setActiveClipId(clips[0]!.id);
+      setTime(0);
+    }
+  }, [clips, activeClipId]);
+
+  const activeClip = useMemo(
+    () => clips.find((clip) => clip.id === activeClipId) ?? null,
+    [clips, activeClipId],
+  );
+
+  const activeBindings = useMemo(
+    () => bindings.filter((binding) => binding.clipId === activeClipId),
+    [bindings, activeClipId],
+  );
+  const mappedChannelCount = useMemo(
+    () => activeBindings.filter((binding) => binding.animatableId).length,
+    [activeBindings],
+  );
+  const unmappedChannels = useMemo(
+    () => activeBindings.filter((binding) => !binding.animatableId),
+    [activeBindings],
+  );
+
+  // componentId (`<animatableId>:<axis>`) -> standard input id, from auto-inputs.
+  const resolveInputId = useMemo(() => {
+    const map = new Map<string, string>();
+    managedStandardInputs.forEach((entry) => {
+      const componentId = entry.metadata?.componentId;
+      if (componentId) {
+        map.set(componentId, entry.input.id);
+      }
+    });
+    return (componentId: string): string | null => map.get(componentId) ?? null;
+  }, [managedStandardInputs]);
+
+  const seek = useCallback(
+    (nextTime: number) => {
+      // Manual scrubbing takes over from playback.
+      setIsPlaying(false);
+      const clamped = activeClip
+        ? Math.max(0, Math.min(nextTime, activeClip.duration))
+        : Math.max(0, nextTime);
+      setTime(clamped);
+      if (!activeClipId) {
+        return;
+      }
+      const writes = sampleFrameToRenderWrites(
+        bindings,
+        activeClipId,
+        clamped,
+        namespace,
+      );
+      if (writes.length > 0) {
+        setValues(writes);
+      }
+    },
+    [activeClip, activeClipId, bindings, namespace, setValues],
+  );
+
+  const setActiveClip = useCallback(
+    (clipId: string) => {
+      setIsPlaying(false);
+      setActiveClipId(clipId);
+      setTime(0);
+      const writes = sampleFrameToRenderWrites(bindings, clipId, 0, namespace);
+      if (writes.length > 0) {
+        setValues(writes);
+      }
+    },
+    [bindings, namespace, setValues],
+  );
+
+  const togglePlay = useCallback(() => {
+    if (!activeClipId || (activeClip?.duration ?? 0) <= 0) {
+      return;
+    }
+    setIsPlaying((previous) => !previous);
+  }, [activeClipId, activeClip]);
+
+  // Playback loop: advance `time` each animation frame and preview it, looping
+  // at the clip's duration. Runs only while `isPlaying`.
+  useEffect(() => {
+    if (!isPlaying || !activeClipId) {
+      return;
+    }
+    const duration = activeClip?.duration ?? 0;
+    if (duration <= 0) {
+      return;
+    }
+    let raf = 0;
+    let lastTs: number | null = null;
+    const tick = (ts: number) => {
+      if (lastTs === null) {
+        lastTs = ts;
+      }
+      const dt = (ts - lastTs) / 1000;
+      lastTs = ts;
+      let next = timeRef.current + dt;
+      if (next >= duration) {
+        next = next % duration;
+      }
+      timeRef.current = next;
+      setTime(next);
+      const writes = sampleFrameToRenderWrites(
+        bindings,
+        activeClipId,
+        next,
+        namespace,
+      );
+      if (writes.length > 0) {
+        setValues(writes);
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [isPlaying, activeClipId, activeClip, bindings, namespace, setValues]);
+
+  // Stop playback if clips disappear (e.g. a new asset is loaded).
+  useEffect(() => {
+    if (clips.length === 0 && isPlaying) {
+      setIsPlaying(false);
+    }
+  }, [clips, isPlaying]);
+
+  const captureFrame = useCallback(
+    ({
+      name,
+      group,
+    }: {
+      name: string;
+      group?: string | null;
+    }): string | null => {
+      if (!activeClipId) {
+        return null;
+      }
+      setIsPlaying(false);
+      const sampledInputValues = sampleFrameToInputValues(
+        bindings,
+        activeClipId,
+        time,
+        resolveInputId,
+      );
+      const pose = PoseSnapshotService.capture(
+        sampledInputValues,
+        neutralInputs,
+        {
+          name,
+          group: group ?? null,
+        },
+      );
+      // Finalize the id against existing poses so repeated captures don't collide
+      // and the returned id stays valid for later rename.
+      const finalId = resolveDeterministicPoseId({
+        existingIds: poses.map((entry) => entry.id),
+        preferredId: pose.id,
+        name: pose.name,
+        group: pose.group,
+        reservedIds: [NEUTRAL_POSE_ID],
+      });
+      addPose({ ...pose, id: finalId });
+      if (group) {
+        createPoseGroup(group);
+        addPoseToGroup(finalId, group);
+      }
+      return finalId;
+    },
+    [
+      activeClipId,
+      addPose,
+      addPoseToGroup,
+      bindings,
+      createPoseGroup,
+      neutralInputs,
+      poses,
+      resolveInputId,
+      time,
+    ],
+  );
+
+  return {
+    isAvailable: clips.length > 0,
+    clips,
+    activeClipId,
+    activeClip,
+    time,
+    isPlaying,
+    setActiveClip,
+    seek,
+    togglePlay,
+    captureFrame,
+    channelCount: mappedChannelCount,
+    unmappedChannels,
+  };
+}

--- a/apps/vizij-authoring/src/state/editFocusPanels.ts
+++ b/apps/vizij-authoring/src/state/editFocusPanels.ts
@@ -18,6 +18,7 @@ export function createEditFocusPanelVisibility(
     debug: base.debug.isVisible,
     animation: base.animation.isVisible,
     motiongraph: base.motiongraph.isVisible,
+    poseExtraction: base.poseExtraction.isVisible,
     toolbar: base.toolbar.isVisible,
     referenceFace: base.referenceFace.isVisible,
     materials: base.materials.isVisible,
@@ -33,6 +34,7 @@ export function createEditFocusPanelVisibility(
     nextVisibility.motiongraphPalette = false;
     nextVisibility.animation = true;
     nextVisibility.motiongraph = false;
+    nextVisibility.poseExtraction = false;
     nextVisibility.referenceFace = false;
     return nextVisibility;
   }
@@ -46,6 +48,7 @@ export function createEditFocusPanelVisibility(
     nextVisibility.motiongraphPalette = true;
     nextVisibility.animation = false;
     nextVisibility.motiongraph = true;
+    nextVisibility.poseExtraction = false;
     nextVisibility.referenceFace = false;
     return nextVisibility;
   }
@@ -53,6 +56,7 @@ export function createEditFocusPanelVisibility(
   if (focus === "reference-face") {
     nextVisibility.animation = false;
     nextVisibility.motiongraph = false;
+    nextVisibility.poseExtraction = false;
     nextVisibility.referenceFace = true;
     nextVisibility.motiongraphPalette = false;
     return nextVisibility;

--- a/apps/vizij-authoring/src/state/workspaceStore.ts
+++ b/apps/vizij-authoring/src/state/workspaceStore.ts
@@ -20,6 +20,7 @@ interface WorkspaceState {
     // Bottom
     animation: PanelState;
     motiongraph: PanelState;
+    poseExtraction: PanelState;
     // Center Top
     toolbar: PanelState;
     referenceFace: PanelState;
@@ -39,6 +40,7 @@ const EXCLUSIVE_CENTER_PANEL_IDS = [
   "animation",
   "motiongraph",
   "referenceFace",
+  "poseExtraction",
 ] as const satisfies readonly WorkspacePanelId[];
 const EXCLUSIVE_CENTER_PANEL_ID_SET: ReadonlySet<WorkspacePanelId> = new Set(
   EXCLUSIVE_CENTER_PANEL_IDS,
@@ -87,6 +89,7 @@ export function createInitialWorkspacePanels(): WorkspacePanels {
     debug: { isVisible: false, order: 2 },
     animation: { isVisible: false, order: 0 },
     motiongraph: { isVisible: false, order: 1 },
+    poseExtraction: { isVisible: false, order: 2 },
     toolbar: { isVisible: true, order: 0 },
     referenceFace: { isVisible: false, order: 0 },
     materials: { isVisible: true, order: 3 },

--- a/packages/@vizij/render/src/functions/load-gltf.ts
+++ b/packages/@vizij/render/src/functions/load-gltf.ts
@@ -208,6 +208,12 @@ export type LoadedVizijAsset = {
   bundle: VizijBundleExtension | null;
   animations: VizijAnimationClipData[];
   scene: Group;
+  /**
+   * Raw THREE.AnimationClip[] as parsed from the glTF/GLB, before any Vizij
+   * metadata correlation. Surfaced so callers can read arbitrary FBX-derived
+   * clips (which `extractVizijAnimations` drops when nodes lack RobotData).
+   */
+  rawClips: AnimationClip[];
 };
 
 function parseScene(
@@ -241,7 +247,14 @@ function parseScene(
   // } else {
   //   console.info("[vizij-render] No bundle extracted during GLTF load.");
   // }
-  return { world, animatables, bundle, animations, scene };
+  return {
+    world,
+    animatables,
+    bundle,
+    animations,
+    scene,
+    rawClips: clips ?? [],
+  };
 }
 
 function createTrackedGLTFLoader() {


### PR DESCRIPTION
## Summary

Adds a **Pose Extraction** tool to `vizij-authoring` for pulling poses out of a GLB that has arbitrary FBX-derived animation clips lumped into it (node-transform / morph animations with **no** Vizij/Robot metadata). You load such a GLB, pick a clip, **scrub or play** it with live viewport preview, and **capture individual frames as named poses** into the existing pose-rig store — so they save/export through the current pose config + GLB bundle pipeline unchanged.

## What changed

- **`@vizij/render`** — surface the raw `THREE.AnimationClip[]` on `LoadedVizijAsset` (`load-gltf.ts`). They were parsed then discarded; `extractVizijAnimations` returns nothing for nodes without `RobotData`, so raw FBX clips were invisible to callers.
- **`useVizijAssetLoader`** — capture `rawClips` / imported animations / scene and expose them.
- **`poseExtraction/`** (new, self-contained subtree):
  - `fbxFrameExtraction.ts` — pure, unit-tested sampling: `indexRawChannels` (track → renderable animatable), `sampleRawTrackAtTime` (THREE interpolant, incl. quaternion slerp), quaternion→euler in the renderer's `XYZ`/up convention, and frame→render-writes / frame→input-values.
  - `useFbxPoseExtraction.ts` — scrub, **play/pause loop** (rAF), and capture via `PoseSnapshotService` onto the auto-generated standard inputs (the bridge that lets raw channels round-trip through the existing pose pipeline).
  - `PoseExtractionPanel.tsx` — docked panel: clip picker, scrubber + play button, group field, capture button, and an inline-editable captured-poses list.
- **Registration/mount** — `workspaceStore`, `editFocusPanels`, `AppMenuBar` (View → Pose Extraction), and `App.tsx`; auto-opens when a raw-FBX GLB loads.

## ⚠️ Known limitation — does not work well yet

**We're still figuring out where the animations were actually saved in the source Blender file.** The sample "Blender Export" GLBs' clips are mostly **single-channel** (morph shape keys / sparse transforms), and many channels resolve to **morph weights or skeleton bones that the importer doesn't expose as animatables**, so they're flagged as "unmapped" and skipped on capture. The plumbing works end-to-end for **transform clips** (e.g. `Face_Tran_C` captures translation targets into the pose store, verified live), but meaningful coverage depends on how the Blender scene authored/exported its animation data. Treat this as WIP until we've confirmed the source-of-truth for the animations in Blender.

## Test plan

- `pnpm --filter vizij-authoring test` — 11 new unit tests for the sampling service (linear/step interp, quaternion→euler parity, channel indexing, input mapping).
- Typecheck + lint clean (requires `pnpm build:packages` so `tsc` resolves `@vizij/*`).
- Manual: load **Quori/Toasty Blender Export** preset → Pose Extraction panel auto-opens → scrub/play a clip → **Capture frame** → pose appears in Authoring → Poses/Pose Groups with sampled targets; inline rename works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)