### PR TITLE
feat(vizij-authoring): import Blender morph-weight animation + bake clips to timeline

### DIFF
--- a/apps/vizij-authoring/src/poseExtraction/components/PoseExtractionPanel.tsx
+++ b/apps/vizij-authoring/src/poseExtraction/components/PoseExtractionPanel.tsx
@@ -1,5 +1,13 @@
 import { useEffect, useMemo, useState, type ChangeEvent } from "react";
-import { Camera, Film, Trash2, AlertTriangle, Play, Pause } from "lucide-react";
+import {
+  Camera,
+  Film,
+  Trash2,
+  AlertTriangle,
+  Play,
+  Pause,
+  Clapperboard,
+} from "lucide-react";
 import { Panel } from "../../components/ui/Panel";
 import { Button } from "../../components/ui/Button";
 import { Input } from "../../components/ui/Input";
@@ -54,6 +62,7 @@ export function PoseExtractionPanel({
     seek,
     togglePlay,
     captureFrame,
+    bakeActiveClip,
     channelCount,
     unmappedChannels,
   } = api;
@@ -64,12 +73,14 @@ export function PoseExtractionPanel({
   const [captured, setCaptured] = useState<CapturedFrame[]>([]);
   const [group, setGroup] = useState("");
   const [poseName, setPoseName] = useState("");
+  const [bakeStatus, setBakeStatus] = useState<string | null>(null);
 
   // Default the group to `fbx/<clip>` whenever the active clip changes.
   useEffect(() => {
     if (activeClip) {
       setGroup(`fbx/${sanitizeGroupSegment(activeClip.name)}`);
     }
+    setBakeStatus(null);
   }, [activeClipId, activeClip]);
 
   const defaultPoseName = useMemo(() => {
@@ -102,6 +113,21 @@ export function PoseExtractionPanel({
       { poseId, name, time, clipId: activeClipId ?? "" },
     ]);
     setPoseName("");
+  };
+
+  const handleBake = () => {
+    const result = bakeActiveClip();
+    if (!result) {
+      setBakeStatus(null);
+      return;
+    }
+    if (result.inputCount === 0) {
+      setBakeStatus("No mappable channels to bake.");
+      return;
+    }
+    setBakeStatus(
+      `Baked ${result.inputCount} input${result.inputCount === 1 ? "" : "s"} · ${result.keyframeCount} keyframe${result.keyframeCount === 1 ? "" : "s"} to the timeline.`,
+    );
   };
 
   const handleRename = (poseId: string, nextName: string) => {
@@ -200,7 +226,7 @@ export function PoseExtractionPanel({
             <span>
               {unmappedChannels.length} channel
               {unmappedChannels.length === 1 ? "" : "s"} couldn&apos;t be mapped
-              to a rig input (bones or morph weights) and will be skipped on
+              to a rig input (e.g. skeleton bones) and will be skipped on
               capture.
             </span>
           </div>
@@ -237,6 +263,21 @@ export function PoseExtractionPanel({
             >
               <Camera className="mr-1.5 h-3.5 w-3.5" />
               Capture frame
+            </Button>
+          </div>
+          <div className="mt-1 flex items-center justify-between gap-2 border-t border-border-default/60 pt-2">
+            <span className="text-[11px] text-text-muted">
+              {bakeStatus ?? "Bake the whole clip into the animation timeline."}
+            </span>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={handleBake}
+              disabled={!activeClipId || channelCount === 0}
+              title="Sample every keyframe of this clip into the animation timeline"
+            >
+              <Clapperboard className="mr-1.5 h-3.5 w-3.5" />
+              Bake clip → timeline
             </Button>
           </div>
         </div>

--- a/apps/vizij-authoring/src/poseExtraction/fbxFrameExtraction.test.ts
+++ b/apps/vizij-authoring/src/poseExtraction/fbxFrameExtraction.test.ts
@@ -3,6 +3,8 @@ import {
   AnimationClip,
   Euler,
   Group,
+  Mesh,
+  NumberKeyframeTrack,
   Object3D,
   Quaternion,
   QuaternionKeyframeTrack,
@@ -11,7 +13,9 @@ import {
 import type { World } from "@vizij/render";
 import {
   channelSampleToRawValue,
+  collectClipFrameTimes,
   indexRawChannels,
+  isChannelMapped,
   sampleFrameToInputValues,
   sampleFrameToRenderWrites,
   sampleRawTrackAtTime,
@@ -42,6 +46,41 @@ function buildFixture() {
   } as unknown as World;
 
   return { node, scene, world };
+}
+
+// A mesh with morph targets, mirroring how `import-geometry.ts` records
+// `Shape.morphTargets` (ordered featureKeys) + per-morph number features.
+function buildMorphFixture() {
+  const mesh = new Mesh();
+  mesh.name = "Mouth";
+  mesh.morphTargetDictionary = { ltsneer: 0, jawud: 1, sidewide: 2 };
+  mesh.morphTargetInfluences = [0, 0, 0];
+  const scene = new Group();
+  scene.add(mesh);
+
+  const world = {
+    [mesh.uuid]: {
+      id: mesh.uuid,
+      name: "Mouth",
+      type: "shape",
+      morphTargets: ["ltsneer", "jawud", "sidewide"],
+      features: {
+        translation: { animated: true, value: "anim-translation" },
+        ltsneer: { animated: true, value: "anim-m0" },
+        jawud: { animated: true, value: "anim-m1" },
+        sidewide: { animated: true, value: "anim-m2" },
+      },
+    },
+  } as unknown as World;
+
+  // Flat weights track: 3 morphs × 2 keyframes (t=0 all zero, t=1 ramp).
+  const track = new NumberKeyframeTrack(
+    "Mouth.morphTargetInfluences",
+    [0, 1],
+    [0, 0, 0, 1, 0.5, 0.25],
+  );
+  const clip = new AnimationClip("smile", 1, [track]);
+  return { scene, world, clip };
 }
 
 describe("sampleRawTrackAtTime", () => {
@@ -211,5 +250,54 @@ describe("summarizeClips", () => {
     const [a, b] = summarizeClips([named, unnamed]);
     expect(a).toMatchObject({ id: "wave", name: "wave", duration: 2 });
     expect(b).toMatchObject({ id: "fbx-animation-1", name: "Animation 2" });
+  });
+});
+
+describe("morph weights", () => {
+  it("indexes a weights channel to the mesh's ordered per-morph animatables", () => {
+    const { scene, world, clip } = buildMorphFixture();
+    const [binding] = indexRawChannels([clip], scene, world);
+    expect(binding.property).toBe("weights");
+    expect(binding.animatableId).toBeNull();
+    expect(binding.morphTargets).toEqual(["anim-m0", "anim-m1", "anim-m2"]);
+    expect(isChannelMapped(binding)).toBe(true);
+  });
+
+  it("splits the flat weights sample into per-morph render writes", () => {
+    const { scene, world, clip } = buildMorphFixture();
+    const bindings = indexRawChannels([clip], scene, world);
+    const writes = sampleFrameToRenderWrites(bindings, "smile", 0.5, "default");
+    expect(writes).toEqual([
+      { id: "anim-m0", namespace: "default", value: 0.5 },
+      { id: "anim-m1", namespace: "default", value: 0.25 },
+      { id: "anim-m2", namespace: "default", value: 0.125 },
+    ]);
+  });
+
+  it("maps each morph to its scalar input id", () => {
+    const { scene, world, clip } = buildMorphFixture();
+    const bindings = indexRawChannels([clip], scene, world);
+    const resolveInputId = (componentId: string): string | null =>
+      ({ "anim-m0": "in0", "anim-m1": "in1", "anim-m2": "in2" })[componentId] ??
+      null;
+    const values = sampleFrameToInputValues(
+      bindings,
+      "smile",
+      1,
+      resolveInputId,
+    );
+    expect(values).toEqual({ in0: 1, in1: 0.5, in2: 0.25 });
+  });
+});
+
+describe("collectClipFrameTimes", () => {
+  it("returns the sorted union of track keyframe times", () => {
+    const { scene, world, clip } = buildMorphFixture();
+    const bindings = indexRawChannels([clip], scene, world);
+    expect(collectClipFrameTimes(bindings, "smile")).toEqual([0, 1]);
+  });
+
+  it("falls back to [0] when no times are present", () => {
+    expect(collectClipFrameTimes([], "missing")).toEqual([0]);
   });
 });

--- a/apps/vizij-authoring/src/poseExtraction/fbxFrameExtraction.ts
+++ b/apps/vizij-authoring/src/poseExtraction/fbxFrameExtraction.ts
@@ -10,6 +10,8 @@ export interface KeyframeTrackLike {
   name: string;
   getValueSize?: () => number;
   createInterpolant: () => { evaluate: (time: number) => ArrayLike<number> };
+  /** Keyframe times (seconds); used to bake a clip at its native keyframes. */
+  times?: ArrayLike<number>;
 }
 
 /** Minimal shape of a THREE.AnimationClip we rely on. */
@@ -71,8 +73,14 @@ export interface RawChannelBinding {
   nodeUuid: string | null;
   /** Mapped renderable feature. */
   property: RawChannelProperty;
-  /** Vizij animatable id owning this channel. Null when unmapped (e.g. weights, bones). */
+  /** Vizij animatable id owning this channel. Null for weights/bones (see morphTargets). */
   animatableId: string | null;
+  /**
+   * For `weights` channels: the per-morph scalar animatable ids in glTF morph
+   * index order (index j corresponds to sample slot j). `null` at a slot means
+   * that morph had no resolvable animatable. Undefined for non-weights channels.
+   */
+  morphTargets?: Array<string | null>;
   /** Animatable value type inferred from the feature. */
   animatableType: AnimatableValue["type"] | null;
   /** Numeric entries per keyframe in the source track. */
@@ -133,6 +141,42 @@ function readFeatureAnimatableId(
   return null;
 }
 
+/**
+ * Read a mesh renderable's per-morph scalar animatable ids in morph-target
+ * order. The renderer stores `Shape.morphTargets` as featureKeys in
+ * `morphTargetDictionary` (i.e. glTF morph index) order, and each featureKey
+ * maps to an `AnimatableNumber` via `features[featureKey].value` — so slot j
+ * here lines up with slot j of a flat glTF `weights` sampler track. Slots whose
+ * feature can't be resolved are kept as `null` to preserve index alignment.
+ */
+function readMorphAnimatableIds(renderable: unknown): Array<string | null> {
+  if (!renderable || typeof renderable !== "object") {
+    return [];
+  }
+  const record = renderable as {
+    morphTargets?: unknown;
+    features?: Record<string, unknown>;
+  };
+  const keys = Array.isArray(record.morphTargets)
+    ? (record.morphTargets as unknown[])
+    : [];
+  const features = record.features ?? {};
+  return keys.map((key) => {
+    if (typeof key !== "string") {
+      return null;
+    }
+    const feature = features[key];
+    if (!feature || typeof feature !== "object") {
+      return null;
+    }
+    const { animated, value } = feature as {
+      animated?: boolean;
+      value?: unknown;
+    };
+    return animated === true && typeof value === "string" ? value : null;
+  });
+}
+
 function inferAnimatableType(
   property: RawChannelProperty,
 ): AnimatableValue["type"] | null {
@@ -150,11 +194,12 @@ function inferAnimatableType(
 }
 
 /**
- * Resolve every track of every clip to a render-store animatable. Tracks whose
+ * Resolve every track of every clip to render targets. Transform channels
+ * resolve to a single animatable (`animatableId`); `weights` channels resolve to
+ * the target mesh's ordered per-morph animatables (`morphTargets`). Tracks whose
  * target node isn't a Vizij renderable (e.g. skeleton bones, which the importer
- * skips) or whose property has no animatable (morph weights) resolve with
- * `animatableId: null` so callers can surface them as unmapped rather than
- * silently dropping them.
+ * skips) resolve unmapped so callers can surface them rather than silently
+ * dropping them.
  */
 export function indexRawChannels(
   clips: AnimationClipLike[],
@@ -177,10 +222,13 @@ export function indexRawChannels(
 
       let nodeUuid: string | null = null;
       let animatableId: string | null = null;
+      let morphTargets: Array<string | null> | undefined;
       if (nodeName) {
         const node = findSceneNode(scene, nodeName);
         nodeUuid = node?.uuid ?? null;
-        if (nodeUuid && property && property !== "weights") {
+        if (nodeUuid && property === "weights") {
+          morphTargets = readMorphAnimatableIds(world[nodeUuid]);
+        } else if (nodeUuid && property) {
           animatableId = readFeatureAnimatableId(world[nodeUuid], property);
         }
       }
@@ -201,6 +249,7 @@ export function indexRawChannels(
         nodeUuid,
         property: property ?? "weights",
         animatableId,
+        morphTargets,
         animatableType: property ? inferAnimatableType(property) : null,
         valueSize,
       });
@@ -299,6 +348,18 @@ function isVectorRawValue(
 }
 
 /**
+ * A channel is mapped when we can drive a rig target from it: a transform
+ * channel with a resolved animatable, or a weights channel with at least one
+ * resolved per-morph animatable.
+ */
+export function isChannelMapped(binding: RawChannelBinding): boolean {
+  if (binding.property === "weights") {
+    return Boolean(binding.morphTargets?.some((id) => id));
+  }
+  return Boolean(binding.animatableId);
+}
+
+/**
  * Sample every mapped channel of a clip at `timeSeconds` into render-store
  * writes (`setValues`). `namespace` is the render namespace the viewport uses.
  */
@@ -310,7 +371,24 @@ export function sampleFrameToRenderWrites(
 ): Array<{ id: string; namespace: string; value: RawValue }> {
   const writes: Array<{ id: string; namespace: string; value: RawValue }> = [];
   bindings.forEach((binding) => {
-    if (binding.clipId !== clipId || !binding.animatableId) {
+    if (binding.clipId !== clipId) {
+      return;
+    }
+    if (binding.property === "weights") {
+      const ids = binding.morphTargets;
+      if (!ids || ids.length === 0) {
+        return;
+      }
+      const sample = sampleRawTrackAtTime(binding.track, timeSeconds);
+      ids.forEach((id, index) => {
+        const value = sample[index];
+        if (id && typeof value === "number") {
+          writes.push({ id, namespace, value });
+        }
+      });
+      return;
+    }
+    if (!binding.animatableId) {
       return;
     }
     const sample = sampleRawTrackAtTime(binding.track, timeSeconds);
@@ -337,7 +415,29 @@ export function sampleFrameToInputValues(
 ): Record<string, number> {
   const values: Record<string, number> = {};
   bindings.forEach((binding) => {
-    if (binding.clipId !== clipId || !binding.animatableId) {
+    if (binding.clipId !== clipId) {
+      return;
+    }
+    if (binding.property === "weights") {
+      const ids = binding.morphTargets;
+      if (!ids || ids.length === 0) {
+        return;
+      }
+      const sample = sampleRawTrackAtTime(binding.track, timeSeconds);
+      ids.forEach((animatableId, index) => {
+        const value = sample[index];
+        if (!animatableId || typeof value !== "number") {
+          return;
+        }
+        // A morph is a scalar animatable: its componentId is the animatable id.
+        const inputId = resolveInputId(animatableId);
+        if (inputId) {
+          values[inputId] = value;
+        }
+      });
+      return;
+    }
+    if (!binding.animatableId) {
       return;
     }
     const sample = sampleRawTrackAtTime(binding.track, timeSeconds);
@@ -361,4 +461,31 @@ export function sampleFrameToInputValues(
     }
   });
   return values;
+}
+
+/**
+ * Collect the sorted, de-duplicated union of keyframe times across a clip's
+ * tracks — the native sample points for baking the clip into a timeline. Falls
+ * back to `[0]` when no track exposes times.
+ */
+export function collectClipFrameTimes(
+  bindings: RawChannelBinding[],
+  clipId: string,
+): number[] {
+  const times = new Set<number>();
+  bindings.forEach((binding) => {
+    if (binding.clipId !== clipId || !binding.track.times) {
+      return;
+    }
+    for (let i = 0; i < binding.track.times.length; i += 1) {
+      const t = binding.track.times[i];
+      if (typeof t === "number" && Number.isFinite(t)) {
+        times.add(t);
+      }
+    }
+  });
+  if (times.size === 0) {
+    return [0];
+  }
+  return Array.from(times).sort((a, b) => a - b);
 }

--- a/apps/vizij-authoring/src/poseExtraction/index.ts
+++ b/apps/vizij-authoring/src/poseExtraction/index.ts
@@ -2,6 +2,7 @@ export {
   useFbxPoseExtraction,
   type FbxPoseExtractionApi,
   type UseFbxPoseExtractionArgs,
+  type BakeResult,
 } from "./useFbxPoseExtraction";
 export { PoseExtractionPanel } from "./components/PoseExtractionPanel";
 export {
@@ -10,6 +11,8 @@ export {
   channelSampleToRawValue,
   sampleFrameToRenderWrites,
   sampleFrameToInputValues,
+  collectClipFrameTimes,
+  isChannelMapped,
   summarizeClips,
   type RawChannelBinding,
   type RawClipSummary,

--- a/apps/vizij-authoring/src/poseExtraction/useFbxPoseExtraction.ts
+++ b/apps/vizij-authoring/src/poseExtraction/useFbxPoseExtraction.ts
@@ -5,9 +5,19 @@ import { useBindingAuthoring } from "../state/RigControllerProvider";
 import { usePoseRigStore, NEUTRAL_POSE_ID } from "../poseRig/store";
 import { PoseSnapshotService } from "../poseRig/services/poseSnapshotService";
 import { resolveDeterministicPoseId } from "../poseRig/utils";
+import { useAnimationStore } from "../state/animationStore";
+import {
+  ANIMATION_CLIP_IR_SCHEMA_VERSION,
+  AUTHORED_TIMELINE_CLIP_ID,
+  type AnimationClipIR,
+  type AnimationKeyframeIR,
+  type AnimationTrackIR,
+} from "../types/animationClipIr";
 import { DEFAULT_NAMESPACE } from "../utils/constants";
 import {
+  collectClipFrameTimes,
   indexRawChannels,
+  isChannelMapped,
   sampleFrameToInputValues,
   sampleFrameToRenderWrites,
   summarizeClips,
@@ -16,6 +26,11 @@ import {
   type RawChannelBinding,
   type RawClipSummary,
 } from "./fbxFrameExtraction";
+
+export interface BakeResult {
+  inputCount: number;
+  keyframeCount: number;
+}
 
 export interface FbxPoseExtractionApi {
   /** True when raw (FBX-derived) clips are present to extract from. */
@@ -36,6 +51,12 @@ export interface FbxPoseExtractionApi {
     name: string;
     group?: string | null;
   }) => string | null;
+  /**
+   * Bake the whole active clip into the authored animation timeline (sampling
+   * every native keyframe into per-input tracks). Returns a summary, or null if
+   * nothing could be baked.
+   */
+  bakeActiveClip: () => BakeResult | null;
   /** Number of channels in the active clip that map to a rig input. */
   channelCount: number;
   /** Active-clip channels that couldn't be mapped (bones, morph weights, …). */
@@ -114,11 +135,11 @@ export function useFbxPoseExtraction(
     [bindings, activeClipId],
   );
   const mappedChannelCount = useMemo(
-    () => activeBindings.filter((binding) => binding.animatableId).length,
+    () => activeBindings.filter(isChannelMapped).length,
     [activeBindings],
   );
   const unmappedChannels = useMemo(
-    () => activeBindings.filter((binding) => !binding.animatableId),
+    () => activeBindings.filter((binding) => !isChannelMapped(binding)),
     [activeBindings],
   );
 
@@ -132,6 +153,15 @@ export function useFbxPoseExtraction(
       }
     });
     return (componentId: string): string | null => map.get(componentId) ?? null;
+  }, [managedStandardInputs]);
+
+  // standard-input id -> its typed path, so baked tracks bind to the right input.
+  const inputPathById = useMemo(() => {
+    const map = new Map<string, string>();
+    managedStandardInputs.forEach((entry) => {
+      map.set(entry.input.id, entry.input.path);
+    });
+    return map;
   }, [managedStandardInputs]);
 
   const seek = useCallback(
@@ -279,6 +309,67 @@ export function useFbxPoseExtraction(
     ],
   );
 
+  const bakeActiveClip = useCallback((): BakeResult | null => {
+    if (!activeClipId || !activeClip) {
+      return null;
+    }
+    setIsPlaying(false);
+    const times = collectClipFrameTimes(bindings, activeClipId);
+    const keyframesByInput = new Map<string, AnimationKeyframeIR[]>();
+    times.forEach((t, frameIndex) => {
+      const values = sampleFrameToInputValues(
+        bindings,
+        activeClipId,
+        t,
+        resolveInputId,
+      );
+      Object.entries(values).forEach(([inputId, value]) => {
+        let keyframes = keyframesByInput.get(inputId);
+        if (!keyframes) {
+          keyframes = [];
+          keyframesByInput.set(inputId, keyframes);
+        }
+        keyframes.push({
+          id: `${inputId}-${frameIndex}`,
+          time: t,
+          value,
+          interpolation: "linear",
+        });
+      });
+    });
+
+    if (keyframesByInput.size === 0) {
+      return { inputCount: 0, keyframeCount: 0 };
+    }
+
+    let keyframeCount = 0;
+    let trackIndex = 0;
+    const tracks: AnimationTrackIR[] = [];
+    keyframesByInput.forEach((keyframes, inputId) => {
+      keyframeCount += keyframes.length;
+      tracks.push({
+        id: `fbx-bake-${trackIndex}`,
+        variableId: inputId,
+        channel: inputPathById.get(inputId) ?? inputId,
+        interpolation: "linear",
+        keyframes,
+      });
+      trackIndex += 1;
+    });
+
+    const lastTime = times[times.length - 1] ?? 0;
+    const clip: AnimationClipIR = {
+      schemaVersion: ANIMATION_CLIP_IR_SCHEMA_VERSION,
+      id: AUTHORED_TIMELINE_CLIP_ID,
+      name: activeClip.name,
+      duration: activeClip.duration > 0 ? activeClip.duration : lastTime,
+      tracks,
+    };
+
+    useAnimationStore.getState().importClipIr(clip);
+    return { inputCount: keyframesByInput.size, keyframeCount };
+  }, [activeClip, activeClipId, bindings, inputPathById, resolveInputId]);
+
   return {
     isAvailable: clips.length > 0,
     clips,
@@ -290,6 +381,7 @@ export function useFbxPoseExtraction(
     seek,
     togglePlay,
     captureFrame,
+    bakeActiveClip,
     channelCount: mappedChannelCount,
     unmappedChannels,
   };


### PR DESCRIPTION
## Summary

Extends the Pose Extraction tool (stacked on #60) to capture the **morph shape-key** work a designer authored in Blender, and to preserve **whole clips as playable/exportable Vizij animation timelines** — not just single-frame poses. This is the "capture everything a designer made in Blender and keep using it in Vizij" step.

> **Stacked PR:** base branch is `sbeleidy/fbx-pose-extraction-vizij-d32ee7` (#60). Merge #60 first, then this.

## What changed (all in `apps/vizij-authoring/src/poseExtraction/`, no `@vizij/render` change)

**Morph weights**
- `indexRawChannels` resolves `weights` (`morphTargetInfluences`) channels to the target mesh's ordered per-morph animatables (`Shape.morphTargets` → featureKey → `features[key].value`), stored on the binding as `morphTargets`.
- `sampleFrameToRenderWrites` / `sampleFrameToInputValues` fan a flat weights sample out to one write/input per morph (scalar `componentId = animatable id`), so morphs **preview live, capture into poses, and count as mapped channels**.
- `isChannelMapped()` treats a weights channel with ≥1 resolved morph as mapped; the "unmapped channels" warning now only fires for genuinely unsupported channels (e.g. skeleton bones).

**Bake clip → timeline**
- `useFbxPoseExtraction.bakeActiveClip()` samples every native keyframe (`collectClipFrameTimes`) into an `AnimationClipIR` (one track per standard input, `channel` = input path) and imports it via `animationStore.importClipIr` — so the clip plays in the Animation panel and exports as a bundle `animations[]` entry.
- `PoseExtractionPanel` gains a **"Bake clip → timeline"** button + status line.

Morphs need **no new rig concept**: they already import as `AnimatableNumber` features and auto-generate scalar standard inputs. This PR only wires the animation channel to them and adds baking.

## Why no bones
No sample GLB (Hugo/Quori/Toasty) contains skeleton bones/skins — the "bones" are transform empties that already import. True skeleton import (a one-line relax of the `isBone` skip in `@vizij/render`) is deferred until we have a GLB that actually has bones.

## Test plan
- `pnpm --filter vizij-authoring test` — **16 tests** (5 new: weights indexing, per-morph render writes, per-morph input mapping, `isChannelMapped`, `collectClipFrameTimes`).
- Typecheck + lint clean (build `@vizij/*` first so `tsc` resolves them).
- **In-app confirmed**: loading Quori Blender Export imports the mouth shape keys as rig inputs/drivers — filtering Input Controls by "sneer" shows `Mouth Ltsneer / Lbsneer / Rtsneer / Rbsneer` with sliders.

### ⚠️ Verification caveat
The browser-automation harness could not operate the base-ui `<Select>` that switches the active clip (it ignores synthetic pointer/keyboard events — a harness limitation, not a product bug), so live morph-clip **scrub / capture / bake** wasn't visually captured this session. The morph mapping is unit-verified and reuses the exact transform sampling/capture paths already verified live in #60; a human selecting a `Key.*Action` clip will exercise it end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)