### PR TITLE
fix(standalone): stable, encrypted Studio identity + visible errors

### DIFF
--- a/apps/vizij-standalone/src-tauri/Cargo.lock
+++ b/apps/vizij-standalone/src-tauri/Cargo.lock
@@ -9,6 +9,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,6 +895,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -1198,7 +1209,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "crypto_secretbox"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1"
+dependencies = [
+ "aead",
+ "cipher",
+ "generic-array",
+ "poly1305",
+ "salsa20",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2087,6 +2114,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -3811,6 +3839,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4333,6 +4367,17 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -5276,6 +5321,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "same-file"
@@ -7107,6 +7161,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7267,8 +7331,10 @@ dependencies = [
  "arora-simple-data-store",
  "arora-studio-bridge-client",
  "arora-types",
+ "async-trait",
  "base64 0.22.1",
  "clap",
+ "crypto_secretbox",
  "dotenvy",
  "futures-util",
  "log",

--- a/apps/vizij-standalone/src-tauri/Cargo.toml
+++ b/apps/vizij-standalone/src-tauri/Cargo.toml
@@ -32,6 +32,9 @@ arora-studio-bridge-client = { version = "3.1.0", optional = true }
 # Install the process-wide rustls crypto provider (ring) the Zenoh/Firebase TLS
 # stacks need — matches the provider arora-studio-bridge-client is built against.
 rustls = { version = "0.23", default-features = false, features = ["ring"], optional = true }
+# Encrypt the persisted anonymous refresh token at rest (XSalsa20Poly1305), the
+# same mechanism arora uses for its saved token. Only needed with studio-bridge.
+crypto_secretbox = { version = "0.1.1", optional = true }
 tauri = { version = "2.10.3", features = [] }
 tauri-plugin-dialog = "2.6.0"
 tauri-plugin-fs = "2.4.5"
@@ -74,10 +77,12 @@ ros2 = ["dep:arora-bridge-ros2"]
 #   cargo build --features studio-bridge
 # Zero-config: the client crate (v3.1+) bakes in the Firebase config + bridge
 # endpoint. Runtime env overrides: STUDIO_BRIDGE_ENDPOINT (non-production bridge),
-# FIREBASE_* (emulator), DEVICE_OWNERS (ownership).
-studio-bridge = ["dep:arora-studio-bridge-client", "dep:rustls"]
+# DEVICE_OWNERS (ownership). vizij always talks to real Firebase — no emulator.
+studio-bridge = ["dep:arora-studio-bridge-client", "dep:rustls", "dep:crypto_secretbox"]
 
 [dev-dependencies]
 ros2-client = "0.8"
 rand = "0.9"
 tokio = { version = "1", features = ["full"] }
+# The mock `Bridge` in the studio-bridge tests implements an `#[async_trait]` trait.
+async-trait = "0.1"

--- a/apps/vizij-standalone/src-tauri/src/lib.rs
+++ b/apps/vizij-standalone/src-tauri/src/lib.rs
@@ -1019,7 +1019,9 @@ fn spawn_studio_bridge(
     initial_owners: Vec<String>,
     device_name: String,
 ) {
-    use arora_studio_bridge_client::firestore_support::options::FirebaseOptions;
+    use arora_studio_bridge_client::firestore_support::options::{
+        FirebaseEmulatorOptions, FirebaseOptions,
+    };
     use arora_studio_bridge_client::zenoh::ZenohDeviceClient;
 
     let firebase_options = FirebaseOptions::from_env();
@@ -1071,18 +1073,17 @@ fn spawn_studio_bridge(
                     let _ = rustls::crypto::ring::default_provider().install_default();
                 }
 
-                // vizij always talks to real Firebase — no emulator wiring at all,
-                // so a stray FIREBASE_*_EMULATOR_HOST can never divert device info.
-                let no_emulator: Option<
-                    &arora_studio_bridge_client::firestore_support::options::FirebaseEmulatorOptions,
-                > = None;
+                // Firebase emulator wiring is left to its default behavior:
+                // `FirebaseEmulatorOptions::from_env()` picks up the emulator when
+                // `FIREBASE_*_EMULATOR_HOST` is set, and targets real Firebase otherwise.
+                let firebase_emulator_options = FirebaseEmulatorOptions::from_env();
 
                 let connect = match endpoint_override {
                     Some(endpoint) => {
                         info!("studio-bridge: connecting to Semio Studio via Zenoh (endpoint: {endpoint})");
                         ZenohDeviceClient::new_endpoint(
                             &firebase_options,
-                            no_emulator,
+                            Some(&firebase_emulator_options),
                             refresh_token,
                             save_token,
                             endpoint,
@@ -1093,7 +1094,7 @@ fn spawn_studio_bridge(
                         info!("studio-bridge: connecting to Semio Studio via the baked-in bridge endpoint");
                         ZenohDeviceClient::new(
                             &firebase_options,
-                            no_emulator,
+                            Some(&firebase_emulator_options),
                             refresh_token,
                             save_token,
                         )

--- a/apps/vizij-standalone/src-tauri/src/lib.rs
+++ b/apps/vizij-standalone/src-tauri/src/lib.rs
@@ -777,6 +777,104 @@ fn random_device_suffix() -> String {
     suffix
 }
 
+/// Tauri event emitted when the Studio bridge fails to connect or register, so
+/// the failure is visible to the UI instead of only reaching the log.
+#[cfg(feature = "studio-bridge")]
+const STUDIO_BRIDGE_ERROR_EVENT: &str = "studio-bridge:error";
+
+/// Paths of the persisted device identity: the encrypted anonymous refresh token
+/// and the key that encrypts it, both under `app_local_data_dir()`. Reusing the
+/// token across launches gives the device ONE stable Studio identity (one
+/// `devices/{uid}` doc) instead of minting a fresh anonymous user — and orphaning
+/// the previous doc and its owners/permissions — every launch.
+#[cfg(feature = "studio-bridge")]
+fn studio_token_paths(
+    app: &tauri::AppHandle,
+) -> Result<(std::path::PathBuf, std::path::PathBuf), String> {
+    let dir = app.path().app_local_data_dir().map_err(|e| e.to_string())?;
+    Ok((
+        dir.join("studio_refresh_token.key"),
+        dir.join("studio_refresh_token"),
+    ))
+}
+
+/// Load the 32-byte token-encryption key from `key_path`, if present and valid.
+#[cfg(feature = "studio-bridge")]
+fn studio_load_key(key_path: &std::path::Path) -> Option<crypto_secretbox::Key> {
+    use crypto_secretbox::aead::generic_array::GenericArray;
+    let bytes = std::fs::read(key_path).ok()?;
+    (bytes.len() == 32).then(|| *GenericArray::from_slice(&bytes))
+}
+
+/// Load the token-encryption key, generating and persisting one on first use.
+#[cfg(feature = "studio-bridge")]
+fn studio_load_or_create_key(key_path: &std::path::Path) -> std::io::Result<crypto_secretbox::Key> {
+    use crypto_secretbox::aead::{KeyInit, OsRng};
+    use crypto_secretbox::XSalsa20Poly1305;
+    if let Some(key) = studio_load_key(key_path) {
+        return Ok(key);
+    }
+    let key = XSalsa20Poly1305::generate_key(&mut OsRng);
+    if let Some(parent) = key_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(key_path, key.as_slice())?;
+    Ok(key)
+}
+
+/// Read + decrypt the persisted anonymous refresh token, if present.
+///
+/// Stored as `nonce (24 bytes) || XSalsa20Poly1305 ciphertext`, matching arora's
+/// token storage. Returns `None` when nothing is saved or the blob can't be
+/// decrypted (e.g. a rotated key).
+#[cfg(feature = "studio-bridge")]
+fn read_studio_refresh_token(
+    key_path: &std::path::Path,
+    token_path: &std::path::Path,
+) -> Option<String> {
+    use crypto_secretbox::aead::generic_array::GenericArray;
+    use crypto_secretbox::aead::{Aead, KeyInit};
+    use crypto_secretbox::{Nonce, XSalsa20Poly1305};
+
+    let blob = std::fs::read(token_path).ok()?;
+    if blob.len() <= 24 {
+        return None;
+    }
+    let key = studio_load_key(key_path)?;
+    let cipher = XSalsa20Poly1305::new(&key);
+    let (nonce_bytes, ciphertext) = blob.split_at(24);
+    let nonce: Nonce = *GenericArray::from_slice(nonce_bytes);
+    let plaintext = cipher.decrypt(&nonce, ciphertext).ok()?;
+    let token = String::from_utf8(plaintext).ok()?.trim().to_string();
+    (!token.is_empty()).then_some(token)
+}
+
+/// Encrypt + persist the anonymous refresh token as the client rotates it, so the
+/// same device identity survives restarts. Encrypted at rest (XSalsa20Poly1305)
+/// under a key stored next to it, like arora's saved token.
+#[cfg(feature = "studio-bridge")]
+fn write_studio_refresh_token(
+    key_path: &std::path::Path,
+    token_path: &std::path::Path,
+    token: &str,
+) -> Result<(), String> {
+    use crypto_secretbox::aead::{Aead, AeadCore, KeyInit, OsRng};
+    use crypto_secretbox::XSalsa20Poly1305;
+
+    let key = studio_load_or_create_key(key_path).map_err(|e| e.to_string())?;
+    let cipher = XSalsa20Poly1305::new(&key);
+    let nonce = XSalsa20Poly1305::generate_nonce(&mut OsRng);
+    let ciphertext = cipher
+        .encrypt(&nonce, token.as_bytes())
+        .map_err(|e| format!("failed to encrypt refresh token: {e}"))?;
+    if let Some(parent) = token_path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    let mut blob = nonce.as_slice().to_vec();
+    blob.extend_from_slice(&ciphertext);
+    std::fs::write(token_path, blob).map_err(|e| e.to_string())
+}
+
 /// The Studio bridge pump. Registers the device, serves access requests, and —
 /// the VIZ-67 close — shares the SAME store as the WS/ROS2 bridges: it fans the
 /// store's live changes out to Studio (`try_send`) and applies Studio's inbound
@@ -789,10 +887,48 @@ fn random_device_suffix() -> String {
 async fn run_studio_pump(
     store: SimpleDataStore,
     app: AppHandle,
+    bridge: Box<dyn Bridge>,
+    owners_rx: tokio::sync::watch::Receiver<Vec<String>>,
+    device_name: String,
+    initial_owners: Vec<String>,
+) {
+    // Production wiring for the injectable core: surface failures as a Tauri event
+    // and route inbound events through the real store/webview handler. The core
+    // itself is Tauri-free so it can run against a mock bridge under test.
+    let error_app = app.clone();
+    let on_error = move |message: String| {
+        let _ = error_app.emit(STUDIO_BRIDGE_ERROR_EVENT, message);
+    };
+    let on_inbound = move |store: &SimpleDataStore, event| host::handle_inbound(store, &app, event);
+    run_studio_pump_core(
+        store,
+        bridge,
+        owners_rx,
+        device_name,
+        initial_owners,
+        on_error,
+        on_inbound,
+    )
+    .await;
+}
+
+/// The Tauri-free core of the studio pump — the injection seam.
+///
+/// Takes the bridge (the real `ZenohDeviceClient` in production, a mock in tests)
+/// plus two sinks: `on_error` for a surfaced failure message (production emits a
+/// Tauri event) and `on_inbound` for an inbound event (production applies it to
+/// the store + webview). Registers the device, keeps it registered as owners
+/// change, and fans store changes out to the bridge — with no dependency on a
+/// running Tauri app, so the registration mechanics are testable with a mock.
+#[cfg(feature = "studio-bridge")]
+async fn run_studio_pump_core(
+    store: SimpleDataStore,
     mut bridge: Box<dyn Bridge>,
     mut owners_rx: tokio::sync::watch::Receiver<Vec<String>>,
     device_name: String,
     initial_owners: Vec<String>,
+    mut on_error: impl FnMut(String),
+    mut on_inbound: impl FnMut(&SimpleDataStore, arora_bridge::Inbound),
 ) {
     use futures_util::StreamExt;
 
@@ -801,6 +937,7 @@ async fn run_studio_pump(
     let info = studio_device_info(device_name.clone(), initial_owners.clone());
     if let Err(e) = bridge.update_device_info(Some(info)).await {
         log::error!("studio-bridge: failed to register device info: {e}");
+        on_error(format!("Failed to register this device with Studio: {e}"));
     } else {
         info!(
             "studio-bridge: registered device \"{device_name}\" with Studio ({} owner(s))",
@@ -838,7 +975,7 @@ async fn run_studio_pump(
                 None => break,
             },
             maybe_event = inbound.next() => match maybe_event {
-                Some(event) => host::handle_inbound(&store, &app, event),
+                Some(event) => on_inbound(&store, event),
                 None => break, // endpoint disconnected
             },
             changed = owners_rx.changed() => {
@@ -852,7 +989,10 @@ async fn run_studio_pump(
                         "studio-bridge: re-registered device \"{device_name}\" ({} owner(s))",
                         owners.len()
                     ),
-                    Err(e) => log::error!("studio-bridge: failed to re-register device info: {e}"),
+                    Err(e) => {
+                        log::error!("studio-bridge: failed to re-register device info: {e}");
+                        on_error(format!("Failed to update this device's owners in Studio: {e}"));
+                    }
                 }
             }
         }
@@ -879,9 +1019,7 @@ fn spawn_studio_bridge(
     initial_owners: Vec<String>,
     device_name: String,
 ) {
-    use arora_studio_bridge_client::firestore_support::options::{
-        FirebaseEmulatorOptions, FirebaseOptions,
-    };
+    use arora_studio_bridge_client::firestore_support::options::FirebaseOptions;
     use arora_studio_bridge_client::zenoh::ZenohDeviceClient;
 
     let firebase_options = FirebaseOptions::from_env();
@@ -889,6 +1027,29 @@ fn spawn_studio_bridge(
         .ok()
         .and_then(|v| v.split(',').next().map(|s| s.trim().to_string()))
         .filter(|s| !s.is_empty());
+
+    // Load the saved (encrypted) anonymous refresh token, if any, so the device
+    // keeps ONE stable Studio identity across launches, and wire the save-callback
+    // so the client persists the token as it rotates. Without this, every launch
+    // minted a fresh anonymous user — a new devices/{uid} doc — orphaning the
+    // previous one and its owners/permissions. Mirrors arora's own device path.
+    let token_paths = studio_token_paths(&app).ok();
+    let refresh_token = token_paths
+        .as_ref()
+        .and_then(|(key_path, token_path)| read_studio_refresh_token(key_path, token_path));
+    if refresh_token.is_some() {
+        info!("studio-bridge: reusing the saved device identity");
+    } else {
+        info!("studio-bridge: no saved device identity yet; one will be created");
+    }
+    let save_token: Option<Box<dyn FnMut(String) + Send + Sync>> =
+        token_paths.map(|(key_path, token_path)| {
+            Box::new(move |token: String| {
+                if let Err(e) = write_studio_refresh_token(&key_path, &token_path, &token) {
+                    log::warn!("studio-bridge: failed to save device identity: {e}");
+                }
+            }) as Box<dyn FnMut(String) + Send + Sync>
+        });
 
     std::thread::Builder::new()
         .name("studio-bridge".into())
@@ -910,16 +1071,20 @@ fn spawn_studio_bridge(
                     let _ = rustls::crypto::ring::default_provider().install_default();
                 }
 
-                let firebase_emulator_options = FirebaseEmulatorOptions::from_env();
+                // vizij always talks to real Firebase — no emulator wiring at all,
+                // so a stray FIREBASE_*_EMULATOR_HOST can never divert device info.
+                let no_emulator: Option<
+                    &arora_studio_bridge_client::firestore_support::options::FirebaseEmulatorOptions,
+                > = None;
 
                 let connect = match endpoint_override {
                     Some(endpoint) => {
                         info!("studio-bridge: connecting to Semio Studio via Zenoh (endpoint: {endpoint})");
                         ZenohDeviceClient::new_endpoint(
                             &firebase_options,
-                            Some(&firebase_emulator_options),
-                            None,
-                            None,
+                            no_emulator,
+                            refresh_token,
+                            save_token,
                             endpoint,
                         )
                         .await
@@ -928,9 +1093,9 @@ fn spawn_studio_bridge(
                         info!("studio-bridge: connecting to Semio Studio via the baked-in bridge endpoint");
                         ZenohDeviceClient::new(
                             &firebase_options,
-                            Some(&firebase_emulator_options),
-                            None,
-                            None,
+                            no_emulator,
+                            refresh_token,
+                            save_token,
                         )
                         .await
                     }
@@ -939,6 +1104,10 @@ fn spawn_studio_bridge(
                     Ok(client) => client,
                     Err(e) => {
                         log::error!("studio-bridge: failed to connect to Semio Studio: {e:?}");
+                        let _ = app.emit(
+                            STUDIO_BRIDGE_ERROR_EVENT,
+                            format!("Failed to connect to Semio Studio: {e:?}"),
+                        );
                         return;
                     }
                 };
@@ -1514,4 +1683,175 @@ pub fn run() {
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(all(test, feature = "studio-bridge"))]
+mod studio_bridge_tests {
+    use super::*;
+    use arora_bridge::{Bridge, BridgeError, BridgeResult, DeviceInfo, Inbound, InboundStream};
+    use async_trait::async_trait;
+    use std::sync::{Arc, Mutex};
+    use tokio::sync::mpsc;
+
+    /// A stand-in for the real `ZenohDeviceClient` — implementing the same
+    /// `arora_bridge::Bridge` trait vizij consumes — so the registration mechanics
+    /// can be exercised with NO Firebase/Zenoh. (ZenohDeviceClient's own behavior
+    /// is covered by studio-bridge's tests.) Records every `update_device_info`
+    /// payload; `fail` makes registration error, to exercise the error path.
+    struct MockDeviceClient {
+        updates: mpsc::UnboundedSender<Option<DeviceInfo>>,
+        fail: bool,
+    }
+
+    #[async_trait]
+    impl Bridge for MockDeviceClient {
+        fn take_inbound(&mut self) -> InboundStream {
+            Box::pin(futures_util::stream::pending())
+        }
+        fn try_send(&mut self, _change: &arora_types::data::StateChange) {}
+        async fn get_device_info(&self) -> BridgeResult<Option<DeviceInfo>> {
+            Ok(None)
+        }
+        async fn update_device_info(
+            &self,
+            info: Option<DeviceInfo>,
+        ) -> BridgeResult<Option<DeviceInfo>> {
+            let _ = self.updates.send(info.clone());
+            if self.fail {
+                Err(BridgeError::Other("mock connection lost".into()))
+            } else {
+                Ok(info)
+            }
+        }
+    }
+
+    /// Spawn the pump core against a mock bridge. Returns the owner sender, the
+    /// stream of recorded `update_device_info` payloads, the collected error
+    /// messages, and the task handle.
+    fn spawn_core(
+        fail: bool,
+    ) -> (
+        tokio::sync::watch::Sender<Vec<String>>,
+        mpsc::UnboundedReceiver<Option<DeviceInfo>>,
+        Arc<Mutex<Vec<String>>>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let (updates_tx, updates_rx) = mpsc::unbounded_channel();
+        let bridge: Box<dyn Bridge> = Box::new(MockDeviceClient {
+            updates: updates_tx,
+            fail,
+        });
+        let store = SimpleDataStore::new();
+        let (owners_tx, owners_rx) = tokio::sync::watch::channel::<Vec<String>>(Vec::new());
+        let errors = Arc::new(Mutex::new(Vec::<String>::new()));
+        let errors_sink = errors.clone();
+        let handle = tokio::spawn(run_studio_pump_core(
+            store,
+            bridge,
+            owners_rx,
+            "vizij-test".to_string(),
+            Vec::new(),
+            move |message| errors_sink.lock().unwrap().push(message),
+            |_store, _event: Inbound| {},
+        ));
+        (owners_tx, updates_rx, errors, handle)
+    }
+
+    /// After the operator chooses an owner, the device re-registers with that uid
+    /// in its owners — the wiring that makes the devices/{uid} doc readable and
+    /// claimable by that user.
+    #[tokio::test]
+    async fn owner_choice_reregisters_with_that_owner() {
+        let (owners_tx, mut updates_rx, errors, handle) = spawn_core(false);
+
+        // Initial registration, before any owner is chosen: ownerless.
+        let first = updates_rx.recv().await.unwrap().unwrap();
+        assert!(first.owners.is_empty(), "initial registration is ownerless");
+
+        // Operator picks an owner → re-registration carries it.
+        owners_tx.send(vec!["studio-user-uid".to_string()]).unwrap();
+        let second = updates_rx.recv().await.unwrap().unwrap();
+        assert_eq!(second.owners, vec!["studio-user-uid".to_string()]);
+        assert_eq!(second.model_family.as_deref(), Some("Vizij"));
+
+        drop(owners_tx); // ends the pump loop
+        let _ = handle.await;
+        assert!(errors.lock().unwrap().is_empty(), "no errors on success");
+    }
+
+    /// A failed registration is surfaced (via `on_error`, a Tauri event in
+    /// production) rather than swallowed.
+    #[tokio::test]
+    async fn failed_registration_is_surfaced() {
+        let (owners_tx, mut updates_rx, errors, handle) = spawn_core(true);
+
+        // The attempt is still made against the bridge...
+        let _ = updates_rx.recv().await.unwrap();
+
+        drop(owners_tx);
+        let _ = handle.await;
+
+        // ...and its failure reached the error sink.
+        let errors = errors.lock().unwrap();
+        assert!(
+            errors
+                .iter()
+                .any(|m| m.contains("Failed to register this device with Studio")),
+            "expected a surfaced registration error, got {errors:?}"
+        );
+    }
+
+    /// The refresh token is persisted encrypted and loads back decrypted — the
+    /// stable-identity mechanic, exercised through the exact save-callback body
+    /// `spawn_studio_bridge` wires to the client.
+    #[test]
+    fn refresh_token_round_trips_encrypted() {
+        let dir = std::env::temp_dir().join(format!(
+            "vizij-studio-token-{}-{}",
+            std::process::id(),
+            rand::random::<u64>()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let key_path = dir.join("studio_refresh_token.key");
+        let token_path = dir.join("studio_refresh_token");
+
+        // Nothing persisted yet.
+        assert_eq!(read_studio_refresh_token(&key_path, &token_path), None);
+
+        // The save-callback, built exactly as spawn_studio_bridge builds it.
+        let mut save_token: Box<dyn FnMut(String)> = {
+            let key_path = key_path.clone();
+            let token_path = token_path.clone();
+            Box::new(move |token: String| {
+                write_studio_refresh_token(&key_path, &token_path, &token).unwrap();
+            })
+        };
+        save_token("secret-refresh-token".to_string());
+
+        // On disk it is ciphertext, not the plaintext token.
+        let blob = std::fs::read(&token_path).unwrap();
+        assert!(
+            !blob
+                .windows("secret-refresh-token".len())
+                .any(|w| w == b"secret-refresh-token"),
+            "token must not be stored in plaintext"
+        );
+
+        // And it loads back decrypted on the next launch.
+        assert_eq!(
+            read_studio_refresh_token(&key_path, &token_path).as_deref(),
+            Some("secret-refresh-token")
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn parse_owners_trims_and_drops_empty() {
+        assert_eq!(
+            parse_owners(" a , ,b, "),
+            vec!["a".to_string(), "b".to_string()]
+        );
+        assert!(parse_owners("  ,, ").is_empty());
+    }
 }

--- a/apps/vizij-standalone/src-tauri/tauri.conf.json
+++ b/apps/vizij-standalone/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Vizij Standalone",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "identifier": "com.vizij.standalone",
   "build": {
     "beforeDevCommand": "pnpm run vite",


### PR DESCRIPTION
## What

Fixes the `studio-bridge` device-registration path so a standalone device reliably appears in Studio with its info and stays claimable. Root cause was **not** the emitted device info (that is correct) but how the client was dispatched — all of it silently.

### 1. Stable, encrypted device identity
The Zenoh device client was built with no refresh token and no save-callback, so **every launch minted a fresh anonymous user** — a new `devices/{uid}` doc — orphaning the previous one and its owners/permissions. The anonymous refresh token is now persisted and reused across launches, **encrypted at rest** (XSalsa20Poly1305 under a key stored beside it — the same mechanism arora uses). The device keeps one stable identity.

### 2. Visible connect/register failures
Connect and (re)register failures were only logged. They now also emit a `studio-bridge:error` Tauri event the UI can surface, so a silent registration failure is no longer invisible.

### 3. Owner seeding (already correct, now durable)
Once the operator chooses an owner (or `DEVICE_OWNERS` / a persisted choice exists), the device re-registers with that owner in its permissions. That wiring was already correct; fix #1 makes the seeded owner **persist** to the same doc instead of being lost on the next launch.

## Testability seam + tests

Refactored the studio pump into a Tauri-free core (`run_studio_pump_core`) that takes an injected `arora_bridge::Bridge` plus `on_error` / `on_inbound` sinks. Production wires the real `ZenohDeviceClient`; tests inject a `MockDeviceClient` implementing the same `Bridge` trait, so the registration mechanics run with **no Firebase or Zenoh**. Tests cover:
- owner choice → re-registration carries that owner;
- a failed registration is surfaced (not swallowed);
- the refresh token round-trips encrypted (ciphertext on disk, decrypts back).

No emulator wiring in the standalone at all — it always talks to real Firebase. Verified with `cargo test --features studio-bridge` (4 passed).

_Note: branch name still says "emulator" for continuity; the emulator wiring has been removed._