### PR TITLE
fix(standalone): mirror the whole device store to the native bridges

### DIFF
--- a/apps/vizij-standalone/src/hooks/useWebSocketSync.ts
+++ b/apps/vizij-standalone/src/hooks/useWebSocketSync.ts
@@ -32,6 +32,8 @@ export function useWebSocketSync() {
     faceId: runtimeFaceId,
     // The runtime's engine-store snapshot (most current after graph evaluation).
     getValueSnapshot: getPathSnapshot,
+    // Whole-store snapshot for the native mirror (every key, arora-serde values).
+    getStoreSnapshot,
   } = useVizijRuntime();
 
   // Get faceId like useMouseGaze does
@@ -329,23 +331,29 @@ export function useWebSocketSync() {
   useEffect(() => {
     if (!ready) return;
 
-    const constraintKeys = Object.keys(inputConstraints);
-    if (constraintKeys.length === 0) return;
-
     const pushValues = () => {
-      const values: Record<string, AroraValue> = {};
-      for (const path of constraintKeys) {
-        const currentValue = getRigValue(path);
-        if (currentValue !== undefined) {
-          // Publish under the canonical store key, not the raw constraint-map
-          // alias. Rig input paths are stored with a leading slash (e.g.
-          // "/rblid/translation/z") and the map also holds namespaced variants;
-          // publishing those verbatim yields empty Zenoh chunks once the bridge
-          // prepends "state/{uid}/" ("state/<uid>//rblid/..."). normalizeSlotPath
-          // strips the leading slash, collapses "//", and drops the namespace,
-          // which also collapses the ~4 aliases of each input to one key.
-          values[normalizeSlotPath(path)] = f64(currentValue);
+      // Mirror the WHOLE device store, not just the rig-input constraint keys:
+      // outputs, pose/emotion/viseme drivers, and structured values all reach
+      // the native store (and thus WS/ROS2/Studio). Values are already in
+      // arora's serde shape — pass-through, no conversion.
+      //
+      // TODO(ticket): this JS mirror between the device's store and the native
+      // SimpleDataStore is a stopgap; the bridges should attach to the device's
+      // own store instead (single-store architecture).
+      const snapshot = getStoreSnapshot();
+      if (!snapshot) return;
+      const values: Record<string, unknown> = {};
+      for (const [path, value] of Object.entries(snapshot)) {
+        if (value === null || value === undefined) continue;
+        // Internal keys stay device-side: arora's golden keys (`arora/…`) and
+        // the animation module's per-tick out-blob.
+        if (path.startsWith("arora/") || path === "vizij/animations/out") {
+          continue;
         }
+        // Publish under the canonical store key (leading slash stripped,
+        // "//" collapsed, namespace dropped) — publishing raw aliases yields
+        // empty Zenoh chunks once the bridge prepends "state/{uid}/".
+        values[normalizeSlotPath(path)] = value;
       }
       if (Object.keys(values).length > 0) {
         invoke("publish_values", { values }).catch((err) => {
@@ -354,11 +362,12 @@ export function useWebSocketSync() {
       }
     };
 
-    // Push once immediately, then on a 10Hz interval for live data.
+    // Push once immediately, then on a 10Hz interval for live data. The native
+    // store is change-only, so re-pushing the full snapshot every tick is cheap.
     pushValues();
     const interval = window.setInterval(pushValues, 100);
     return () => window.clearInterval(interval);
-  }, [ready, inputConstraints, getRigValue, normalizeSlotPath]);
+  }, [ready, getStoreSnapshot, normalizeSlotPath]);
 
   return {
     ready,

--- a/packages/@vizij/runtime-react/src/VizijRuntimeProvider.tsx
+++ b/packages/@vizij/runtime-react/src/VizijRuntimeProvider.tsx
@@ -2042,6 +2042,18 @@ function VizijRuntimeProviderInner({
     [deviceSlot],
   );
 
+  // Whole-store snapshot (path → arora-serde Value, pass-through from the
+  // device) for mirrors/bridges that forward every key — see the context doc.
+  const getStoreSnapshot = useCallback(():
+    | Record<string, unknown>
+    | undefined => {
+    const handle = deviceSlot.current;
+    if (!handle) {
+      return undefined;
+    }
+    return handle.device.snapshot() as Record<string, unknown>;
+  }, [deviceSlot]);
+
   /**
    * Route the animation module's per-tick `[TrackOutput]` (read from
    * `ANIMATIONS_OUT_PATH`, written by the animations source last step) to the
@@ -3666,6 +3678,7 @@ function VizijRuntimeProviderInner({
       assetBundle,
       setInput,
       getValueSnapshot: getPathSnapshot,
+      getStoreSnapshot,
       subscribeToStep,
       setGraphBundle,
       setValue: setRendererValue,
@@ -3693,6 +3706,7 @@ function VizijRuntimeProviderInner({
       assetBundle,
       setInput,
       getPathSnapshot,
+      getStoreSnapshot,
       subscribeToStep,
       setGraphBundle,
       setRendererValue,

--- a/packages/@vizij/runtime-react/src/types.ts
+++ b/packages/@vizij/runtime-react/src/types.ts
@@ -300,6 +300,14 @@ export type VizijRuntimeContextValue = VizijRuntimeStatus & {
   /** Current engine-store value of a path (read-your-own-write included). */
   getValueSnapshot: (path: string) => ValueJSON | undefined;
   /**
+   * A snapshot of EVERY key currently in the device store, as path → Value in
+   * arora's serde JSON shape (pass-through from the device; not `ValueJSON`).
+   * `undefined` until the device exists. For mirrors/bridges that forward the
+   * whole store (e.g. the standalone's native-store mirror), not for per-path
+   * sampling — use `getValueSnapshot` for that.
+   */
+  getStoreSnapshot: () => Record<string, unknown> | undefined;
+  /**
    * Notifies after each engine step, once the step's store changes have been
    * applied. Pair with `getValueSnapshot` to sample values step-aligned.
    * Returns an unsubscribe function.


### PR DESCRIPTION
The webview→native mirror forwarded only rig-input constraint keys whose snapshot happened to resolve, so Studio/WS/ROS2 consumers saw a partial, alias-filtered subset: single coordinates went missing (eye X without Y), and pose/emotion/viseme drivers and outputs never appeared at all.

The device already exposes `snapshot()` (every key, arora-serde values, shared value type), so the mirror now forwards the **entire store** at 10 Hz, minus device-internal keys (`arora/*` golden keys, the animation module's out-blob). Values pass through verbatim; the change-only native store keeps re-pushing cheap.

`@vizij/runtime-react` gains `getStoreSnapshot()` on the runtime context (additive).

Follow-up (ticketed separately): the JS mirror between the device store and the native store is itself a stopgap — the native bridges should attach to the device's own store (single-store architecture).

Verified: `pnpm run typecheck:all` clean, runtime-react tests 75/75, prettier clean.