### PR TITLE
chore(deps): @vizij/animation-module 0.1.1 — inlined module header

### DIFF
--- a/packages/@vizij/runtime-react/package.json
+++ b/packages/@vizij/runtime-react/package.json
@@ -38,7 +38,7 @@
     "prepack": "pnpm run build && pnpm run test && pnpm run typecheck && pnpm run lint"
   },
   "dependencies": {
-    "@vizij/animation-module": "^0.1.0",
+    "@vizij/animation-module": "^0.1.1",
     "@vizij/arora-web-wasm": "^0.2.0",
     "@vizij/node-graph-authoring": "workspace:*",
     "@vizij/render": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -890,8 +890,8 @@ importers:
   packages/@vizij/runtime-react:
     dependencies:
       '@vizij/animation-module':
-        specifier: ^0.1.0
-        version: 0.1.0
+        specifier: ^0.1.1
+        version: 0.1.1
       '@vizij/arora-web-wasm':
         specifier: ^0.2.0
         version: 0.2.0
@@ -2673,8 +2673,8 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
-  '@vizij/animation-module@0.1.0':
-    resolution: {integrity: sha512-Ry2xx9dHSN/BDkrUlNMVcYuWdnYMcIiUzJcJip+VB/v7txttq+VqfgEAs74gsPWrhg2Cg0pToWNPQEK78xmb2g==}
+  '@vizij/animation-module@0.1.1':
+    resolution: {integrity: sha512-ZSpZk44S2NM7nAlQty9wMIY9qHQLKJWrOYeqRmuLuAc1h6SnvCyBnx2WVYqYoeojesro782zXFxDL5S7KukDqw==}
 
   '@vizij/animation-wasm@0.4.0':
     resolution: {integrity: sha512-CbDWOZQ73tx/syzGfKjlPwIOo0Hw/v1TK4JYg/rpuyBQAaGP7pFzxYyYVZ8cj1bEPV6gJO9jk+5jxt0Q2QgnIw==}
@@ -6919,7 +6919,7 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
-  '@vizij/animation-module@0.1.0': {}
+  '@vizij/animation-module@0.1.1': {}
 
   '@vizij/animation-wasm@0.4.0':
     dependencies:


### PR DESCRIPTION
Picks up [vizij-rs #52](https://github.com/vizij-ai/vizij-rs/pull/52): the module header ships inlined in the JS instead of being fetched from `artifact/header.json`, fixing the standalone's device start under dev servers whose SPA fallback answered the missing asset with HTML (`modules[0].headerJson is not a module header: expected value at line 1 column 1`). Lockfile-only.