### PR TITLE
feat(standalone): change-driven device→native store bridge (VIZ-74)

### DIFF
--- a/apps/vizij-standalone/src/hooks/useWebSocketSync.ts
+++ b/apps/vizij-standalone/src/hooks/useWebSocketSync.ts
@@ -32,8 +32,9 @@ export function useWebSocketSync() {
     faceId: runtimeFaceId,
     // The runtime's engine-store snapshot (most current after graph evaluation).
     getValueSnapshot: getPathSnapshot,
-    // Whole-store snapshot for the native mirror (every key, arora-serde values).
+    // Whole-store snapshot + change feed for the native-store bridge.
     getStoreSnapshot,
+    subscribeToStoreChanges,
   } = useVizijRuntime();
 
   // Get faceId like useMouseGaze does
@@ -331,43 +332,68 @@ export function useWebSocketSync() {
   useEffect(() => {
     if (!ready) return;
 
-    const pushValues = () => {
-      // Mirror the WHOLE device store, not just the rig-input constraint keys:
-      // outputs, pose/emotion/viseme drivers, and structured values all reach
-      // the native store (and thus WS/ROS2/Studio). Values are already in
-      // arora's serde shape — pass-through, no conversion.
-      //
-      // TODO(ticket): this JS mirror between the device's store and the native
-      // SimpleDataStore is a stopgap; the bridges should attach to the device's
-      // own store instead (single-store architecture).
-      const snapshot = getStoreSnapshot();
-      if (!snapshot) return;
-      const values: Record<string, unknown> = {};
-      for (const [path, value] of Object.entries(snapshot)) {
-        if (value === null || value === undefined) continue;
-        // Internal keys stay device-side: arora's golden keys (`arora/…`) and
-        // the animation module's per-tick out-blob.
-        if (path.startsWith("arora/") || path === "vizij/animations/out") {
-          continue;
-        }
-        // Publish under the canonical store key (leading slash stripped,
-        // "//" collapsed, namespace dropped) — publishing raw aliases yields
-        // empty Zenoh chunks once the bridge prepends "state/{uid}/".
-        values[normalizeSlotPath(path)] = value;
-      }
-      if (Object.keys(values).length > 0) {
-        invoke("publish_values", { values }).catch((err) => {
-          console.error("[vizij-standalone] Failed to publish values:", err);
-        });
+    // The device↔native store bridge, VIZ-74: the device store is canonical;
+    // its changes stream to the native store (and thus WS/ROS2/Studio) as they
+    // happen — no polling, no snapshots after the first. Values are already in
+    // arora's serde shape — pass-through, no conversion. The reverse direction
+    // is the `update-values` Tauri event handled above. The remaining step to
+    // a literal single store is running the device natively (tracked on the
+    // ticket); until then this IPC bridge IS the store seam.
+    const FLUSH_MS = 50;
+    let pending: Record<string, unknown> = {};
+    let flushTimer: number | null = null;
+    let cancelled = false;
+
+    // Internal keys stay device-side: arora's golden keys (`arora/…`) and the
+    // animation module's per-tick out-blob. Everything else publishes under
+    // the canonical store key (leading slash stripped, "//" collapsed,
+    // namespace dropped) — raw aliases yield empty Zenoh chunks once the
+    // bridge prepends "state/{uid}/".
+    const stage = (path: string, value: unknown) => {
+      if (value === null || value === undefined) return;
+      if (path.startsWith("arora/") || path === "vizij/animations/out") return;
+      pending[normalizeSlotPath(path)] = value;
+    };
+
+    const flush = () => {
+      flushTimer = null;
+      if (cancelled) return;
+      const values = pending;
+      pending = {};
+      if (Object.keys(values).length === 0) return;
+      invoke("publish_values", { values }).catch((err) => {
+        console.error("[vizij-standalone] Failed to publish values:", err);
+      });
+    };
+
+    const scheduleFlush = () => {
+      if (flushTimer === null) {
+        flushTimer = window.setTimeout(flush, FLUSH_MS);
       }
     };
 
-    // Push once immediately, then on a 10Hz interval for live data. The native
-    // store is change-only, so re-pushing the full snapshot every tick is cheap.
-    pushValues();
-    const interval = window.setInterval(pushValues, 100);
-    return () => window.clearInterval(interval);
-  }, [ready, getStoreSnapshot, normalizeSlotPath]);
+    // Seed the native store with the full current state once, then stay
+    // current from the per-step change feed.
+    const snapshot = getStoreSnapshot();
+    if (snapshot) {
+      for (const [path, value] of Object.entries(snapshot)) {
+        stage(path, value);
+      }
+      scheduleFlush();
+    }
+    const unsubscribe = subscribeToStoreChanges((changes) => {
+      for (const [path, value] of Object.entries(changes)) {
+        stage(path, value);
+      }
+      scheduleFlush();
+    });
+
+    return () => {
+      cancelled = true;
+      if (flushTimer !== null) window.clearTimeout(flushTimer);
+      unsubscribe();
+    };
+  }, [ready, getStoreSnapshot, subscribeToStoreChanges, normalizeSlotPath]);
 
   return {
     ready,

--- a/packages/@vizij/runtime-react/package.json
+++ b/packages/@vizij/runtime-react/package.json
@@ -38,7 +38,7 @@
     "prepack": "pnpm run build && pnpm run test && pnpm run typecheck && pnpm run lint"
   },
   "dependencies": {
-    "@vizij/animation-module": "^0.1.0",
+    "@vizij/animation-module": "^0.1.1",
     "@vizij/arora-web-wasm": "^0.2.0",
     "@vizij/node-graph-authoring": "workspace:*",
     "@vizij/render": "workspace:*",

--- a/packages/@vizij/runtime-react/src/VizijRuntimeProvider.tsx
+++ b/packages/@vizij/runtime-react/src/VizijRuntimeProvider.tsx
@@ -2136,7 +2136,25 @@ function VizijRuntimeProviderInner({
         return;
       }
       handle.device.step(dt * 1000);
-      applyEngineChangesRef.current(handle.device.drainChanges());
+      const changes = handle.device.drainChanges() as Record<
+        string,
+        ValueJSON | null
+      >;
+      applyEngineChangesRef.current(changes);
+      // Fan this step's store changes to subscribers (e.g. the standalone's
+      // native-store bridge): change-driven, so mirrors need no polling.
+      if (storeChangeListenersRef.current.size > 0) {
+        const paths = Object.keys(changes);
+        if (paths.length > 0) {
+          storeChangeListenersRef.current.forEach((listener) => {
+            try {
+              listener(changes);
+            } catch (err) {
+              console.error("[vizij-runtime] store-change listener error", err);
+            }
+          });
+        }
+      }
       stepListenersRef.current.forEach((listener) => {
         try {
           listener();
@@ -2146,6 +2164,20 @@ function VizijRuntimeProviderInner({
       });
     },
     [deviceSlot],
+  );
+
+  const storeChangeListenersRef = useRef(
+    new Set<(changes: Record<string, unknown>) => void>(),
+  );
+  const subscribeToStoreChanges = useCallback(
+    (listener: (changes: Record<string, unknown>) => void) => {
+      const listeners = storeChangeListenersRef.current;
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    [],
   );
 
   const clearControllers = useCallback(() => {
@@ -3679,6 +3711,7 @@ function VizijRuntimeProviderInner({
       setInput,
       getValueSnapshot: getPathSnapshot,
       getStoreSnapshot,
+      subscribeToStoreChanges,
       subscribeToStep,
       setGraphBundle,
       setValue: setRendererValue,
@@ -3707,6 +3740,7 @@ function VizijRuntimeProviderInner({
       setInput,
       getPathSnapshot,
       getStoreSnapshot,
+      subscribeToStoreChanges,
       subscribeToStep,
       setGraphBundle,
       setRendererValue,

--- a/packages/@vizij/runtime-react/src/types.ts
+++ b/packages/@vizij/runtime-react/src/types.ts
@@ -303,10 +303,19 @@ export type VizijRuntimeContextValue = VizijRuntimeStatus & {
    * A snapshot of EVERY key currently in the device store, as path → Value in
    * arora's serde JSON shape (pass-through from the device; not `ValueJSON`).
    * `undefined` until the device exists. For mirrors/bridges that forward the
-   * whole store (e.g. the standalone's native-store mirror), not for per-path
+   * whole store (e.g. the standalone's native-store bridge), not for per-path
    * sampling — use `getValueSnapshot` for that.
    */
   getStoreSnapshot: () => Record<string, unknown> | undefined;
+  /**
+   * Notifies with each step's drained store changes (path → Value in arora's
+   * serde JSON shape; `null` for a cleared key). The change-driven counterpart
+   * to `getStoreSnapshot` for store bridges: seed from the snapshot, then stay
+   * current from these. Returns an unsubscribe function.
+   */
+  subscribeToStoreChanges: (
+    listener: (changes: Record<string, unknown>) => void,
+  ) => () => void;
   /**
    * Notifies after each engine step, once the step's store changes have been
    * applied. Pair with `getValueSnapshot` to sample values step-aligned.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -890,8 +890,8 @@ importers:
   packages/@vizij/runtime-react:
     dependencies:
       '@vizij/animation-module':
-        specifier: ^0.1.0
-        version: 0.1.0
+        specifier: ^0.1.1
+        version: 0.1.1
       '@vizij/arora-web-wasm':
         specifier: ^0.2.0
         version: 0.2.0
@@ -2673,8 +2673,8 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
-  '@vizij/animation-module@0.1.0':
-    resolution: {integrity: sha512-Ry2xx9dHSN/BDkrUlNMVcYuWdnYMcIiUzJcJip+VB/v7txttq+VqfgEAs74gsPWrhg2Cg0pToWNPQEK78xmb2g==}
+  '@vizij/animation-module@0.1.1':
+    resolution: {integrity: sha512-ZSpZk44S2NM7nAlQty9wMIY9qHQLKJWrOYeqRmuLuAc1h6SnvCyBnx2WVYqYoeojesro782zXFxDL5S7KukDqw==}
 
   '@vizij/animation-wasm@0.4.0':
     resolution: {integrity: sha512-CbDWOZQ73tx/syzGfKjlPwIOo0Hw/v1TK4JYg/rpuyBQAaGP7pFzxYyYVZ8cj1bEPV6gJO9jk+5jxt0Q2QgnIw==}
@@ -6919,7 +6919,7 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
-  '@vizij/animation-module@0.1.0': {}
+  '@vizij/animation-module@0.1.1': {}
 
   '@vizij/animation-wasm@0.4.0':
     dependencies:


### PR DESCRIPTION
First increment of VIZ-74 (single-store architecture). The device store is canonical; the webview→native mirror no longer polls 10 Hz full snapshots — it forwards exactly what changes:

- `@vizij/runtime-react`: `subscribeToStoreChanges(listener)` (additive) — fans each step's drained store changes (path → arora-serde Value, `null` = cleared) to subscribers, right where the render store already consumes them.
- standalone: seeds the native store from one `getStoreSnapshot()`, then streams changes batched into `publish_values` flushes (≤50 ms). Internal keys (`arora/*`, the animation module's out-blob) stay device-side, as before.
- Reverse direction unchanged (`update-values` Tauri event).

Honest scope note: a literal single store can't span the webview/native process boundary while the device runs in the webview — this makes the IPC the store seam (change-driven, bidirectional, device-canonical). The end-state — running the device natively over its `BlackboardStore` via `AroraBuilder::run()` (arora-sdk #162) — stays tracked on the ticket.

Verified: runtime-react build + 75/75 tests, `typecheck:all` clean, prettier clean.