### PR TITLE
fix(vite): never pre-bundle @vizij/animation-module

### DIFF
--- a/apps/demo-vizij-player/vite.config.ts
+++ b/apps/demo-vizij-player/vite.config.ts
@@ -39,7 +39,11 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
-    exclude: ["@vizij/node-graph-wasm", "@vizij/arora-web-wasm"],
+    exclude: [
+      "@vizij/node-graph-wasm",
+      "@vizij/arora-web-wasm",
+      "@vizij/animation-module",
+    ],
     include: ["@vizij/render"],
   },
 });

--- a/apps/tutorial-agent-face/vite.config.ts
+++ b/apps/tutorial-agent-face/vite.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
-    exclude: ["@vizij/arora-web-wasm"],
+    exclude: ["@vizij/arora-web-wasm", "@vizij/animation-module"],
     include: ["@vizij/render"],
   },
 });

--- a/apps/tutorial-fullscreen-face/vite.config.ts
+++ b/apps/tutorial-fullscreen-face/vite.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
-    exclude: ["@vizij/arora-web-wasm"],
+    exclude: ["@vizij/arora-web-wasm", "@vizij/animation-module"],
     include: ["@vizij/render"],
   },
 });

--- a/apps/vizij-authoring/vite.config.ts
+++ b/apps/vizij-authoring/vite.config.ts
@@ -83,6 +83,7 @@ export default defineConfig(({ mode }) => {
         "@vizij/animation-wasm",
         "@vizij/node-graph-wasm",
         "@vizij/arora-web-wasm",
+        "@vizij/animation-module",
       ],
       include: ["@vizij/node-graph-react"],
       force: true,

--- a/apps/vizij-showcase/vite.config.ts
+++ b/apps/vizij-showcase/vite.config.ts
@@ -39,7 +39,11 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
-    exclude: ["@vizij/node-graph-wasm", "@vizij/arora-web-wasm"],
+    exclude: [
+      "@vizij/node-graph-wasm",
+      "@vizij/arora-web-wasm",
+      "@vizij/animation-module",
+    ],
     include: ["@vizij/render"],
   },
 });

--- a/apps/vizij-standalone/src-tauri/tauri.conf.json
+++ b/apps/vizij-standalone/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Vizij Standalone",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "identifier": "com.vizij.standalone",
   "build": {
     "beforeDevCommand": "pnpm run vite",

--- a/apps/vizij-standalone/vite.config.ts
+++ b/apps/vizij-standalone/vite.config.ts
@@ -50,7 +50,11 @@ export default defineConfig(async () => ({
     },
   },
   optimizeDeps: {
-    exclude: ["@vizij/node-graph-wasm", "@vizij/arora-web-wasm"],
+    exclude: [
+      "@vizij/node-graph-wasm",
+      "@vizij/arora-web-wasm",
+      "@vizij/animation-module",
+    ],
     include: [
       "@vizij/node-graph-react",
       "@vizij/node-graph-authoring",


### PR DESCRIPTION
Vite's dep optimizer relocated `@vizij/animation-module` into `.vite/deps`, breaking its `new URL("../artifact/…", import.meta.url)` wasm reference — the dev server's SPA fallback answered the fetch with HTML and the device failed to start with `WebAssembly.Module doesn't parse at byte 0: module doesn't start with '\\0asm'`. Excludes the package from `optimizeDeps` in every runtime-react consumer app, exactly like the sibling wasm packages (`arora-web-wasm`, `node-graph-wasm`). Dev-server-only behavior; production builds already emitted the asset correctly.