### PR TITLE
fix(standalone): persist a DEVICE_OWNERS override

### DIFF
--- a/apps/vizij-standalone/src-tauri/src/lib.rs
+++ b/apps/vizij-standalone/src-tauri/src/lib.rs
@@ -1493,6 +1493,13 @@ pub fn run() {
                     .map(|s| parse_owners(&s))
                     .unwrap_or_default();
                 let (initial_owners, needs_prompt) = if !env_owners.is_empty() {
+                    // An env override becomes the persisted choice too, so the
+                    // next launch WITHOUT `DEVICE_OWNERS` keeps these owners
+                    // (and the device identity stays claimable) instead of
+                    // falling back to the previous persisted value or a prompt.
+                    if let Err(e) = persist_studio_owners(handle, &env_owners) {
+                        log::warn!("studio-bridge: failed to persist DEVICE_OWNERS override: {e}");
+                    }
                     (env_owners, false)
                 } else if let Some(persisted) = read_persisted_owners(handle) {
                     (persisted, false)


### PR DESCRIPTION
An owners override from the `DEVICE_OWNERS` env var was used for the session but never written to the persistent owner file, so the next launch **without** the variable fell back to the previous persisted choice or the prompt. The override now writes through `persist_studio_owners` (the same path as the UI owner choice), best-effort with a warning on failure.

Verified: `cargo check --features studio-bridge` clean, studio-bridge tests 4/4.