### PR TITLE
fix(runtime-react): infer suspensions in the step loop (no dt from suspended time)

### DIFF
--- a/packages/@vizij/runtime-react/src/VizijRuntimeProvider.tsx
+++ b/packages/@vizij/runtime-react/src/VizijRuntimeProvider.tsx
@@ -120,6 +120,28 @@ type LoopMode = "active" | "idle-visible" | "idle-hidden" | "stopped";
 const ACTIVE_GRACE_MS = 250;
 const VISIBLE_IDLE_FPS = 30;
 const HIDDEN_IDLE_FPS = 1;
+// The step loops follow the native engine driver contract: engine time
+// advances whenever steps run, and never across a suspension. A pause is a
+// SUSPENSION — the host stopped scheduling JS entirely (e.g. an OS-suspended
+// WebView) — detected as an inter-step wall-clock gap beyond this threshold,
+// far outside any plausible frame period. A detected suspension re-baselines
+// the clock and steps with dt = 0, so the paused span never reaches the
+// engine. Document visibility is deliberately NOT a pause signal: hidden
+// pages are expected to keep running (the interval fallback keeps ticking,
+// rAF throttles as the browser decides) with their real dt.
+const IMPLICIT_PAUSE_GAP_S = 5;
+
+const inferImplicitPause = (dt: number): number => {
+  if (dt <= IMPLICIT_PAUSE_GAP_S) {
+    return dt;
+  }
+  console.warn(
+    `[vizij-runtime] step loop woke after a ${dt.toFixed(
+      1,
+    )}s wall-clock gap; treating it as a suspension (dt = 0)`,
+  );
+  return 0;
+};
 
 const DEFAULT_MERGE: MergeStrategyOptions = {
   outputs: "add",
@@ -3598,7 +3620,9 @@ function VizijRuntimeProviderInner({
       if (lastTime == null) {
         lastTime = timestamp;
       }
-      const dt = Math.max(0, (timestamp - lastTime) / 1000);
+      // dt is measured between consecutive frames; an implausible gap
+      // means the host suspended the loop (see IMPLICIT_PAUSE_GAP_S).
+      const dt = inferImplicitPause(Math.max(0, (timestamp - lastTime) / 1000));
       lastTime = timestamp;
       step(dt || 0);
       requestLoopMode(computeDesiredLoopMode());
@@ -3634,7 +3658,9 @@ function VizijRuntimeProviderInner({
         return;
       }
       const current = now();
-      const dt = Math.max(0, (current - lastTime) / 1000);
+      // dt is measured between consecutive ticks; an implausible gap
+      // means the host suspended the loop (see IMPLICIT_PAUSE_GAP_S).
+      const dt = inferImplicitPause(Math.max(0, (current - lastTime) / 1000));
       lastTime = current;
       step(dt || 0);
       requestLoopMode(computeDesiredLoopMode());


### PR DESCRIPTION
## Problem

When the OS suspends a backgrounded WebView (e.g. an Android app going to the background), no JS runs at all — rAF and timers stop being scheduled. On resume, the step loops in `VizijRuntimeProvider` measured `dt` as the **entire suspension** and fed it to the engine in a single step:

- **Spring nodes** use single-step semi-implicit Euler integration; a multi-second `dt` makes them numerically explode, producing violent motions/emotions on resume.
- **Noise/oscillator nodes** see their time input teleport forward.
- **Animation playback** fast-forwards by the suspension duration.

## Contract

The loops follow the native engine driver's semantics: **engine time advances whenever steps run, and never across a suspension.**

- **A pause is a suspension** — the host stopped scheduling JS entirely — detected as an inter-step wall-clock gap beyond `IMPLICIT_PAUSE_GAP_S` (5 s), far outside any plausible frame period. A detected suspension logs a `console.warn` naming the gap, re-baselines the clock, and runs that step with `dt = 0`, so the paused span never reaches the engine.
- **Visibility is deliberately NOT a pause signal**: hidden pages are expected to keep running — the interval fallback keeps ticking, rAF throttles as the browser decides — and their steps carry their real `dt`. Hidden-state behavior is exactly as on `main`.
- This is discrete suspension detection, not a per-frame cap: ordinary large frames (e.g. 0.3 s of jank) pass through unmodified. (An earlier revision clamped `dt` per frame — rejected, since clamping silently rewrites time. A later revision paused on `visibilitychange` — also rejected, since hidden webviews should keep running.)

## Notes

- While hidden, the fallback loop steps at a low rate, so `dt` can reach ~1 s; single-step spring integration is unstable at such `dt`. That pre-existing characteristic is unchanged here and is addressed by the separately tracked engine-side spring hardening (substepping).
- Validated with `pnpm --filter @vizij/runtime-react typecheck`, `lint`, and `test` (75 tests passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)