### PR TITLE
experiment(runtime-react): setInterval-driven step loop (instead of rAF)

### DIFF
--- a/packages/@vizij/runtime-react/src/VizijRuntimeProvider.tsx
+++ b/packages/@vizij/runtime-react/src/VizijRuntimeProvider.tsx
@@ -118,6 +118,13 @@ type ProgramTransportState = {
 type LoopMode = "active" | "idle-visible" | "idle-hidden" | "stopped";
 
 const ACTIVE_GRACE_MS = 250;
+// EXPERIMENT: the active loop steps on a setInterval timer at this rate
+// instead of requestAnimationFrame. Timers keep firing while the document
+// is hidden (Chromium throttles them to >= 1 s) whereas rAF stops
+// entirely; the trade-off is that steps are no longer frame-aligned. dt is
+// still the measured wall-clock delta between fires, not the nominal
+// period.
+const ACTIVE_STEP_HZ = 60;
 const VISIBLE_IDLE_FPS = 30;
 const HIDDEN_IDLE_FPS = 1;
 // The step loops follow the native engine driver contract: engine time
@@ -3611,28 +3618,29 @@ function VizijRuntimeProviderInner({
     if (loopMode !== "active") {
       return;
     }
-    let rafId: number | null = null;
+    if (typeof window === "undefined") {
+      return;
+    }
     let lastTime: number | null = null;
-    const tick = (timestamp: number) => {
+    const interval = 1000 / ACTIVE_STEP_HZ;
+    const tick = () => {
       if (loopModeRef.current !== "active") {
         return;
       }
+      const timestamp = now();
       if (lastTime == null) {
         lastTime = timestamp;
       }
-      // dt is measured between consecutive frames; an implausible gap
+      // dt is measured between consecutive fires; an implausible gap
       // means the host suspended the loop (see IMPLICIT_PAUSE_GAP_S).
       const dt = inferImplicitPause(Math.max(0, (timestamp - lastTime) / 1000));
       lastTime = timestamp;
       step(dt || 0);
       requestLoopMode(computeDesiredLoopMode());
-      rafId = requestAnimationFrame(tick);
     };
-    rafId = requestAnimationFrame(tick);
+    const intervalId = window.setInterval(tick, interval);
     return () => {
-      if (rafId !== null) {
-        cancelAnimationFrame(rafId);
-      }
+      window.clearInterval(intervalId);
     };
   }, [loopMode, computeDesiredLoopMode, requestLoopMode, step]);
 


### PR DESCRIPTION
## Purpose

An experiment for on-device evaluation, **not a decided direction**: drive the active step loop with `setInterval` at `ACTIVE_STEP_HZ` (60 Hz, ~16.7 ms period) instead of `requestAnimationFrame`. The motivation is hidden-state behavior — Chromium throttles background timers to >= 1 s but keeps them firing, whereas rAF stops entirely, so with a timer driver the runtime keeps stepping (slowly) while the page is hidden.

`dt` remains the measured `performance.now()` delta between fires (real dt, not the nominal period), with the suspension inference from #75 still applied. Only the active driver changes: the idle/interval fallback loop, all loop-mode switching, and rendering paths are untouched.

## Expected consequences to observe

- **Visual jitter / beat frequency vs vsync**: steps are no longer frame-aligned; a 60 Hz timer beats against the display refresh, which may show as periodic judder.
- **Hidden-state stepping at ~1 Hz with dt ≈ 1 s**: single-step spring integration can ring at such dt — engine-side spring hardening (substepping) is tracked separately.
- **Process freeze still stops timers** (OS-suspended WebView): handled by the stacked suspension inference — the first fire after resume observes the whole gap and steps with dt = 0.

## Stacking

Deliberately stacked on #75 (`fix/resume-dt-clamp`) so the suspension inference is present in the test build — resume-after-freeze must not explode and muddy observations. The PR base is set to `fix/resume-dt-clamp` for a clean diff; it re-targets `main` when #75 merges (and must be rebased if #75 changes). Merge order: #75 first.

## Validation

`pnpm --filter @vizij/runtime-react typecheck`, `lint`, and `test` (75 tests passing); prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)