### PR TITLE
feat(authoring): Face Bounds tooling to customize the face bounding box

### DIFF
--- a/apps/vizij-authoring/src/App.tsx
+++ b/apps/vizij-authoring/src/App.tsx
@@ -3049,6 +3049,10 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
     loadingCoordinatorSettled &&
     !loadingSessionActive &&
     !isLoading;
+  const rootBoundsForExport = rootId
+    ? ((runtimeWorld[rootId] as { rootBounds?: unknown } | undefined)
+        ?.rootBounds ?? null)
+    : null;
   const exportDirtySnapshot = useMemo(
     () =>
       buildGlbExportDirtySnapshot({
@@ -3058,6 +3062,7 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
         animatables,
         animatableComponents,
         featureLabelOverrides,
+        rootBounds: rootBoundsForExport,
         standardInputs,
         bindings,
         inputBindings,
@@ -3089,6 +3094,7 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
       poseRig.poseGraphFileName,
       poseRig.poseGraphSpec,
       poseRig.poseIrDraft,
+      rootBoundsForExport,
       standardInputs,
     ],
   );

--- a/apps/vizij-authoring/src/components/app/Viewer.test.tsx
+++ b/apps/vizij-authoring/src/components/app/Viewer.test.tsx
@@ -36,6 +36,9 @@ const setGraphBundleSpy = vi.fn((payload: unknown) => {
   }
 });
 const setVizijStoreSpy = vi.fn();
+const getVizijStoreStateSpy = vi.fn(() => ({
+  world: {} as Record<string, unknown>,
+}));
 const stopAnimationSpy = vi.fn();
 const setAnimationActiveSpy = vi.fn();
 const pauseAnimationSpy = vi.fn();
@@ -59,6 +62,8 @@ vi.mock("@vizij/render", () => ({
       world: {},
     }),
   useVizijStoreSetter: () => setVizijStoreSpy,
+  useVizijStoreGetter: () => getVizijStoreStateSpy,
+  deriveRootBounds: () => null,
 }));
 
 vi.mock("@vizij/runtime-react", () => ({

--- a/apps/vizij-authoring/src/components/app/Viewer.tsx
+++ b/apps/vizij-authoring/src/components/app/Viewer.tsx
@@ -11,7 +11,12 @@ import {
   useRef,
 } from "react";
 import { useVizijRuntime } from "@vizij/runtime-react";
-import { useVizijStore, useVizijStoreSetter } from "@vizij/render";
+import {
+  deriveRootBounds,
+  useVizijStore,
+  useVizijStoreGetter,
+  useVizijStoreSetter,
+} from "@vizij/render";
 import type { StandardRigInput } from "@vizij/utils";
 import { Button } from "../ui";
 import { MotionGraphDriverBridge } from "../../motiongraph/MotionGraphDriverBridge";
@@ -28,6 +33,7 @@ import {
   useGraphRuntimeStoreApi,
 } from "../../state/RigControllerProvider";
 import { useAnimationStore } from "../../state/animationStore";
+import { useWorkspaceStore } from "../../state/workspaceStore";
 import { AnimationRuntimeBridge } from "../../hooks/useAnimationTransport";
 import type { AnimationClipIR } from "../../types/animationClipIr";
 import {
@@ -227,6 +233,88 @@ function RuntimeInputBridge() {
     },
     [graphRuntimeStore],
   );
+
+  return null;
+}
+
+type FaceBounds = {
+  center: { x: number; y: number };
+  size: { x: number; y: number };
+};
+
+function faceBoundsEqual(a: FaceBounds, b: FaceBounds): boolean {
+  return (
+    a.center.x === b.center.x &&
+    a.center.y === b.center.y &&
+    a.size.x === b.size.x &&
+    a.size.y === b.size.y
+  );
+}
+
+function FaceBoundsRuntimeBridge() {
+  const { rootId } = useVizijRuntime();
+  const getVizijState = useVizijStoreGetter();
+  const setRuntimeStoreState = useVizijStoreSetter();
+  const graphRuntimeStore = useGraphRuntimeStoreApi();
+  const authoredBounds = useGraphRuntime((state) => {
+    if (!rootId) {
+      return undefined;
+    }
+    const entry = state.world[rootId] as
+      | { type?: string; rootBounds?: FaceBounds }
+      | undefined;
+    return entry?.type === "group" ? entry.rootBounds : undefined;
+  });
+
+  // Lets the inspector's "Fit to Geometry" measure the rendered face.
+  useEffect(() => {
+    graphRuntimeStore.setState({
+      measureFaceGeometryBounds: rootId
+        ? () => {
+            const state = getVizijState();
+            const refs = Object.values(state.world[rootId]?.refs ?? {});
+            const target = refs.find((ref) => ref?.current)?.current ?? null;
+            return target
+              ? deriveRootBounds(
+                  target as Parameters<typeof deriveRootBounds>[0],
+                )
+              : null;
+          }
+        : undefined,
+    });
+  }, [getVizijState, graphRuntimeStore, rootId]);
+
+  useEffect(
+    () => () => {
+      graphRuntimeStore.setState({ measureFaceGeometryBounds: undefined });
+    },
+    [graphRuntimeStore],
+  );
+
+  // The runtime view renders from its own isolated store, so authored bounds
+  // edits are pushed into it here for the camera and safe-area overlay.
+  useEffect(() => {
+    if (!rootId || !authoredBounds) {
+      return;
+    }
+    setRuntimeStoreState((state) => {
+      const entry = state.world[rootId];
+      if (!entry || entry.type !== "group") {
+        return state;
+      }
+      const current = (entry as { rootBounds?: FaceBounds }).rootBounds;
+      if (current && faceBoundsEqual(current, authoredBounds)) {
+        return state;
+      }
+      return {
+        ...state,
+        world: {
+          ...state.world,
+          [rootId]: { ...entry, root: true, rootBounds: authoredBounds },
+        },
+      };
+    });
+  }, [authoredBounds, rootId, setRuntimeStoreState]);
 
   return null;
 }
@@ -567,6 +655,9 @@ export function Viewer({
   onRuntimeExportBodiesChange,
 }: ViewerProps) {
   const graphRuntimeStore = useGraphRuntimeStoreApi();
+  const faceBoundsOverlayVisible = useWorkspaceStore(
+    (state) => state.faceBoundsOverlayVisible,
+  );
   const runtimeWarning = useGraphRuntime((state) => state.graphWarning);
   const runtimeError = useGraphRuntime((state) => state.graphError);
   const plotActive = useEditorStore((state) => state.plotActive);
@@ -706,6 +797,7 @@ export function Viewer({
               />
             ) : null}
             <RuntimeInputBridge />
+            <FaceBoundsRuntimeBridge />
             <RuntimeGraphBridge />
             <AnimationRuntimeBridge
               active={animationSourceActive}
@@ -737,7 +829,7 @@ export function Viewer({
             <div data-testid="main-runtime-view" className="h-full w-full">
               <VizijRuntimeFace
                 className="h-full w-full"
-                showSafeArea={false}
+                showSafeArea={faceBoundsOverlayVisible}
                 showSelectionGlow={showSelectionGlow}
                 onPointerMissed={() => {
                   onClearSelection();

--- a/apps/vizij-authoring/src/components/inspector/FaceBoundsSection.tsx
+++ b/apps/vizij-authoring/src/components/inspector/FaceBoundsSection.tsx
@@ -1,0 +1,243 @@
+import { useCallback, useRef } from "react";
+import { Scan } from "lucide-react";
+import type { Group as VizijGroup } from "@vizij/render";
+import type { SceneObjectNode } from "../../scene/sceneGraph";
+import { useGraphRuntime } from "../../state/RigControllerProvider";
+import { useWorkspaceStore } from "../../state/workspaceStore";
+import { Button, Switch } from "../ui";
+import { CommitOnBlurNumberInput, ScrubbableLabel } from "./RiggingPropertyRow";
+
+type FaceBounds = NonNullable<VizijGroup["rootBounds"]>;
+
+// Mirrors the fallback the renderer uses when a root group has no bounds.
+const FALLBACK_BOUNDS: FaceBounds = {
+  center: { x: 0, y: 0 },
+  size: { x: 5, y: 4 },
+};
+
+const MIN_BOUNDS_SIZE = 1e-3;
+
+function formatBoundsNumber(value: number): string {
+  return String(Number(value.toFixed(4)));
+}
+
+interface BoundsFieldProps {
+  label: string;
+  value: number;
+  step: number;
+  testId: string;
+  onCommit: (value: number) => void;
+}
+
+function BoundsField({ label, value, step, testId, onCommit }: BoundsFieldProps) {
+  const scrubStartRef = useRef(0);
+  return (
+    <div
+      data-testid={testId}
+      className="flex items-center bg-bg-input/50 rounded-sm border border-transparent relative flex-1 min-w-0 h-5 focus-within:border-accent/50"
+    >
+      <ScrubbableLabel
+        label={label}
+        className="text-[9px] font-bold px-1 text-text-secondary"
+        onScrubStart={() => {
+          scrubStartRef.current = value;
+        }}
+        onScrub={(_, totalDelta) => {
+          onCommit(scrubStartRef.current + totalDelta * step);
+        }}
+      />
+      <CommitOnBlurNumberInput
+        value={value}
+        step={step}
+        formatValue={formatBoundsNumber}
+        onCommit={onCommit}
+      />
+    </div>
+  );
+}
+
+interface FaceBoundsSectionProps {
+  node: SceneObjectNode;
+}
+
+/**
+ * Inspector section for the face's camera bounding box (`rootBounds` on the
+ * root group). The runtime camera crops the face to this rectangle, so
+ * editing it reframes the face everywhere it renders.
+ */
+export function FaceBoundsSection({ node }: FaceBoundsSectionProps) {
+  const world = useGraphRuntime((state) => state.world);
+  const setStoreState = useGraphRuntime((state) => state.setStoreState);
+  const runtimeViewRootId = useGraphRuntime((state) => state.runtimeViewRootId);
+  const measureFaceGeometryBounds = useGraphRuntime(
+    (state) => state.measureFaceGeometryBounds,
+  );
+  const overlayVisible = useWorkspaceStore(
+    (state) => state.faceBoundsOverlayVisible,
+  );
+  const setOverlayVisible = useWorkspaceStore(
+    (state) => state.setFaceBoundsOverlayVisible,
+  );
+
+  const applyBounds = useCallback(
+    (updater: (current: FaceBounds) => FaceBounds) => {
+      setStoreState((state) => {
+        const entry = state.world[node.id];
+        if (!entry || entry.type !== "group") {
+          return state;
+        }
+        const next = updater(entry.rootBounds ?? FALLBACK_BOUNDS);
+        const sanitized: FaceBounds = {
+          center: { x: next.center.x, y: next.center.y },
+          size: {
+            x: Math.max(Math.abs(next.size.x), MIN_BOUNDS_SIZE),
+            y: Math.max(Math.abs(next.size.y), MIN_BOUNDS_SIZE),
+          },
+        };
+        return {
+          ...state,
+          world: {
+            ...state.world,
+            [node.id]: { ...entry, root: true, rootBounds: sanitized },
+          },
+        };
+      });
+    },
+    [node.id, setStoreState],
+  );
+
+  const handleFitToGeometry = useCallback(() => {
+    const measured = measureFaceGeometryBounds?.();
+    if (!measured) {
+      return;
+    }
+    applyBounds(() => measured);
+  }, [applyBounds, measureFaceGeometryBounds]);
+
+  const entry = world[node.id] as VizijGroup | undefined;
+  const isFaceRoot =
+    entry?.type === "group" &&
+    (Boolean(entry.rootBounds) ||
+      entry.root === true ||
+      node.id === runtimeViewRootId);
+
+  if (!isFaceRoot) {
+    return null;
+  }
+
+  const bounds = entry?.rootBounds ?? FALLBACK_BOUNDS;
+  const hasStoredBounds = Boolean(entry?.rootBounds);
+  const scrubStep = Math.max(
+    0.01,
+    Math.max(bounds.size.x, bounds.size.y) / 200,
+  );
+  const aspect =
+    bounds.size.y > 0 ? bounds.size.x / bounds.size.y : Number.NaN;
+
+  return (
+    <div
+      data-testid="face-bounds-section"
+      className="flex flex-col gap-1 p-1.5 bg-bg-panel/40 rounded-lg border border-border-default/50"
+    >
+      <div className="flex items-center justify-between px-0.5">
+        <div className="text-[9px] font-bold text-text-secondary uppercase tracking-wider">
+          Face Bounds
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span className="text-[9px] text-text-muted">Show</span>
+          <Switch
+            data-testid="face-bounds-overlay-toggle"
+            size="sm"
+            checked={overlayVisible}
+            onChange={setOverlayVisible}
+          />
+        </div>
+      </div>
+      <p className="px-0.5 text-[10px] leading-tight text-text-muted">
+        The camera crops the face to this box. Toggle Show to see it in the
+        viewport.
+      </p>
+      <div className="flex items-center gap-1.5">
+        <span className="w-12 shrink-0 text-[10px] text-text-secondary">
+          Center
+        </span>
+        <BoundsField
+          label="X"
+          testId="face-bounds-center-x"
+          value={bounds.center.x}
+          step={scrubStep}
+          onCommit={(value) =>
+            applyBounds((current) => ({
+              ...current,
+              center: { ...current.center, x: value },
+            }))
+          }
+        />
+        <BoundsField
+          label="Y"
+          testId="face-bounds-center-y"
+          value={bounds.center.y}
+          step={scrubStep}
+          onCommit={(value) =>
+            applyBounds((current) => ({
+              ...current,
+              center: { ...current.center, y: value },
+            }))
+          }
+        />
+      </div>
+      <div className="flex items-center gap-1.5">
+        <span className="w-12 shrink-0 text-[10px] text-text-secondary">
+          Size
+        </span>
+        <BoundsField
+          label="W"
+          testId="face-bounds-size-x"
+          value={bounds.size.x}
+          step={scrubStep}
+          onCommit={(value) =>
+            applyBounds((current) => ({
+              ...current,
+              size: { ...current.size, x: value },
+            }))
+          }
+        />
+        <BoundsField
+          label="H"
+          testId="face-bounds-size-y"
+          value={bounds.size.y}
+          step={scrubStep}
+          onCommit={(value) =>
+            applyBounds((current) => ({
+              ...current,
+              size: { ...current.size, y: value },
+            }))
+          }
+        />
+      </div>
+      <div className="flex items-center justify-between gap-1.5 px-0.5">
+        <span className="text-[9px] text-text-muted">
+          {Number.isFinite(aspect)
+            ? `Aspect ${aspect.toFixed(3)}`
+            : "Aspect —"}
+          {hasStoredBounds ? "" : " · using default bounds"}
+        </span>
+        <Button
+          data-testid="face-bounds-fit-geometry"
+          variant="ghost"
+          size="sm"
+          disabled={!measureFaceGeometryBounds}
+          onClick={handleFitToGeometry}
+          title={
+            measureFaceGeometryBounds
+              ? "Recompute the bounds from the rendered face geometry"
+              : "Available while the runtime preview is mounted"
+          }
+        >
+          <Scan size={12} className="mr-1 shrink-0" />
+          Fit to Geometry
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/vizij-authoring/src/components/inspector/FaceBoundsSection.tsx
+++ b/apps/vizij-authoring/src/components/inspector/FaceBoundsSection.tsx
@@ -29,7 +29,13 @@ interface BoundsFieldProps {
   onCommit: (value: number) => void;
 }
 
-function BoundsField({ label, value, step, testId, onCommit }: BoundsFieldProps) {
+function BoundsField({
+  label,
+  value,
+  step,
+  testId,
+  onCommit,
+}: BoundsFieldProps) {
   const scrubStartRef = useRef(0);
   return (
     <div
@@ -131,8 +137,7 @@ export function FaceBoundsSection({ node }: FaceBoundsSectionProps) {
     0.01,
     Math.max(bounds.size.x, bounds.size.y) / 200,
   );
-  const aspect =
-    bounds.size.y > 0 ? bounds.size.x / bounds.size.y : Number.NaN;
+  const aspect = bounds.size.y > 0 ? bounds.size.x / bounds.size.y : Number.NaN;
 
   return (
     <div
@@ -217,9 +222,7 @@ export function FaceBoundsSection({ node }: FaceBoundsSectionProps) {
       </div>
       <div className="flex items-center justify-between gap-1.5 px-0.5">
         <span className="text-[9px] text-text-muted">
-          {Number.isFinite(aspect)
-            ? `Aspect ${aspect.toFixed(3)}`
-            : "Aspect —"}
+          {Number.isFinite(aspect) ? `Aspect ${aspect.toFixed(3)}` : "Aspect —"}
           {hasStoredBounds ? "" : " · using default bounds"}
         </span>
         <Button

--- a/apps/vizij-authoring/src/components/inspector/InspectorContent.tsx
+++ b/apps/vizij-authoring/src/components/inspector/InspectorContent.tsx
@@ -73,6 +73,7 @@ import { resolveRigMetadataInputId } from "../../utils/rigElementInputs";
 import { RiggingPropertyRow } from "./RiggingPropertyRow";
 import { VariableSelector, type VariableSelection } from "./VariableSelector";
 import { InspectorHeader } from "./InspectorHeader";
+import { FaceBoundsSection } from "./FaceBoundsSection";
 import { RiggingTransformSection } from "./RiggingTransformSection";
 import { BindingConnections } from "./BindingConnections";
 import { RiggingMorphTargetsSection } from "./RiggingMorphTargetsSection";
@@ -2619,6 +2620,7 @@ export function InspectorContent({
               </Button>
             </div>
           ) : null}
+          <FaceBoundsSection node={node} />
           <RiggingTransformSection node={node} />
 
           <RiggingMorphTargetsSection node={node} />

--- a/apps/vizij-authoring/src/hooks/__tests__/useExportDirtyState.test.tsx
+++ b/apps/vizij-authoring/src/hooks/__tests__/useExportDirtyState.test.tsx
@@ -56,6 +56,7 @@ function createSnapshotOptions(
       },
     ],
     featureLabelOverrides: {},
+    rootBounds: null,
     standardInputs: [INPUT],
     bindings: {
       [ANIMATABLE.id]: {
@@ -137,6 +138,20 @@ describe("buildGlbExportDirtySnapshot", () => {
           ...ANIMATABLE,
           default: 0.4,
         },
+      },
+    });
+
+    expect(first).not.toEqual(second);
+  });
+
+  it("tracks face bounds changes even when bundle export is disabled", () => {
+    const base = createSnapshotOptions({ includeVizijBundle: false });
+    const first = buildGlbExportDirtySnapshot(base);
+    const second = buildGlbExportDirtySnapshot({
+      ...base,
+      rootBounds: {
+        center: { x: 0, y: 0.5 },
+        size: { x: 6, y: 4 },
       },
     });
 

--- a/apps/vizij-authoring/src/hooks/useExportDirtyState.ts
+++ b/apps/vizij-authoring/src/hooks/useExportDirtyState.ts
@@ -24,6 +24,7 @@ export interface GlbExportDirtySnapshotOptions {
   animatables: Record<string, AnimatableValue>;
   animatableComponents: AnimatableComponent[];
   featureLabelOverrides: Record<string, string>;
+  rootBounds: unknown;
   standardInputs: StandardRigInput[];
   bindings: BindingMap;
   inputBindings: InputBindingMap;
@@ -46,6 +47,7 @@ export function buildGlbExportDirtySnapshot(
     animatables: options.animatables,
     animatableComponents: options.animatableComponents,
     featureLabelOverrides: options.featureLabelOverrides,
+    rootBounds: options.rootBounds ?? null,
   };
 
   if (!options.includeVizijBundle) {

--- a/apps/vizij-authoring/src/state/graphRuntimeStore.tsx
+++ b/apps/vizij-authoring/src/state/graphRuntimeStore.tsx
@@ -66,6 +66,15 @@ export interface GraphRuntimeState {
   runtimeViewRootId: string | null;
   runtimeViewGraphCount: number;
   runtimeViewOutputCount: number;
+  /**
+   * Measures the rendered face geometry in the runtime view and returns its
+   * 2D bounding box, or null when nothing is mounted. Registered by the
+   * viewer's runtime bridge while a face is loaded.
+   */
+  measureFaceGeometryBounds?: () => {
+    center: { x: number; y: number };
+    size: { x: number; y: number };
+  } | null;
 }
 
 type GraphRuntimeStoreUpdate =
@@ -121,6 +130,7 @@ const defaultGraphRuntimeState: GraphRuntimeState = {
   runtimeViewRootId: null,
   runtimeViewGraphCount: 0,
   runtimeViewOutputCount: 0,
+  measureFaceGeometryBounds: undefined,
 };
 
 export function createGraphRuntimeStore(

--- a/apps/vizij-authoring/src/state/workspaceStore.ts
+++ b/apps/vizij-authoring/src/state/workspaceStore.ts
@@ -30,6 +30,9 @@ interface WorkspaceState {
     panelId: keyof WorkspaceState["panels"],
     isVisible: boolean,
   ) => void;
+  /** Draws the face bounds (camera safe area) rectangle over the main viewport. */
+  faceBoundsOverlayVisible: boolean;
+  setFaceBoundsOverlayVisible: (isVisible: boolean) => void;
 }
 
 export type WorkspacePanels = WorkspaceState["panels"];
@@ -95,6 +98,9 @@ export function createInitialWorkspacePanels(): WorkspacePanels {
 
 export const useWorkspaceStore = create<WorkspaceState>((set) => ({
   panels: createInitialWorkspacePanels(),
+  faceBoundsOverlayVisible: false,
+  setFaceBoundsOverlayVisible: (isVisible) =>
+    set({ faceBoundsOverlayVisible: isVisible }),
   togglePanel: (panelId) =>
     set((state) => {
       const nextVisibility = !state.panels[panelId].isVisible;

--- a/packages/@vizij/render/src/functions/gltf-loading/traverse-three.ts
+++ b/packages/@vizij/render/src/functions/gltf-loading/traverse-three.ts
@@ -317,7 +317,7 @@ function isRectangleFeatures(
   }
 }
 
-function deriveRootBounds(
+export function deriveRootBounds(
   group: Group,
 ): { center: RawVector2; size: RawVector2 } | null {
   const boundingBox = new THREE.Box3().setFromObject(group);

--- a/packages/@vizij/render/src/index.tsx
+++ b/packages/@vizij/render/src/index.tsx
@@ -9,6 +9,7 @@ export * from "./hooks/use-features";
 export * from "./hooks/use-vizij-store-setter";
 export * from "./hooks/use-vizij-store-getter";
 export * from "./functions/load-gltf";
+export { deriveRootBounds } from "./functions/gltf-loading/traverse-three";
 export * from "./functions/load-gltf-blob";
 export * from "./functions/export";
 export * from "./functions/vizij-bundle";

--- a/packages/@vizij/render/src/store-types.ts
+++ b/packages/@vizij/render/src/store-types.ts
@@ -3,7 +3,7 @@ import type * as THREE from "three";
 import type { Group, Mesh } from "three";
 import type { ThreeEvent } from "@react-three/fiber";
 import type { MouseEvent as ReactMouseEvent } from "react";
-import type { RawValue, AnimatableValue } from "@vizij/utils";
+import type { RawValue, RawVector2, AnimatableValue } from "@vizij/utils";
 import type { World, Selection, RenderableFeature } from "./types";
 
 export interface VizijData {
@@ -64,6 +64,10 @@ export interface VizijActions {
   setOrigin: (
     id: string,
     origin: { translation?: THREE.Vector3; rotation?: THREE.Vector3 },
+  ) => void;
+  setRootBounds: (
+    id: string,
+    rootBounds: { center: RawVector2; size: RawVector2 } | undefined,
   ) => void;
   setAxis: (id: string, axis: THREE.Vector3) => void;
   setTags: (id: string, tags: string[]) => void;

--- a/packages/@vizij/render/src/store.ts
+++ b/packages/@vizij/render/src/store.ts
@@ -6,7 +6,12 @@ import * as THREE from "three";
 import type { ThreeEvent } from "@react-three/fiber";
 import type { MouseEvent as ReactMouseEvent } from "react";
 import type { Group, Mesh } from "three";
-import { type RawValue, type AnimatableValue, getLookup } from "@vizij/utils";
+import {
+  type RawValue,
+  type RawVector2,
+  type AnimatableValue,
+  getLookup,
+} from "@vizij/utils";
 import type { World } from "./types/world";
 import { createNewElement } from "./actions/create-new-element";
 import { removeFromTree } from "./actions/remove-children";
@@ -247,6 +252,28 @@ export const VizijSlice = (set: VizijStoreSetter, get: VizijStoreGetter) => ({
         } else {
           if (rotation) state.world[id].origin.rotation = rotation;
           if (translation) state.world[id].origin.translation = translation;
+        }
+      }),
+    );
+  },
+  setRootBounds: (
+    id: string,
+    rootBounds: { center: RawVector2; size: RawVector2 } | undefined,
+  ) => {
+    set(
+      produce((state: VizijData) => {
+        const entry = state.world[id];
+        if (!entry || entry.type !== "group") {
+          return;
+        }
+        if (rootBounds) {
+          entry.rootBounds = {
+            center: { ...rootBounds.center },
+            size: { ...rootBounds.size },
+          };
+          entry.root = true;
+        } else {
+          delete entry.rootBounds;
         }
       }),
     );


### PR DESCRIPTION
## Summary

The face's bounding box (`rootBounds` on the root group) drives the orthographic camera crop everywhere a face renders, but until now it was only ever derived from geometry at import — there was no way to customize it. Bad baked bounds (e.g. from invisible helper meshes skewing the Box3) previously required hand-patching the GLB's JSON chunk.

This adds a **Face Bounds** section to the authoring tool's Inspector, shown when the root group is selected:

- **Center X/Y and Size W/H fields** — type or scrub; the camera recrops live as you edit
- **Show toggle** — draws the existing red safe-area rectangle over the main viewport (was hardcoded off)
- **Fit to Geometry** — recomputes the box from the currently rendered face
- **Aspect readout** for checking the crop ratio

Edited bounds mark the GLB export dirty and persist through Save/Export (they re-serialize into the root node's `RobotData` extension), so a customized crop survives reimport.

## Implementation notes

- **`@vizij/render`**: new `setRootBounds` store action; `deriveRootBounds` (geometry Box3 → bounds) is now exported for reuse.
- **`FaceBoundsSection`** (inspector) edits the app-level store via the established `setStoreState` path.
- **`FaceBoundsRuntimeBridge`** (Viewer, inside `VizijRuntimeProvider`): the main viewport renders from the provider's isolated store, so world edits in the app store don't reach it on their own. The bridge pushes authored bounds into the runtime store (same pattern as the showcase's `FaceCameraBounds`) and registers `measureFaceGeometryBounds` on the graph runtime store for Fit to Geometry.
- **`workspaceStore.faceBoundsOverlayVisible`** drives `showSafeArea` on `VizijRuntimeFace`.
- **Export dirty tracking**: `rootBounds` added to the GLB export dirty snapshot.

## Testing

- Typecheck + lint clean for `@vizij/render` and `vizij-authoring`; all 730 vitest tests pass
- New test: bounds changes trip the export dirty snapshot
- Verified live with the Quori Extended preset: overlay toggle, numeric edit (W 22.58 → 10) reframes the camera and Save goes dirty, Fit to Geometry restores geometry-derived bounds

## Possible follow-ups

- Draggable corner/edge handles on the viewport rectangle
- Use the new `setRootBounds` action in vizij-showcase instead of its hardcoded `FACE_ROOT_BOUNDS` override

🤖 Generated with [Claude Code](https://claude.com/claude-code)