### PR TITLE
feat(runtime-react): the device runs itself — arora 9 / @vizij/runtime 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ When you need edits from the Rust workspace:
 
    ```bash
    # link a subset
-   pnpm run wasm:link -- --pkgs "node-graph-wasm arora-web-wasm"
+   pnpm run wasm:link -- --pkgs "node-graph-wasm runtime"
    # or link everything
    pnpm run wasm:link -- --pkgs all
 

--- a/apps/demo-vizij-player/vite.config.ts
+++ b/apps/demo-vizij-player/vite.config.ts
@@ -41,7 +41,7 @@ export default defineConfig({
   optimizeDeps: {
     exclude: [
       "@vizij/node-graph-wasm",
-      "@vizij/arora-web-wasm",
+      "@vizij/runtime",
       "@vizij/animation-module",
     ],
     include: ["@vizij/render"],

--- a/apps/tutorial-agent-face/vite.config.ts
+++ b/apps/tutorial-agent-face/vite.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
-    exclude: ["@vizij/arora-web-wasm", "@vizij/animation-module"],
+    exclude: ["@vizij/runtime", "@vizij/animation-module"],
     include: ["@vizij/render"],
   },
 });

--- a/apps/tutorial-fullscreen-face/vite.config.ts
+++ b/apps/tutorial-fullscreen-face/vite.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
-    exclude: ["@vizij/arora-web-wasm", "@vizij/animation-module"],
+    exclude: ["@vizij/runtime", "@vizij/animation-module"],
     include: ["@vizij/render"],
   },
 });

--- a/apps/vizij-authoring/vite.config.ts
+++ b/apps/vizij-authoring/vite.config.ts
@@ -82,7 +82,7 @@ export default defineConfig(({ mode }) => {
       exclude: [
         "@vizij/animation-wasm",
         "@vizij/node-graph-wasm",
-        "@vizij/arora-web-wasm",
+        "@vizij/runtime",
         "@vizij/animation-module",
       ],
       include: ["@vizij/node-graph-react"],

--- a/apps/vizij-showcase/vite.config.ts
+++ b/apps/vizij-showcase/vite.config.ts
@@ -41,7 +41,7 @@ export default defineConfig({
   optimizeDeps: {
     exclude: [
       "@vizij/node-graph-wasm",
-      "@vizij/arora-web-wasm",
+      "@vizij/runtime",
       "@vizij/animation-module",
     ],
     include: ["@vizij/render"],

--- a/apps/vizij-standalone/vite.config.ts
+++ b/apps/vizij-standalone/vite.config.ts
@@ -52,7 +52,7 @@ export default defineConfig(async () => ({
   optimizeDeps: {
     exclude: [
       "@vizij/node-graph-wasm",
-      "@vizij/arora-web-wasm",
+      "@vizij/runtime",
       "@vizij/animation-module",
     ],
     include: [

--- a/e2e/tests/demo-vizij-player-load-sample.spec.ts
+++ b/e2e/tests/demo-vizij-player-load-sample.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "@playwright/test";
 import { STANDALONE_DEMOS, demoUrl } from "../standalone-demos";
 
 // Regression for the arora value-marshalling bug: `demo-vizij-player` mounts the
-// arora runtime (`@vizij/runtime-react` → `@vizij/arora-web-wasm`). Loading a
+// arora runtime (`@vizij/runtime-react` → `@vizij/runtime`). Loading a
 // sample drives `setValue` with vizij `ValueJSON` shorthand (`{"float": …}`,
 // `{"vec3": …}`); the arora store speaks the canonical `Value` serde (`{"f32": …}`),
 // so before @vizij/arora-web-wasm@0.1.2 every write threw `unknown variant 'float'`

--- a/packages/@vizij/runtime-react/AGENTS.md
+++ b/packages/@vizij/runtime-react/AGENTS.md
@@ -1,7 +1,7 @@
 # Agent Notes - @vizij/runtime-react
 
 - Run scripts with `pnpm --filter "@vizij/runtime-react"` (`build`, `test`, `typecheck`, `lint`, `dev`, `clean`). Builds are handled by `tsup`; keep bundles in `dist/`.
-- The runtime stitches together `@vizij/render`, `@vizij/arora-web-wasm` (the engine device), and asset bundle helpers. When updating hooks or provider props, verify the tutorial runtime (`apps/tutorial-fullscreen-face`) and any sample bundles still load without console errors.
+- The runtime stitches together `@vizij/render`, `@vizij/runtime` (the engine device), and asset bundle helpers. When updating hooks or provider props, verify the tutorial runtime (`apps/tutorial-fullscreen-face`) and any sample bundles still load without console errors.
 - Keep README usage samples aligned with the render package and the arora-web wasm; export changes there usually require mirrored docs and new integration notes here.
 - Before publishing, run:
 

--- a/packages/@vizij/runtime-react/README.md
+++ b/packages/@vizij/runtime-react/README.md
@@ -1,6 +1,6 @@
 # @vizij/runtime-react
 
-`@vizij/runtime-react` is the bundle-first React runtime for Vizij faces. It loads a GLB or prebuilt world, extracts embedded Vizij metadata, composes the rig/pose/program graphs into the behavior of an Arora device ([`@vizij/arora-web-wasm`](https://www.npmjs.com/package/@vizij/arora-web-wasm) — an Arora runtime compiled to WebAssembly), mirrors resolved values into the renderer store, and exposes a React-friendly control surface for apps.
+`@vizij/runtime-react` is the bundle-first React runtime for Vizij faces. It loads a GLB or prebuilt world, extracts embedded Vizij metadata, composes the rig/pose/program graphs into the behavior of an Arora device ([`@vizij/runtime`](https://www.npmjs.com/package/@vizij/runtime) — an Arora runtime compiled to WebAssembly), mirrors resolved values into the renderer store, and exposes a React-friendly control surface for apps.
 
 The package is intentionally aimed at app authors. If your app wants to render a Vizij face and drive it through authored rig inputs, this is the layer to build on.
 
@@ -24,10 +24,10 @@ pnpm add @vizij/runtime-react react react-dom
 If your app also imports lower-level renderer or engine APIs directly, install those packages too:
 
 ```bash
-pnpm add @vizij/render @vizij/arora-web-wasm
+pnpm add @vizij/render @vizij/runtime
 ```
 
-`@vizij/runtime-react`, `@vizij/render`, and `@vizij/arora-web-wasm` should stay on the same workspace/release line.
+`@vizij/runtime-react`, `@vizij/render`, and `@vizij/runtime` should stay on the same workspace/release line.
 
 ### Bundler Notes
 

--- a/packages/@vizij/runtime-react/package.json
+++ b/packages/@vizij/runtime-react/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@vizij/animation-module": "^0.1.1",
-    "@vizij/arora-web-wasm": "^0.2.0",
+    "@vizij/arora-web-wasm": "^1.0.0",
     "@vizij/node-graph-authoring": "workspace:*",
     "@vizij/render": "workspace:*",
     "@vizij/utils": "workspace:*",

--- a/packages/@vizij/runtime-react/package.json
+++ b/packages/@vizij/runtime-react/package.json
@@ -41,7 +41,7 @@
     "@vizij/animation-module": "^0.1.1",
     "@vizij/node-graph-authoring": "workspace:*",
     "@vizij/render": "workspace:*",
-    "@vizij/runtime": "^1.0.0",
+    "@vizij/runtime": "^1.0.2",
     "@vizij/utils": "workspace:*",
     "@vizij/value-json": "^0.2.0"
   },

--- a/packages/@vizij/runtime-react/package.json
+++ b/packages/@vizij/runtime-react/package.json
@@ -39,9 +39,9 @@
   },
   "dependencies": {
     "@vizij/animation-module": "^0.1.1",
-    "@vizij/arora-web-wasm": "^1.0.0",
     "@vizij/node-graph-authoring": "workspace:*",
     "@vizij/render": "workspace:*",
+    "@vizij/runtime": "^1.0.0",
     "@vizij/utils": "workspace:*",
     "@vizij/value-json": "^0.2.0"
   },

--- a/packages/@vizij/runtime-react/src/VizijRuntimeProvider.tsx
+++ b/packages/@vizij/runtime-react/src/VizijRuntimeProvider.tsx
@@ -14,7 +14,12 @@ import { compileIrGraph, type IrGraph } from "@vizij/node-graph-authoring";
 import { valueAsNumber, type ValueJSON } from "@vizij/value-json";
 import { getLookup, type AnimatableValue, type RawValue } from "@vizij/utils";
 import { loadAnimationModule } from "@vizij/animation-module";
-import { DeviceSlot, ensureWasmInit, isGoldenPath } from "./engine/aroraEngine";
+import {
+  DeviceSlot,
+  RUN_PERIOD_MS,
+  ensureWasmInit,
+  isGoldenPath,
+} from "./engine/aroraEngine";
 import { composeGraphSpecs, type GraphSource } from "./utils/composeGraph";
 import type {
   GraphRegistrationConfig,
@@ -1442,8 +1447,8 @@ function VizijRuntimeProviderInner({
   const [ready, setReady] = useState(false);
   /**
    * Specs currently composed into the device's ONE graph, in evaluation order.
-   * Every (un)registration recomposes and restarts the device. Where each
-   * source comes from:
+   * Every (un)registration recomposes, swapping the device's graph in place.
+   * Where each source comes from:
    *
    * - **rig** — the loaded asset bundle's rig graph (authored into the GLB):
    *   maps rig input paths to the face's morph/bone/material writes.
@@ -1819,8 +1824,8 @@ function VizijRuntimeProviderInner({
   // The engine surface, device-backed. The call shapes (synchronous
   // registration returning ids, snapshot getters) are implemented over the
   // single Arora device: registered graphs accumulate as sources in
-  // graphSourcesRef, and every registration change recomposes the one graph
-  // and restarts the device, carrying the store across (engine/aroraEngine.ts).
+  // graphSourcesRef, and every registration change recomposes the one graph,
+  // swapped into the running device in place (engine/aroraEngine.ts).
   // Animations tick INSIDE the device: the animation module samples the loaded
   // clips each step and the "animations" source drives it (see the
   // graphSourcesRef provenance note and engine/animationModule*.ts).
@@ -1837,9 +1842,9 @@ function VizijRuntimeProviderInner({
 
   /**
    * The animation module host, constructed once the module artifact has
-   * loaded. Also arms the slot: every device this slot starts loads the
-   * module, and each fresh device replays the host's setup calls (module
-   * guest state does not survive a restart).
+   * loaded. Also arms the slot: every device this slot boots loads the
+   * module, and a rebuilt device replays the host's setup calls (module
+   * guest state does not survive a rebuild).
    */
   const ensureAnimationHost = useCallback((): AnimationModuleHost | null => {
     if (!animationModuleRef.current) {
@@ -1858,7 +1863,7 @@ function VizijRuntimeProviderInner({
   const recomposeDevice = useCallback(() => {
     const spec = composeGraphSpecs(graphSourcesRef.current);
     deviceSlot
-      .restart(spec)
+      .recompose(spec)
       .then((handle) => {
         if (pendingWritesRef.current.size > 0) {
           handle.device.writeValues(
@@ -1869,7 +1874,7 @@ function VizijRuntimeProviderInner({
       })
       .catch((err: unknown) => {
         pushError({
-          message: "Failed to (re)start the arora device",
+          message: "Failed to (re)compose the arora device",
           cause: err,
           phase: "engine",
           timestamp: performance.now(),
@@ -1884,16 +1889,18 @@ function VizijRuntimeProviderInner({
   }, []);
 
   // Load the animation module when the bundle carries animations, and arm the
-  // device slot with it: every device this slot starts loads the module, and
-  // each fresh device (a boot or a restart) replays the host's setup calls,
-  // because module guest state does not survive a restart.
+  // device slot with it. The slot is told the load is in flight right away —
+  // boots wait for it, so the device is always built WITH the module (a live
+  // device cannot load one; a changed module set forces a rebuild).
+  // `onDeviceStarted` replays the host's setup calls into a rebuilt device,
+  // whose module guest state starts from scratch.
   const hasBundleAnimations = (assetBundle.animations?.length ?? 0) > 0;
   useEffect(() => {
     if (!hasBundleAnimations || animationModuleRef.current) {
       return;
     }
     let cancelled = false;
-    loadAnimationModule()
+    const loading = loadAnimationModule()
       .then((module) => {
         if (cancelled) {
           return;
@@ -1913,6 +1920,7 @@ function VizijRuntimeProviderInner({
           timestamp: performance.now(),
         });
       });
+    deviceSlot.waitForModules(loading);
     return () => {
       cancelled = true;
     };
@@ -2144,12 +2152,13 @@ function VizijRuntimeProviderInner({
   }, []);
 
   /**
-   * One tick: step the device (dt seconds → ms at exactly this boundary),
-   * then pull the changed keys and apply them to the render store. The
-   * push-model frame subscription this replaces re-rendered the provider
-   * every step; the pull model renders only what the changes touch —
-   * step-aligned consumers subscribe through `subscribeToStep` and read
-   * the values they care about via `getValueSnapshot`.
+   * One tick: pull the changed keys off the device and apply them to the
+   * render store. A device under its own `run()` loop is already stepping —
+   * only the drain happens here; a manually driven one is stepped first
+   * (dt seconds → ms at exactly this boundary). The pull model renders only
+   * what the changes touch — step-aligned consumers subscribe through
+   * `subscribeToStep` and read the values they care about via
+   * `getValueSnapshot`.
    */
   const stepRuntime = useCallback(
     (dt: number) => {
@@ -2157,7 +2166,9 @@ function VizijRuntimeProviderInner({
       if (!handle) {
         return;
       }
-      handle.device.step(dt * 1000);
+      if (!handle.device.running) {
+        handle.device.step(dt * 1000);
+      }
       const changes = handle.device.drainChanges() as Record<
         string,
         ValueJSON | null
@@ -2251,6 +2262,29 @@ function VizijRuntimeProviderInner({
   useEffect(() => {
     driveRuntimeRef.current = driveRuntime;
   }, [driveRuntime]);
+
+  // A driving provider hands its device to the device's own loop: it paces
+  // itself (RUN_PERIOD_MS), and the JS loop below only pumps — tweens,
+  // routing, staged-input flush, change drain. A non-driving provider leaves
+  // the device manually stepped (step via forceRuntime). Once under run() a
+  // device cannot be handed back: turning driveRuntime off later only stops
+  // this provider's pump cadence from being the active one.
+  useEffect(() => {
+    deviceSlot.onRunEnded = (error: unknown) => {
+      pushError({
+        message: "The device's run loop ended: stepping failed",
+        cause: error,
+        phase: "engine",
+        timestamp: performance.now(),
+      });
+    };
+    if (driveRuntime) {
+      deviceSlot.runPeriodMs = RUN_PERIOD_MS;
+      deviceSlot.startRun();
+    } else {
+      deviceSlot.runPeriodMs = null;
+    }
+  }, [deviceSlot, driveRuntime, pushError]);
 
   const glbAsset = effectiveAssetBundle.glb;
   const baseBundle: VizijBundleExtension | null =

--- a/packages/@vizij/runtime-react/src/engine/animationModuleHost.ts
+++ b/packages/@vizij/runtime-react/src/engine/animationModuleHost.ts
@@ -23,7 +23,7 @@
  *    another clip plays is NOT expressible against this module (documented
  *    capability gap — a future module-transport extension, not faked here).
  */
-import type { AroraDevice } from "@vizij/arora-web-wasm";
+import type { AroraDevice } from "@vizij/runtime";
 import {
   addInstanceCall,
   callResultU32,

--- a/packages/@vizij/runtime-react/src/engine/aroraEngine.ts
+++ b/packages/@vizij/runtime-react/src/engine/aroraEngine.ts
@@ -32,7 +32,7 @@ import {
   type DeviceModule,
   type ValueJSON,
   type InitInput,
-} from "@vizij/arora-web-wasm";
+} from "@vizij/runtime";
 
 export type { DeviceModule };
 

--- a/packages/@vizij/runtime-react/src/engine/aroraEngine.ts
+++ b/packages/@vizij/runtime-react/src/engine/aroraEngine.ts
@@ -7,17 +7,23 @@
  * concurrent boots share one device. Devices are deliberately never freed on
  * unmount: the provider can remount around a live device.
  *
- * Changing the composed graph goes through `restartDevice`: the device's
- * behavior is fixed at construction in arora-web 5.2, so a recompose tears
- * the device down and rebuilds it, carrying the store across (snapshot minus
- * the runtime-owned `arora/*` golden keys, re-written into the new device).
- * VIZ-57 replaces this with an in-place behavior load once `BrowserRuntime`
- * exposes the interpreter module's LOAD function.
+ * Changing the composed graph goes through `recompose`: the device swaps its
+ * behavior **in place** (`device.loadGraph`, the interpreter-module LOAD
+ * reached through the device's caller — VIZ-57), so the store, the loaded
+ * modules, and the device itself survive every recomposition. The one thing
+ * a live device cannot change is its **module set** — modules load at device
+ * build — so a recompose that finds the slot's modules changed since boot
+ * rebuilds the device, carrying the store across (snapshot minus the
+ * runtime-owned `arora/*` golden keys). Boots wait for modules a
+ * `waitForModules` promise announces, so the supported flows never hit that
+ * rebuild.
  *
- * A slot can also load Arora wasm **modules** into every device it starts
- * (`setModules`) — e.g. the animation module. Module guest state lives in
- * the module instance, so unlike the store it does NOT survive a restart;
- * owners replay their module setup calls from `onDeviceStarted`.
+ * When `runPeriodMs` is set, every device this slot boots is handed to its
+ * own loop (`device.run`) — it paces itself and `step()` becomes
+ * unavailable; a slot left at `null` serves hosts that step manually. A
+ * device under `run()` cannot be handed back: it keeps its loop for good
+ * (including across a module-set rebuild, where the replaced device's loop
+ * keeps ticking unreachable until the page goes).
  */
 import {
   init,
@@ -37,6 +43,14 @@ export function isGoldenPath(path: string): boolean {
   return path.startsWith(GOLDEN_PREFIX);
 }
 
+/**
+ * The self-paced device's step period: the ~60 Hz render-aligned cadence the
+ * JS-driven step loop used to run at. The browser throttles the loop's
+ * timers with a hidden page, so a backgrounded device slows with its tab;
+ * the step `dt` stays the measured wall clock either way.
+ */
+export const RUN_PERIOD_MS = 1000 / 60;
+
 let initPromise: Promise<void> | null = null;
 
 /** Load the wasm module once per realm. */
@@ -49,36 +63,47 @@ export function ensureWasmInit(input?: InitInput): Promise<void> {
 
 export interface DeviceHandle {
   device: AroraDevice;
-  /** The composed spec the device was started with (for recompose diffing). */
+  /** The composed spec the device currently runs (for recompose diffing). */
   spec: object;
+  /** The slot's module list the device was built with (identity compare). */
+  modules: DeviceModule[] | undefined;
 }
 
 /**
  * One device slot per handle owner (each provider instance creates its own
- * slot). Creation is deduped: a second `ensure` during a pending create
- * resolves to the same device.
+ * slot). Creation is deduped: a second `recompose` during a pending boot
+ * chains behind it and lands on the same device.
  */
 export class DeviceSlot {
   private handle: DeviceHandle | null = null;
-  /** Arora wasm modules loaded into every device this slot starts. */
+  /** Arora wasm modules loaded into every device this slot boots. */
   private modules: DeviceModule[] | undefined;
+  /** Module loading a boot must wait out before it reads `modules`. */
+  private modulesLoading: Promise<unknown> | null = null;
+  /**
+   * When set, a booted device is handed to its own loop (`device.run`) at
+   * this period. `null`: the host drives `step()` itself.
+   */
+  runPeriodMs: number | null = null;
   /**
    * Runs (inside the serialized op) each time a fresh device comes up — a
-   * boot or a restart — before the (re)start promise resolves. Module guest
-   * state does not survive a restart (a new device instantiates its modules
-   * from scratch), so this is where owners replay module setup calls (e.g.
-   * re-`load_animation` the clips).
+   * boot or a module-set rebuild — before the promise resolves. Module guest
+   * state lives in the device, so this is where owners replay module setup
+   * calls (e.g. re-`load_animation` the clips) after a rebuild.
    */
   onDeviceStarted?: (handle: DeviceHandle) => void;
   /**
-   * Serializes device (re)starts. Every `ensure`/`restart` chains behind the
-   * previous op so two recomposes never run concurrently — a second restart
-   * that captured the same `old` handle would dispose an already-freed device
-   * (wasm "null pointer passed to rust"). A bundle whose import fans out into
-   * several graph registrations recomposes several times in a burst, which is
-   * exactly when that race fires. Failures are swallowed on the chain so one
-   * failed (re)start doesn't wedge later ones; each caller still sees its own
-   * rejection through the promise `enqueue` returns.
+   * Notified when a self-paced device's run loop ends — `device.run`'s
+   * promise only ever rejects, and it rejecting means stepping failed.
+   */
+  onRunEnded?: (error: unknown) => void;
+  /**
+   * Serializes device operations. Every `recompose` chains behind the
+   * previous op so two never run concurrently — a bundle whose import fans
+   * out into several graph registrations recomposes in a burst. Failures are
+   * swallowed on the chain so one failed op doesn't wedge later ones; each
+   * caller still sees its own rejection through the promise `enqueue`
+   * returns.
    */
   private opChain: Promise<unknown> = Promise.resolve();
 
@@ -87,11 +112,46 @@ export class DeviceSlot {
   }
 
   /**
-   * The modules every subsequent device start loads. Takes effect at the
-   * next `ensure`/`restart`; the live device (if any) is not touched.
+   * The modules every subsequent device boot loads. The live device (if any)
+   * is not touched: a later `recompose` that sees the list changed rebuilds.
    */
   setModules(modules: DeviceModule[] | undefined): void {
     this.modules = modules && modules.length > 0 ? modules : undefined;
+  }
+
+  /**
+   * Announce module loading in flight: boots wait for `loading` to settle
+   * before reading the module list, so a device never boots without modules
+   * that were already on their way. Pass a promise that cannot reject (the
+   * owner handles its own failures) — boots resume either way.
+   */
+  waitForModules(loading: Promise<unknown>): void {
+    this.modulesLoading = loading;
+  }
+
+  /**
+   * Hand the live device to its own loop, if there is one and `runPeriodMs`
+   * says so — for a host whose drive mode turns self-paced after boot.
+   */
+  startRun(): void {
+    if (this.handle) {
+      this.maybeRun(this.handle.device);
+    }
+  }
+
+  private maybeRun(device: AroraDevice): void {
+    if (this.runPeriodMs === null || device.running) {
+      return;
+    }
+    // Known gap: a self-paced device measures dt inside arora, so the JS
+    // step loops' suspension inference (VizijRuntimeProvider's
+    // IMPLICIT_PAUSE_GAP_S, dt = 0 on an implausible inter-step gap) never
+    // applies here — a host suspension (e.g. an OS-suspended WebView)
+    // reaches the engine as one large dt on the first tick after resume.
+    // Only manually stepped devices get the re-baseline.
+    device.run(this.runPeriodMs).catch((error: unknown) => {
+      this.onRunEnded?.(error);
+    });
   }
 
   private enqueue<T>(op: () => Promise<T>): Promise<T> {
@@ -105,56 +165,67 @@ export class DeviceSlot {
 
   private async boot(spec: object): Promise<DeviceHandle> {
     await ensureWasmInit();
+    if (this.modulesLoading) {
+      await this.modulesLoading;
+    }
     const device = await startDevice(spec, undefined, this.modules);
-    this.handle = { device, spec };
+    this.handle = { device, spec, modules: this.modules };
     this.onDeviceStarted?.(this.handle);
+    this.maybeRun(device);
     return this.handle;
   }
 
-  /** Boot the device with `spec` if none is live; otherwise return the live one. */
-  ensure(spec: object): Promise<DeviceHandle> {
-    return this.enqueue(async () => {
-      if (this.handle) {
-        return this.handle;
+  /**
+   * Rebuild the device because its module set changed since boot — the one
+   * change a live device cannot take. Carries the store across (snapshot
+   * minus golden keys) and replays module setup via `onDeviceStarted`. The
+   * old device's wrapper is freed; if it was self-paced its loop keeps
+   * ticking unreachable — which is why boots wait for announced modules
+   * instead of leaning on this path.
+   */
+  private async rebuild(
+    old: DeviceHandle,
+    spec: object,
+  ): Promise<DeviceHandle> {
+    const carried: Record<string, ValueJSON> = {};
+    for (const [path, value] of Object.entries(old.device.snapshot())) {
+      if (!isGoldenPath(path)) {
+        carried[path] = value;
       }
-      return this.boot(spec);
-    });
+    }
+
+    const device = await startDevice(spec, undefined, this.modules);
+    if (Object.keys(carried).length > 0) {
+      device.writeValues(carried);
+    }
+    this.handle = { device, spec, modules: this.modules };
+    old.device.dispose();
+    this.onDeviceStarted?.(this.handle);
+    this.maybeRun(device);
+    return this.handle;
   }
 
   /**
-   * Replace the device's composed graph: snapshot the store (minus golden
-   * keys), start a fresh device with `spec`, restore the snapshot, dispose
-   * the old device. No-op if the spec is identical by reference. Serialized
-   * behind any in-flight (re)start (see `opChain`) so device disposal never
-   * races another restart's snapshot/dispose of the same device.
+   * Make the device run `spec`: boot it if none is live, otherwise swap the
+   * graph in place (the store is the same store, so nothing is carried).
+   * No-op if the spec is identical by reference. Serialized behind any
+   * in-flight op (see `opChain`).
    */
-  restart(spec: object): Promise<DeviceHandle> {
+  recompose(spec: object): Promise<DeviceHandle> {
     return this.enqueue(async () => {
       const old = this.handle;
-      if (old && old.spec === spec) {
-        return old;
-      }
-      // First live device: same path as `ensure`, inlined so it runs inside
-      // this queued op instead of enqueuing behind itself (which would deadlock).
       if (!old) {
         return this.boot(spec);
       }
-
-      const carried: Record<string, ValueJSON> = {};
-      for (const [path, value] of Object.entries(old.device.snapshot())) {
-        if (!isGoldenPath(path)) {
-          carried[path] = value;
-        }
+      if (old.modules !== this.modules) {
+        return this.rebuild(old, spec);
       }
-
-      const device = await startDevice(spec, undefined, this.modules);
-      if (Object.keys(carried).length > 0) {
-        device.writeValues(carried);
+      if (old.spec === spec) {
+        return old;
       }
-      this.handle = { device, spec };
-      old.device.dispose();
-      this.onDeviceStarted?.(this.handle);
-      return this.handle;
+      await old.device.loadGraph(spec);
+      old.spec = spec;
+      return old;
     });
   }
 }

--- a/packages/@vizij/runtime-react/src/types.ts
+++ b/packages/@vizij/runtime-react/src/types.ts
@@ -369,6 +369,13 @@ export type VizijRuntimeProviderProps = {
   updateTier?: RuntimeUpdateTier;
   autoCreate?: boolean;
   autostart?: boolean;
+  /**
+   * Whether this provider's device paces itself: when true the device is
+   * handed to its own `run()` loop at boot and the provider only pumps its
+   * changes; when false the device advances solely on `step(dt,
+   * { forceRuntime: true })` calls from the host. A device handed to `run()`
+   * keeps its loop even if this later turns false.
+   */
   driveRuntime?: boolean;
   mergeStrategy?: MergeStrategyOptions;
   onRegisterControllers?: (ids: { graphs: string[]; anims: string[] }) => void;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -899,8 +899,8 @@ importers:
         specifier: workspace:*
         version: link:../render
       '@vizij/runtime':
-        specifier: ^1.0.0
-        version: 1.0.1
+        specifier: ^1.0.2
+        version: 1.0.2
       '@vizij/utils':
         specifier: workspace:*
         version: link:../utils
@@ -2682,8 +2682,8 @@ packages:
   '@vizij/node-graph-wasm@0.7.0':
     resolution: {integrity: sha512-h9R+84qLxWn4G9fT2DumgWylg5eTgktMM02k+jlxaNZcKZa62ZaHnJijF+0TnTA+GEQEmKGuDdf+A6JBSh7HAw==}
 
-  '@vizij/runtime@1.0.1':
-    resolution: {integrity: sha512-bWEfE18onKW4WRk0qSPd+AKI4Ev5n0kx0WHU3DWKwGzhsTMnPrRodrVLSzzYWb6zmvxAI2v/GJy8yQx56hq4SA==}
+  '@vizij/runtime@1.0.2':
+    resolution: {integrity: sha512-J/wD043IjAAj4aXQmy0zRCOA1MmBj1MEKNepWYm0T8Xd3C7cfl53AfiDnxSAyqJi/5LD3sE6vbHinu8Al3Gu0w==}
 
   '@vizij/value-json@0.2.0':
     resolution: {integrity: sha512-1wNxYLm4DPBnkcciIY4YClweIfIQinefMPsE8pQeacv1u8/0ls/Y3+GNCb3Rwa1yvdvKodRFhIf69JE2LsUC1Q==}
@@ -6931,7 +6931,7 @@ snapshots:
       '@vizij/value-json': 0.2.0
       '@vizij/wasm-loader': 0.1.5
 
-  '@vizij/runtime@1.0.1':
+  '@vizij/runtime@1.0.2':
     dependencies:
       '@vizij/value-json': 0.2.0
       '@vizij/wasm-loader': 0.1.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -892,15 +892,15 @@ importers:
       '@vizij/animation-module':
         specifier: ^0.1.1
         version: 0.1.1
-      '@vizij/arora-web-wasm':
-        specifier: ^0.2.0
-        version: 0.2.0
       '@vizij/node-graph-authoring':
         specifier: workspace:*
         version: link:../node-graph-authoring
       '@vizij/render':
         specifier: workspace:*
         version: link:../render
+      '@vizij/runtime':
+        specifier: ^1.0.0
+        version: 1.0.1
       '@vizij/utils':
         specifier: workspace:*
         version: link:../utils
@@ -2679,11 +2679,11 @@ packages:
   '@vizij/animation-wasm@0.4.0':
     resolution: {integrity: sha512-CbDWOZQ73tx/syzGfKjlPwIOo0Hw/v1TK4JYg/rpuyBQAaGP7pFzxYyYVZ8cj1bEPV6gJO9jk+5jxt0Q2QgnIw==}
 
-  '@vizij/arora-web-wasm@0.2.0':
-    resolution: {integrity: sha512-tKhcZiThAWQMe1FYvXfKlaXbW4mqY+EN/BGt2iiWMG+ThPRjyHw/dPWUZmE+XpPc1WGT88CSbGZK6/u5yyWR5Q==}
-
   '@vizij/node-graph-wasm@0.7.0':
     resolution: {integrity: sha512-h9R+84qLxWn4G9fT2DumgWylg5eTgktMM02k+jlxaNZcKZa62ZaHnJijF+0TnTA+GEQEmKGuDdf+A6JBSh7HAw==}
+
+  '@vizij/runtime@1.0.1':
+    resolution: {integrity: sha512-bWEfE18onKW4WRk0qSPd+AKI4Ev5n0kx0WHU3DWKwGzhsTMnPrRodrVLSzzYWb6zmvxAI2v/GJy8yQx56hq4SA==}
 
   '@vizij/value-json@0.2.0':
     resolution: {integrity: sha512-1wNxYLm4DPBnkcciIY4YClweIfIQinefMPsE8pQeacv1u8/0ls/Y3+GNCb3Rwa1yvdvKodRFhIf69JE2LsUC1Q==}
@@ -6926,12 +6926,12 @@ snapshots:
       '@vizij/value-json': 0.2.0
       '@vizij/wasm-loader': 0.1.5
 
-  '@vizij/arora-web-wasm@0.2.0':
+  '@vizij/node-graph-wasm@0.7.0':
     dependencies:
       '@vizij/value-json': 0.2.0
       '@vizij/wasm-loader': 0.1.5
 
-  '@vizij/node-graph-wasm@0.7.0':
+  '@vizij/runtime@1.0.1':
     dependencies:
       '@vizij/value-json': 0.2.0
       '@vizij/wasm-loader': 0.1.5

--- a/scripts/wasm-links.mjs
+++ b/scripts/wasm-links.mjs
@@ -21,7 +21,7 @@ const DEFAULT_VIZIJ_RS = path.resolve(REPO_ROOT, "..", "vizij-rs");
 const ALL_PACKAGES = [
   "animation-module",
   "animation-wasm",
-  "arora-web-wasm",
+  "runtime",
   "node-graph-wasm",
   "value-json",
   "wasm-loader",
@@ -37,8 +37,8 @@ Usage:
 
 Examples:
   pnpm run wasm:status
-  pnpm run wasm:link -- --pkgs "node-graph-wasm arora-web-wasm"
-  WASM_PKGS="graph arora-web-wasm" pnpm run wasm:link
+  pnpm run wasm:link -- --pkgs "node-graph-wasm runtime"
+  WASM_PKGS="graph runtime" pnpm run wasm:link
   pnpm run wasm:unlink -- --pkgs "all"
 
 Notes:


### PR DESCRIPTION
## What

The runtime-react device slot adopts **@vizij/runtime 1.0** (the arora 9 wave):

- **The device paces itself.** A driving provider hands its device to the device's own `run()` loop (~60 Hz) at boot; the JS loop only pumps — tweens, routing, staged-input flush, change drain. A non-driving provider keeps stepping manually via `forceRuntime`. A run-loop rejection surfaces as an engine-phase runtime error.
- **Recompose swaps the graph in place.** Every registration change goes through `device.loadGraph` — the interpreter-module LOAD reached through the device's caller ([VIZ-57](https://linear.app/semio-ai/issue/VIZ-57)) — so the store, the loaded modules, and the device survive. The carry-the-store rebuild remains only for a module set changed after boot, and boots wait for announced module loading so the supported flows never hit it.
- **First drain = full state.** `drainChanges()` opens the subscription on the store's whole current state, so the separate init snapshot is gone.
- **The wrapper package is `@vizij/runtime`** (renamed from `@vizij/arora-web-wasm`, [vizij-rs #55](https://github.com/vizij-ai/vizij-rs/pull/55)): dependency range `^1.0.0`, import specifiers, vite `optimizeDeps` excludes, wasm-links tooling, docs. The lockfile pins **1.0.1** from the registry — the first installable release (the 1.0.0 artifact carries unresolved `workspace:*` ranges).

## Suspension-dt reconciliation

Rebased over #75 (suspension inference in the step loops) with no conflicts, and the semantics compose: `stepRuntime` only steps a device **not** under `run()`, so `inferImplicitPause` (dt = 0 past `IMPLICIT_PAUSE_GAP_S`) guards exactly the manual-step path. A self-paced device measures dt inside arora and does not get the JS-side clamp — a host suspension reaches the engine as one large dt on resume. That gap is documented at `DeviceSlot.maybeRun` (where `device.run` starts), not worked around here.

## Verification

- `@vizij/runtime-react` typecheck clean, vitest **75/75**, tsup build success — against the linked local build and with the registry-locked 1.0.1.
- The demo-vizij-player load-sample e2e spec continues to cover the write path through the device (`runtime-react` → `@vizij/runtime`).

Part of the arora 9 wave migration ([VIZ-53](https://linear.app/semio-ai/issue/VIZ-53), tracking). The animation-module path is untouched, keeping [VIZ-61](https://linear.app/semio-ai/issue/VIZ-61) unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)