### PR TITLE
chore(vizij): finish VIZ-54 — retire arora-connection/arora-websocket references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,13 +33,6 @@ This repo is the implementation home for Vizij's web packages, demos, tutorials,
 | `@vizij/minimal-demo-ui`      | Shared UI/chrome for minimal demo apps                        |
 | `@vizij/arora-types`          | TypeScript protocol surface for standalone/control work       |
 
-### Local Rust crates under `packages/`
-
-| Crate              | Focus                                           |
-| ------------------ | ----------------------------------------------- |
-| `arora-connection` | Core Arora connection traits/types              |
-| `arora-websocket`  | WebSocket implementation for the Arora protocol |
-
 ### Apps (`apps/*`)
 
 | App                            | Focus                                |

--- a/README.md
+++ b/README.md
@@ -51,13 +51,6 @@ This workspace consumes the Rust artefacts from [`vizij-rs`](../vizij-rs) via `@
 | `@vizij/runtime-react`        | `packages/@vizij/runtime-react`        | Runtime provider wiring the renderer to an Arora device engine. | `dev`, `build`, `test`, `typecheck`, `clean` |
 | `@vizij/utils`                | `packages/@vizij/utils`                | Shared math/value utilities consumed across packages/apps.      | `dev`, `build`, `test`, `clean`              |
 
-### Local protocol / standalone crates
-
-| Crate              | Path                        | Summary                                              |
-| ------------------ | --------------------------- | ---------------------------------------------------- |
-| `arora-connection` | `packages/arora-connection` | Rust protocol traits and shared connection types     |
-| `arora-websocket`  | `packages/arora-websocket`  | Rust WebSocket implementation for the Arora protocol |
-
 ### Apps
 
 | App                            | Path                                | Purpose                                                                 | Typical scripts                        |

--- a/packages/@vizij/arora-types/src/value.ts
+++ b/packages/@vizij/arora-types/src/value.ts
@@ -1,5 +1,5 @@
 /**
- * Arora Value - matches Rust arora_schema::Value serde format.
+ * Arora Value - matches Rust arora_types::value::Value serde format.
  *
  * The Rust enum uses #[serde(rename = "...")] on variants with externally tagged
  * serialization (the default), which produces JSON like:
@@ -43,7 +43,7 @@ export type AroraValue =
   | { "value[]": AroraValue[] };
 
 /**
- * Arora Type - matches Rust arora_schema::Type serde format.
+ * Arora Type - matches Rust arora_types::value::Type serde format.
  * Describes the type of a Value without holding data.
  */
 export type AroraType =


### PR DESCRIPTION
Finishes [VIZ-54](https://linear.app/semio-ai/issue/VIZ-54/retire-packagesarora-connection-arora-websocket-finish).

The `packages/arora-connection` and `packages/arora-websocket` Rust crates were already deleted on `main` (superseded by the published `arora-bridge-ws` + the arora runtime store). This removes the last dangling references to them:

- **README.md / AGENTS.md** — drop the "local Rust crates" table rows for the two deleted packages. Both rows were the entire content of those sections, so the sections go with them.
- **packages/@vizij/arora-types/src/value.ts** — update the two doc comments that still named the old `arora_schema` crate to `arora_types::value` — the last `arora_schema` references in the repo.

Docs + comments only — no functional change, no API surface touched (`AroraValue`/`AroraType` unchanged). The `@vizij/arora-types` TS package stays (still consumed by the standalone WS-sync shim), per the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)