### PR TITLE
docs: fix stale references in vizij-web docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,13 +32,14 @@ This repo is the implementation home for Vizij's web packages, demos, tutorials,
 | `@vizij/node-graph-authoring` | Authoring/compiler helpers and IR report CLI                  |
 | `@vizij/minimal-demo-ui`      | Shared UI/chrome for minimal demo apps                        |
 | `@vizij/arora-types`          | TypeScript protocol surface for standalone/control work       |
+| `@vizij/speech-react`         | STT/LLM/TTS speech pipeline hooks for Vizij React apps        |
 
 ### Apps (`apps/*`)
 
 | App                            | Focus                                |
 | ------------------------------ | ------------------------------------ |
 | `vizij-authoring`              | Runtime-truthful authoring surface   |
-| `demo-vizij-player`            | Authoring/runtime playback demo      |
+| `demo-vizij-player`            | Bundle-first runtime-react player    |
 | `demo-animation-studio`        | Animation playground                 |
 | `demo-graph-studio`            | Graph editing demo                   |
 | `minimal-demo-animation`       | Minimal animation smoke surface      |

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This workspace consumes the Rust artefacts from [`vizij-rs`](../vizij-rs) via th
 | `@vizij/node-graph-react`     | `packages/@vizij/node-graph-react`     | React provider & hooks for node graphs.                         | `dev`, `build`, `test`, `typecheck`, `clean` |
 | `@vizij/render`               | `packages/@vizij/render`               | Three.js renderer + controllers for Vizij rigs.                 | `dev`, `build`, `typecheck`, `clean`         |
 | `@vizij/runtime-react`        | `packages/@vizij/runtime-react`        | Runtime provider wiring the renderer to an Arora device engine. | `dev`, `build`, `test`, `typecheck`, `clean` |
-| `@vizij/speech-react`         | `packages/@vizij/speech-react`         | Shared STT/LLM/TTS speech pipeline hooks for Vizij React apps.   | `dev`, `build`, `typecheck`, `clean`         |
+| `@vizij/speech-react`         | `packages/@vizij/speech-react`         | Shared STT/LLM/TTS speech pipeline hooks for Vizij React apps.  | `dev`, `build`, `typecheck`, `clean`         |
 | `@vizij/utils`                | `packages/@vizij/utils`                | Shared math/value utilities consumed across packages/apps.      | `dev`, `build`, `test`, `clean`              |
 
 ### Apps

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **TypeScript packages, React integrations, and demo applications that showcase Vizij’s real-time animation platform.**
 
-This workspace consumes the Rust artefacts from [`vizij-rs`](../vizij-rs) via `@vizij/*-wasm` packages and exposes production-ready packages plus a suite of internal apps.
+This workspace consumes the Rust artefacts from [`vizij-rs`](../vizij-rs) via the published `@vizij/*` bindings (the `@vizij/animation-wasm` and `@vizij/node-graph-wasm` engines plus the `@vizij/runtime` runtime) and exposes production-ready packages plus a suite of internal apps.
 
 ---
 
@@ -49,6 +49,7 @@ This workspace consumes the Rust artefacts from [`vizij-rs`](../vizij-rs) via `@
 | `@vizij/node-graph-react`     | `packages/@vizij/node-graph-react`     | React provider & hooks for node graphs.                         | `dev`, `build`, `test`, `typecheck`, `clean` |
 | `@vizij/render`               | `packages/@vizij/render`               | Three.js renderer + controllers for Vizij rigs.                 | `dev`, `build`, `typecheck`, `clean`         |
 | `@vizij/runtime-react`        | `packages/@vizij/runtime-react`        | Runtime provider wiring the renderer to an Arora device engine. | `dev`, `build`, `test`, `typecheck`, `clean` |
+| `@vizij/speech-react`         | `packages/@vizij/speech-react`         | Shared STT/LLM/TTS speech pipeline hooks for Vizij React apps.   | `dev`, `build`, `typecheck`, `clean`         |
 | `@vizij/utils`                | `packages/@vizij/utils`                | Shared math/value utilities consumed across packages/apps.      | `dev`, `build`, `test`, `clean`              |
 
 ### Apps
@@ -58,7 +59,7 @@ This workspace consumes the Rust artefacts from [`vizij-rs`](../vizij-rs) via `@
 | `demo-animation-studio`        | `apps/demo-animation-studio`        | Playground for animation presets & advanced rig control.                | `dev`, `build`, `typecheck`, `preview` |
 | `demo-graph-studio`            | `apps/demo-graph-studio`            | Work-in-progress Vizij node graph editor.                               | `dev`, `build`, `typecheck`, `preview` |
 | `vizij-authoring`              | `apps/vizij-authoring`              | Author vizij assets, configure rig bindings, and export GLBs.           | `dev`, `build`, `typecheck`, `preview` |
-| `demo-vizij-player`            | `apps/demo-vizij-player`            | Authoring surface for facial rigs and runtime-driven playback.          | `dev`, `build`, `typecheck`, `preview` |
+| `demo-vizij-player`            | `apps/demo-vizij-player`            | Bundle-first reference player/showcase for `@vizij/runtime-react`.      | `dev`, `build`, `typecheck`, `preview` |
 | `minimal-demo-animation`       | `apps/minimal-demo-animation`       | Minimal animation runtime example for quick smoke tests.                | `dev`, `build`, `typecheck`, `preview` |
 | `minimal-demo-animation-graph` | `apps/minimal-demo-animation-graph` | Animation + node-graph integration showcase (URDF IK, filtering).       | `dev`, `build`, `typecheck`, `preview` |
 | `minimal-demo-graph`           | `apps/minimal-demo-graph`           | Lightweight node-graph playground (inputs, outputs, staging behaviour). | `dev`, `build`, `typecheck`, `preview` |

--- a/apps/AGENTS.md
+++ b/apps/AGENTS.md
@@ -20,11 +20,13 @@ Use this file when working under `apps/`.
 | `demo-animation-studio`        | Advanced animation playground with preset + rig editors.              |
 | `demo-graph-studio`            | Node graph editor; depends heavily on `@vizij/node-graph-react`.      |
 | `vizij-authoring`              | GLB inspector/exporter and motiongraph authoring surface.             |
-| `demo-vizij-player`            | Facial rig runtime authoring surface for end-to-end workflows.        |
+| `demo-vizij-player`            | Bundle-first reference player/showcase for `@vizij/runtime-react`.     |
 | `minimal-demo-animation`       | Minimal animation runtime smoke test.                                 |
 | `minimal-demo-animation-graph` | Combined animation + node-graph sample featuring URDF IK and filters. |
 | `minimal-demo-graph`           | Lightweight node-graph playground (inputs/outputs/staging demos).     |
 | `tutorial-fullscreen-face`     | Lightweight getting-started face demo for the runtime provider.       |
+| `tutorial-agent-face`          | Live conversational runtime demo (Gemini Live, visemes, agent tools). |
 | `vizij-showcase`               | Larger face showcase with advanced controls and staging helpers.      |
+| `vizij-standalone`             | Tauri desktop runtime app wrapping `@vizij/runtime-react`.            |
 
 Each app directory contains its own `AGENTS.md` (if not, add one before doing extensive work) alongside README/setup instructions.

--- a/apps/AGENTS.md
+++ b/apps/AGENTS.md
@@ -20,7 +20,7 @@ Use this file when working under `apps/`.
 | `demo-animation-studio`        | Advanced animation playground with preset + rig editors.              |
 | `demo-graph-studio`            | Node graph editor; depends heavily on `@vizij/node-graph-react`.      |
 | `vizij-authoring`              | GLB inspector/exporter and motiongraph authoring surface.             |
-| `demo-vizij-player`            | Bundle-first reference player/showcase for `@vizij/runtime-react`.     |
+| `demo-vizij-player`            | Bundle-first reference player/showcase for `@vizij/runtime-react`.    |
 | `minimal-demo-animation`       | Minimal animation runtime smoke test.                                 |
 | `minimal-demo-animation-graph` | Combined animation + node-graph sample featuring URDF IK and filters. |
 | `minimal-demo-graph`           | Lightweight node-graph playground (inputs/outputs/staging demos).     |

--- a/apps/demo-graph-studio/README.md
+++ b/apps/demo-graph-studio/README.md
@@ -28,15 +28,15 @@
 
 ```bash
 pnpm install
-pnpm --filter vizij-node-graph-editor dev
+pnpm --filter demo-graph-studio dev
 ```
 
 Additional scripts:
 
 ```bash
-pnpm --filter vizij-node-graph-editor build      # production build + type checks
-pnpm --filter vizij-node-graph-editor preview    # preview production output
-pnpm --filter vizij-node-graph-editor test       # Vitest unit tests
+pnpm --filter demo-graph-studio build      # production build + type checks
+pnpm --filter demo-graph-studio preview    # preview production output
+pnpm --filter demo-graph-studio test       # Vitest unit tests
 ```
 
 ---

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -12,12 +12,16 @@ Use this note when touching anything under `packages/`.
 
 ## Workspace Snapshot
 
-| Package                   | Path                      | Notes                                                          |
-| ------------------------- | ------------------------- | -------------------------------------------------------------- |
-| `@vizij/animation-react`  | `@vizij/animation-react`  | React bindings for the animation runtime.                      |
-| `@vizij/node-graph-react` | `@vizij/node-graph-react` | React bindings for node graphs and staging helpers.            |
-| `@vizij/render`           | `@vizij/render`           | Three.js renderer/controllers used across demos.               |
-| `@vizij/runtime-react`    | `@vizij/runtime-react`    | All-in-one runtime provider that wires render + orchestration. |
-| `@vizij/utils`            | `@vizij/utils`            | Shared math/value helpers used by all other packages/apps.     |
+| Package                       | Path                          | Notes                                                          |
+| ----------------------------- | ----------------------------- | -------------------------------------------------------------- |
+| `@vizij/animation-react`      | `@vizij/animation-react`      | React bindings for the animation runtime.                      |
+| `@vizij/arora-types`          | `@vizij/arora-types`          | TypeScript protocol surface for standalone/control work.       |
+| `@vizij/minimal-demo-ui`      | `@vizij/minimal-demo-ui`      | Shared UI/chrome for minimal demo apps.                        |
+| `@vizij/node-graph-authoring` | `@vizij/node-graph-authoring` | Authoring/compiler helpers and IR report CLI.                  |
+| `@vizij/node-graph-react`     | `@vizij/node-graph-react`     | React bindings for node graphs and staging helpers.            |
+| `@vizij/render`               | `@vizij/render`               | Three.js renderer/controllers used across demos.               |
+| `@vizij/runtime-react`        | `@vizij/runtime-react`        | All-in-one runtime provider that wires render + orchestration. |
+| `@vizij/speech-react`         | `@vizij/speech-react`         | STT/LLM/TTS speech pipeline hooks for Vizij React apps.        |
+| `@vizij/utils`                | `@vizij/utils`                | Shared math/value helpers used by all other packages/apps.     |
 
 See each package’s own `AGENTS.md` for test expectations, release notes, and integration tips.


### PR DESCRIPTION
Fixes documentation staleness discovered by auditing the docs against the current workspace surface (verified via `packages/@vizij/*`, `apps/*`, and each `package.json`).

## Changes

**Broken demo-graph-studio filter**
- `apps/demo-graph-studio/README.md`: the Quick Start / scripts used `pnpm --filter vizij-node-graph-editor …`, but the app's package name is `demo-graph-studio`. Corrected all four invocations.

**demo-vizij-player description**
- `README.md`, `AGENTS.md`, `apps/AGENTS.md`: it was described as an "authoring surface for facial rigs". Per `apps/demo-vizij-player/README.md` it is the bundle-first reference player/showcase for `@vizij/runtime-react`. Corrected in all three.

**wasm consumption line**
- `README.md`: the intro claimed the workspace consumes vizij-rs "via `@vizij/*-wasm` packages". The runtime engine ships as `@vizij/runtime` (no `-wasm`), so this now names the actual `@vizij/animation-wasm` / `@vizij/node-graph-wasm` engines plus `@vizij/runtime` instead of blanket-claiming `-wasm`.

**Inventory omissions**
- `README.md` packages table + `AGENTS.md` Workspace Map: added the tracked `@vizij/speech-react` package.
- `packages/AGENTS.md` Workspace Snapshot: added `@vizij/node-graph-authoring`, `@vizij/minimal-demo-ui`, `@vizij/arora-types`, and `@vizij/speech-react`.
- `apps/AGENTS.md` App Directory Map: added the real apps `tutorial-agent-face` and `vizij-standalone`.

## Notes
- The previously reported obsolete `arora-connection` / `arora-websocket` rows are already absent from current `main` (retired in favour of the published `arora-bridge-ws` / `arora-bridge-ros2`); nothing to remove there.
- Left `orchestrator-react` / `minimal-demo-orchestrator` out of the inventories: those directories are untracked leftover `dist`/`node_modules` with no source or `package.json`, so they are not real workspaces.
- Scope limited to doc files; no code, `.vscode/`, or generated docs (`docs/archive|plans|notes|reports`, CHANGELOGs) touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)