### PR TITLE
chore: reconstruct CHANGELOGs for packages missing them

### DIFF
--- a/packages/@vizij/arora-types/CHANGELOG.md
+++ b/packages/@vizij/arora-types/CHANGELOG.md
@@ -1,0 +1,33 @@
+# @vizij/arora-types
+
+All notable changes to this package are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0/).
+
+## [0.1.0] - 2026-02-05
+
+Initial release. TypeScript types and helpers mirroring the Rust `arora-types`
+serde format, so browser clients and the arora websocket protocol share one
+value and message model.
+
+### Added
+
+- Value model: `AroraValue`, `AroraType`, `AroraStructure`, `AroraStructureField`,
+  `AroraEnumeration`, `AroraKeyValue`, and `AroraKeyValueField` types.
+- Value constructors (`unit`, `f64`, `f32`, `i64`, `i32`, `u64`, `u32`, `str`,
+  `bool`, `uuid`, `some`, `none`, `f64Array`, `i32Array`, `strArray`,
+  `valueArray`), extractors (`extractNumericValue`, `extractStringValue`,
+  `extractBooleanValue`, `extractUuidValue`, `extractOptionValue`), and value
+  type guards (`isNumeric`, `isString`, `isBoolean`, `isUnit`, `isOption`).
+- Protocol message model: `Incoming`/`Outgoing` messages carrying `NodeInfo`,
+  `MethodInfo`, `MethodParam`, and `SlotInfo` payloads; message constructors
+  (`createUpdate`, `createListNodes`, `createListMethods`, `createInvoke`); and
+  response type guards (`isUpdateResp`, `isListNodesResp`, `isListMethodsResp`,
+  `isInvokeResp`, `isError`).
+- Slot operations: `createSetSlotValues`, `createGetSlotValues`, and
+  `createListSlots` constructors with matching `isSetSlotValuesResp`,
+  `isGetSlotValuesResp`, and `isListSlotsResp` guards, aligned with the Rust
+  websocket naming and request-id flow.
+- Protocol contract test asserting the TypeScript message shapes stay in sync
+  with the Rust wire format.


### PR DESCRIPTION
## What

Reconstructs the missing CHANGELOG for the one published `@vizij/*` package that lacked a current one. All other published packages already have current, Changesets-generated CHANGELOGs and are left untouched (Changesets owns them).

## Package that got a CHANGELOG

| Package | Version range | Source |
| --- | --- | --- |
| `@vizij/arora-types` | `0.1.0` (single entry, 2026-02-05) | git history — no Changesets tag exists for this package |

`@vizij/arora-types` is public (`publishConfig.access: public`, not `private`) but was added on 2026-02-05, after the last Changesets release wave (tags dated 2026-01-23), so Changesets never generated a changelog for it. Its version has never moved from `0.1.0` (no tags), so the reconstructed CHANGELOG is a single initial-release entry in Keep a Changelog format, dated to the version boundary commit `ee72e586` (2026-02-05). It folds in the later same-version refinement (`1b545760`, 2026-02-13) that added slot operations and aligned the request-id flow with the Rust websocket side. Contents were verified against the current `src/index.ts` export surface.

## Already current — left alone (Changesets-owned)

Top CHANGELOG entry matches `package.json` version for each:

- `@vizij/animation-react` — 0.2.0
- `@vizij/node-graph-authoring` — 0.2.0
- `@vizij/node-graph-react` — 0.2.0
- `@vizij/render` — 0.1.1
- `@vizij/runtime-react` — 0.2.0
- `@vizij/speech-react` — 0.1.1
- `@vizij/utils` — 0.1.0

## Skipped

- `@vizij/minimal-demo-ui` — `"private": true` (not published)
- `orchestrator-react` — no `package.json` on this branch (only `dist/` + `node_modules/`); not a source package to publish

## Scope

Only adds `packages/@vizij/arora-types/CHANGELOG.md`. No code, docs, apps, `.vscode/`, or existing Changesets-generated changelogs were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)