### PR TITLE
chore: migrate minimal animation demos to the @vizij/runtime path

### DIFF
--- a/apps/minimal-demo-animation-graph/package.json
+++ b/apps/minimal-demo-animation-graph/package.json
@@ -17,9 +17,9 @@
     "reset:hard": "pnpm run reset && rm -f pnpm-lock.yaml package-lock.json yarn.lock"
   },
   "dependencies": {
-    "@vizij/animation-react": "workspace:*",
-    "@vizij/animation-wasm": "^0.4.0",
+    "@vizij/animation-module": "^0.2.0",
     "@vizij/minimal-demo-ui": "workspace:*",
+    "@vizij/runtime": "^1.1.0",
     "@vizij/value-json": "^0.2.0",
     "@vizij/node-graph-react": "workspace:*",
     "@vizij/node-graph-wasm": "^0.7.0",

--- a/apps/minimal-demo-animation-graph/src/animationRuntime.ts
+++ b/apps/minimal-demo-animation-graph/src/animationRuntime.ts
@@ -1,0 +1,758 @@
+/**
+ * Local helper: run stored animation clips through a `@vizij/runtime` runtime
+ * with the `@vizij/animation-module` guest, in place of the standalone
+ * `@vizij/animation-wasm` engine + `@vizij/animation-react` provider.
+ *
+ * The runtime (`@vizij/runtime`'s `startDevice`/`AroraDevice` — "device" is the
+ * package's own term for a running Arora instance) executes a small behavior
+ * graph: an `ExternalFunction` node calls the module's `step(dt_ns)` every tick
+ * (fed the golden `arora/dt`), a path-less `output` node applies the returned
+ * `[TrackOutput]` batch onto the store keys each record names (its authored
+ * `default_key`, decided at clip load), and a second `ExternalFunction` /
+ * `output` pair writes `player_states()` to `ANIMATION_PLAYERS_PATH`. Clips
+ * load into a single player as data through the module's call surface, and a
+ * `requestAnimationFrame` loop advances the runtime and drains the store.
+ *
+ * Call arguments/returns use the Arora `Value` JSON encoding (`{ str }`,
+ * `{ f32 }`, `{ u32 }`, `{ struct }`, `{ structs }`, …); sampled outputs land in
+ * the store as Vizij `ValueJSON`, read back with `@vizij/value-json` helpers.
+ *
+ * This is a demo-local copy — the same glue exists (unexported) inside
+ * `@vizij/runtime-react`; the demos keep a small copy rather than depend on the
+ * full renderer runtime. The reusable home for it is upstream in
+ * `@vizij/runtime` / `@vizij/animation-module`.
+ */
+import { useEffect, useMemo, useRef, useState } from "react";
+import { init, startDevice, type AroraDevice } from "@vizij/runtime";
+import { loadAnimationModule } from "@vizij/animation-module";
+import type { ValueJSON } from "@vizij/value-json";
+
+// --- declared function + parameter ids (module.yaml) -------------------------
+export const ANIMATION_MODULE_FN = {
+  loadAnimation: "76697a69-6a00-0000-0f00-000000000001",
+  createPlayer: "76697a69-6a00-0000-0f00-000000000002",
+  addInstance: "76697a69-6a00-0000-0f00-000000000003",
+  step: "76697a69-6a00-0000-0f00-000000000004",
+  play: "76697a69-6a00-0000-0f00-000000000005",
+  pause: "76697a69-6a00-0000-0f00-000000000006",
+  stop: "76697a69-6a00-0000-0f00-000000000007",
+  seek: "76697a69-6a00-0000-0f00-000000000008",
+  setSpeed: "76697a69-6a00-0000-0f00-000000000009",
+  setLoop: "76697a69-6a00-0000-0f00-00000000000a",
+  setWeight: "76697a69-6a00-0000-0f00-00000000000b",
+  removeInstance: "76697a69-6a00-0000-0f00-00000000000c",
+  playerStates: "76697a69-6a00-0000-0f00-00000000000d",
+} as const;
+
+export const ANIMATION_MODULE_PARAM = {
+  clip: "76697a69-6a00-0000-0f01-000000000001",
+  playerName: "76697a69-6a00-0000-0f02-000000000001",
+  player: "76697a69-6a00-0000-0f03-000000000001",
+  anim: "76697a69-6a00-0000-0f03-000000000002",
+  dtNs: "76697a69-6a00-0000-0f04-000000000001",
+  playPlayer: "76697a69-6a00-0000-0f05-000000000001",
+  pausePlayer: "76697a69-6a00-0000-0f06-000000000001",
+  stopPlayer: "76697a69-6a00-0000-0f07-000000000001",
+  seekPlayer: "76697a69-6a00-0000-0f08-000000000001",
+  seekTimeNs: "76697a69-6a00-0000-0f08-000000000002",
+  speedPlayer: "76697a69-6a00-0000-0f09-000000000001",
+  speedValue: "76697a69-6a00-0000-0f09-000000000002",
+  loopPlayer: "76697a69-6a00-0000-0f0a-000000000001",
+  loopMode: "76697a69-6a00-0000-0f0a-000000000002",
+} as const;
+
+// --- declared structure ids (records/structure/*.yaml) -----------------------
+export const ANIMATION_MODULE_TYPE = {
+  clip: "76697a69-6a00-0000-0000-000000000100",
+  track: "76697a69-6a00-0000-0000-000000000101",
+  keypoint: "76697a69-6a00-0000-0000-000000000102",
+  transitionHandle: "76697a69-6a00-0000-0000-000000000103",
+} as const;
+
+export const ANIMATION_MODULE_FIELD = {
+  clipName: "76697a69-6a00-0000-0100-000000000001",
+  clipDuration: "76697a69-6a00-0000-0100-000000000002",
+  clipTracks: "76697a69-6a00-0000-0100-000000000003",
+  trackId: "76697a69-6a00-0000-0101-000000000001",
+  trackName: "76697a69-6a00-0000-0101-000000000002",
+  trackAnimatable: "76697a69-6a00-0000-0101-000000000003",
+  trackPoints: "76697a69-6a00-0000-0101-000000000004",
+  keypointId: "76697a69-6a00-0000-0102-000000000001",
+  keypointStamp: "76697a69-6a00-0000-0102-000000000002",
+  keypointValue: "76697a69-6a00-0000-0102-000000000003",
+  keypointTransitionsIn: "76697a69-6a00-0000-0102-000000000004",
+  keypointTransitionsOut: "76697a69-6a00-0000-0102-000000000005",
+  handleX: "76697a69-6a00-0000-0103-000000000001",
+  handleY: "76697a69-6a00-0000-0103-000000000002",
+  outputDefaultKey: "76697a69-6a00-0000-0110-000000000002",
+  outputValue: "76697a69-6a00-0000-0110-000000000003",
+  statePlayer: "76697a69-6a00-0000-0111-000000000001",
+  stateState: "76697a69-6a00-0000-0111-000000000002",
+  stateTimeNs: "76697a69-6a00-0000-0111-000000000003",
+  stateDurationNs: "76697a69-6a00-0000-0111-000000000004",
+  stateSpeed: "76697a69-6a00-0000-0111-000000000005",
+} as const;
+
+// --- the Arora `Value` JSON encoding (narrow, only what this seam needs) -----
+export interface AroraField {
+  id: string;
+  value: AroraValueJSON;
+}
+
+export interface AroraStruct {
+  id: string;
+  fields: AroraField[];
+}
+
+export type AroraValueJSON =
+  | { str: string }
+  | { f32: number }
+  | { u32: number }
+  | { u64: number }
+  | { struct: AroraStruct }
+  | { structs: { id: string; elements: Array<{ fields: AroraField[] }> } }
+  | Record<string, unknown>;
+
+/** An Arora `Call` payload for `AroraDevice.call`. */
+export interface AnimationModuleCall {
+  id: string;
+  args: AroraField[];
+}
+
+export type AnimationLoopMode = "once" | "loop" | "ping_pong";
+
+// --- the stored-clip shape ----------------------------------------------------
+
+/** One authored keyframe: a normalized stamp (0..1) and a scalar value. */
+export interface StoredKeypoint {
+  id?: string;
+  stamp: number;
+  value: number;
+  /** Authored timing handles (`linear`/`step` ride through; absent = default ease). */
+  transitions?: {
+    in?: { x: number; y: number };
+    out?: { x: number; y: number };
+  };
+}
+
+/** One authored track: the store path it drives plus its keyframes. */
+export interface StoredTrack {
+  id?: string;
+  name?: string;
+  animatableId: string;
+  points: StoredKeypoint[];
+  /** Ignored by the module; carried for demo UIs (e.g. `{ color }`). */
+  settings?: unknown;
+}
+
+/**
+ * A stored animation clip — the JSON shape the demos author and the standalone
+ * `@vizij/animation-wasm` engine also loads (`duration` in ms, per-track
+ * keypoints with normalized 0..1 stamps). Extra fields are ignored.
+ */
+export interface StoredAnimation {
+  id?: string | number;
+  name?: string;
+  duration?: number;
+  tracks: StoredTrack[];
+  groups?: unknown;
+}
+
+const field = (id: string, value: AroraValueJSON): AroraField => ({
+  id,
+  value,
+});
+
+/** One target path per authored track key; identity when no resolver is given. */
+export type ResolveTrackKeys = (animatableId: string) => string[];
+
+/**
+ * Convert a stored clip into the module's declared `AnimationClip` value.
+ *
+ * `resolveKeys` decides the final store keys at load time: each track is
+ * emitted once per resolved target path, with that path as its `animatable_id`
+ * — so the module's `[TrackOutput]` names the store keys the graph's path-less
+ * `output` node applies, and no per-tick re-keying exists anywhere. Authored
+ * `cubic` keyframes carry no explicit handles in the stored form, so they
+ * sample the engine's default ease (`linear`/`step` ride through as handles).
+ */
+export function storedClipToModuleValue(
+  clip: StoredAnimation,
+  resolveKeys?: ResolveTrackKeys,
+): AroraValueJSON {
+  const name =
+    typeof clip.name === "string" && clip.name.trim().length > 0
+      ? clip.name.trim()
+      : typeof clip.id === "string"
+        ? clip.id
+        : "";
+  const durationMs = Number(clip.duration);
+  const duration =
+    Number.isFinite(durationMs) && durationMs > 0 ? Math.round(durationMs) : 1;
+
+  const tracks = (Array.isArray(clip.tracks) ? clip.tracks : [])
+    .map((rawTrack, index) => {
+      if (!rawTrack || typeof rawTrack !== "object") {
+        return null;
+      }
+      const animatableId =
+        typeof rawTrack.animatableId === "string"
+          ? rawTrack.animatableId.trim()
+          : "";
+      if (!animatableId) {
+        return null;
+      }
+      const trackId =
+        typeof rawTrack.id === "string" && rawTrack.id.trim().length > 0
+          ? rawTrack.id.trim()
+          : `track-${index}`;
+      const trackName =
+        typeof rawTrack.name === "string" && rawTrack.name.trim().length > 0
+          ? rawTrack.name.trim()
+          : trackId;
+
+      const points = (Array.isArray(rawTrack.points) ? rawTrack.points : [])
+        .map((rawPoint, pointIndex) => {
+          if (!rawPoint || typeof rawPoint !== "object") {
+            return null;
+          }
+          const stamp = Number(rawPoint.stamp);
+          const value = Number(rawPoint.value);
+          if (!Number.isFinite(stamp) || !Number.isFinite(value)) {
+            return null;
+          }
+          const pointId =
+            typeof rawPoint.id === "string" && rawPoint.id.trim().length > 0
+              ? rawPoint.id.trim()
+              : `${trackId}:point-${pointIndex}`;
+          const handles = (
+            handle: { x: number; y: number } | undefined,
+          ): AroraValueJSON => ({
+            structs: {
+              id: ANIMATION_MODULE_TYPE.transitionHandle,
+              elements: handle
+                ? [
+                    {
+                      fields: [
+                        field(ANIMATION_MODULE_FIELD.handleX, {
+                          f32: handle.x,
+                        }),
+                        field(ANIMATION_MODULE_FIELD.handleY, {
+                          f32: handle.y,
+                        }),
+                      ],
+                    },
+                  ]
+                : [],
+            },
+          });
+          return {
+            fields: [
+              field(ANIMATION_MODULE_FIELD.keypointId, { str: pointId }),
+              field(ANIMATION_MODULE_FIELD.keypointStamp, {
+                f32: Math.max(0, Math.min(1, stamp)),
+              }),
+              field(ANIMATION_MODULE_FIELD.keypointValue, { f32: value }),
+              field(
+                ANIMATION_MODULE_FIELD.keypointTransitionsIn,
+                handles(rawPoint.transitions?.in),
+              ),
+              field(
+                ANIMATION_MODULE_FIELD.keypointTransitionsOut,
+                handles(rawPoint.transitions?.out),
+              ),
+            ],
+          };
+        })
+        .filter(Boolean) as Array<{ fields: AroraField[] }>;
+
+      if (points.length === 0) {
+        return null;
+      }
+
+      const targets = resolveKeys?.(animatableId) ?? [animatableId];
+      return targets.map((target, targetIndex) => ({
+        fields: [
+          field(ANIMATION_MODULE_FIELD.trackId, {
+            str: targetIndex === 0 ? trackId : `${trackId}~${targetIndex}`,
+          }),
+          field(ANIMATION_MODULE_FIELD.trackName, { str: trackName }),
+          field(ANIMATION_MODULE_FIELD.trackAnimatable, { str: target }),
+          field(ANIMATION_MODULE_FIELD.trackPoints, {
+            structs: {
+              id: ANIMATION_MODULE_TYPE.keypoint,
+              elements: points,
+            },
+          }),
+        ],
+      }));
+    })
+    .filter(Boolean)
+    .flat() as Array<{ fields: AroraField[] }>;
+
+  return {
+    struct: {
+      id: ANIMATION_MODULE_TYPE.clip,
+      fields: [
+        field(ANIMATION_MODULE_FIELD.clipName, { str: name }),
+        field(ANIMATION_MODULE_FIELD.clipDuration, { u32: duration }),
+        field(ANIMATION_MODULE_FIELD.clipTracks, {
+          structs: {
+            id: ANIMATION_MODULE_TYPE.track,
+            elements: tracks,
+          },
+        }),
+      ],
+    },
+  };
+}
+
+// --- call builders ------------------------------------------------------------
+
+/** `load_animation(clip) → { u32: AnimId }`. */
+export function loadAnimationCall(
+  clipValue: AroraValueJSON,
+): AnimationModuleCall {
+  return {
+    id: ANIMATION_MODULE_FN.loadAnimation,
+    args: [field(ANIMATION_MODULE_PARAM.clip, clipValue)],
+  };
+}
+
+/** `create_player(name) → { u32: PlayerId }`. */
+export function createPlayerCall(name: string): AnimationModuleCall {
+  return {
+    id: ANIMATION_MODULE_FN.createPlayer,
+    args: [field(ANIMATION_MODULE_PARAM.playerName, { str: name })],
+  };
+}
+
+/** `add_instance(player, anim) → { u32: InstId }`. */
+export function addInstanceCall(
+  player: number,
+  anim: number,
+): AnimationModuleCall {
+  return {
+    id: ANIMATION_MODULE_FN.addInstance,
+    args: [
+      field(ANIMATION_MODULE_PARAM.player, { u32: player }),
+      field(ANIMATION_MODULE_PARAM.anim, { u32: anim }),
+    ],
+  };
+}
+
+/** `play(player)`: resume or start playback at the next step. */
+export function playCall(player: number): AnimationModuleCall {
+  return {
+    id: ANIMATION_MODULE_FN.play,
+    args: [field(ANIMATION_MODULE_PARAM.playPlayer, { u32: player })],
+  };
+}
+
+/** `pause(player)`: hold the playhead at the next step. */
+export function pauseCall(player: number): AnimationModuleCall {
+  return {
+    id: ANIMATION_MODULE_FN.pause,
+    args: [field(ANIMATION_MODULE_PARAM.pausePlayer, { u32: player })],
+  };
+}
+
+/** `stop(player)`: reset the playhead to the window start at the next step. */
+export function stopCall(player: number): AnimationModuleCall {
+  return {
+    id: ANIMATION_MODULE_FN.stop,
+    args: [field(ANIMATION_MODULE_PARAM.stopPlayer, { u32: player })],
+  };
+}
+
+/** `seek(player, time_ns)`: move the playhead (nanoseconds, the dt_ns base). */
+export function seekCall(player: number, timeNs: number): AnimationModuleCall {
+  return {
+    id: ANIMATION_MODULE_FN.seek,
+    args: [
+      field(ANIMATION_MODULE_PARAM.seekPlayer, { u32: player }),
+      field(ANIMATION_MODULE_PARAM.seekTimeNs, {
+        u64: Math.max(0, Math.round(timeNs)),
+      }),
+    ],
+  };
+}
+
+/** `set_speed(player, speed)`: playback speed multiplier. */
+export function setSpeedCall(
+  player: number,
+  speed: number,
+): AnimationModuleCall {
+  return {
+    id: ANIMATION_MODULE_FN.setSpeed,
+    args: [
+      field(ANIMATION_MODULE_PARAM.speedPlayer, { u32: player }),
+      field(ANIMATION_MODULE_PARAM.speedValue, { f32: speed }),
+    ],
+  };
+}
+
+/** `set_loop(player, mode)`: `"once" | "loop" | "ping_pong"`. */
+export function setLoopCall(
+  player: number,
+  mode: AnimationLoopMode,
+): AnimationModuleCall {
+  return {
+    id: ANIMATION_MODULE_FN.setLoop,
+    args: [
+      field(ANIMATION_MODULE_PARAM.loopPlayer, { u32: player }),
+      field(ANIMATION_MODULE_PARAM.loopMode, { str: mode }),
+    ],
+  };
+}
+
+/** The `{ u32 }` a setup call returns, or `null` on any other shape. */
+export function callResultU32(result: { ret: unknown }): number | null {
+  const ret = result.ret;
+  if (ret && typeof ret === "object" && "u32" in ret) {
+    const value = Number((ret as { u32: unknown }).u32);
+    return Number.isFinite(value) ? value : null;
+  }
+  return null;
+}
+
+// --- the behavior graph -------------------------------------------------------
+
+/**
+ * Store path the graph writes the module's per-tick `[PlayerState]` feedback
+ * to. Not an `arora/` golden key, so it reads back like any store value.
+ */
+export const ANIMATION_PLAYERS_PATH = "vizij/animations/players";
+
+/** A Vizij graph spec, structurally (what `startDevice` accepts). */
+export interface AnimationGraphSpec {
+  nodes: Array<Record<string, unknown>>;
+  edges: Array<Record<string, unknown>>;
+}
+
+/**
+ * The behavior graph that ticks the animation module: an `ExternalFunction`
+ * node calls the module's `step` every tick, fed the golden `arora/dt`
+ * (nanoseconds); a path-less `output` node applies the returned `[TrackOutput]`
+ * batch onto the store keys each record names (`default_key` — the final store
+ * paths, decided at clip load); and a second `ExternalFunction` / `output` pair
+ * writes `player_states()` to `ANIMATION_PLAYERS_PATH`.
+ */
+export function buildAnimationGraph(): AnimationGraphSpec {
+  return {
+    nodes: [
+      { id: "dt", type: "input", params: { path: "arora/dt" } },
+      {
+        id: "step",
+        type: "externalfunction",
+        params: {
+          function: ANIMATION_MODULE_FN.step,
+          param_ids: [ANIMATION_MODULE_PARAM.dtNs],
+        },
+      },
+      {
+        id: "apply",
+        type: "output",
+        params: {
+          key_field: ANIMATION_MODULE_FIELD.outputDefaultKey,
+          value_field: ANIMATION_MODULE_FIELD.outputValue,
+        },
+      },
+      {
+        id: "states",
+        type: "externalfunction",
+        params: { function: ANIMATION_MODULE_FN.playerStates, param_ids: [] },
+      },
+      {
+        id: "states-out",
+        type: "output",
+        params: { path: ANIMATION_PLAYERS_PATH },
+      },
+    ],
+    edges: [
+      { from: { node_id: "dt" }, to: { node_id: "step", input: "args_0" } },
+      { from: { node_id: "step" }, to: { node_id: "apply", input: "in" } },
+      {
+        from: { node_id: "states" },
+        to: { node_id: "states-out", input: "in" },
+      },
+    ],
+  };
+}
+
+// --- PlayerState decoding -------------------------------------------------------
+
+export interface AnimationPlayerState {
+  /** The module `PlayerId` (correlate via the loaded clips' player ids). */
+  player: number;
+  /** `"playing" | "paused" | "stopped"` — the engine's derived state. */
+  state: string;
+  /** Playhead in seconds. */
+  time: number;
+  /** Full player length in seconds. */
+  duration: number;
+  /** Playback speed multiplier. */
+  speed: number;
+}
+
+function fieldNumber(value: AroraValueJSON | undefined): number | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  for (const key of ["u64", "u32", "f32", "f64"]) {
+    if (key in value) {
+      const parsed = Number((value as Record<string, unknown>)[key]);
+      return Number.isFinite(parsed) ? parsed : null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Decode the `[PlayerState]` value the graph writes to `ANIMATION_PLAYERS_PATH`
+ * (a `structs` of the declared PlayerState type). Tolerant: unknown shapes
+ * decode to an empty list.
+ */
+export function decodePlayerStates(raw: unknown): AnimationPlayerState[] {
+  if (!raw || typeof raw !== "object" || !("structs" in raw)) {
+    return [];
+  }
+  const structs = (raw as { structs?: { elements?: unknown } }).structs;
+  const elements = Array.isArray(structs?.elements) ? structs.elements : [];
+  const states: AnimationPlayerState[] = [];
+  for (const element of elements) {
+    const fields = (element as { fields?: unknown })?.fields;
+    if (!Array.isArray(fields)) {
+      continue;
+    }
+    const byId = new Map<string, AroraValueJSON>();
+    for (const entry of fields) {
+      const id = (entry as { id?: unknown })?.id;
+      const value = (entry as { value?: unknown })?.value;
+      if (typeof id === "string" && value && typeof value === "object") {
+        byId.set(id, value as AroraValueJSON);
+      }
+    }
+    const player = fieldNumber(byId.get(ANIMATION_MODULE_FIELD.statePlayer));
+    if (player === null) {
+      continue;
+    }
+    const stateValue = byId.get(ANIMATION_MODULE_FIELD.stateState);
+    states.push({
+      player,
+      state:
+        stateValue && "str" in stateValue
+          ? String((stateValue as { str: unknown }).str)
+          : "",
+      time:
+        (fieldNumber(byId.get(ANIMATION_MODULE_FIELD.stateTimeNs)) ?? 0) / 1e9,
+      duration:
+        (fieldNumber(byId.get(ANIMATION_MODULE_FIELD.stateDurationNs)) ?? 0) /
+        1e9,
+      speed: fieldNumber(byId.get(ANIMATION_MODULE_FIELD.stateSpeed)) ?? 1,
+    });
+  }
+  return states;
+}
+
+// --- the React hook -----------------------------------------------------------
+
+export interface UseAnimationRuntimeOptions {
+  /** Start playback as soon as the clips are loaded (default: true). */
+  autoplay?: boolean;
+  /** How player time maps into clip time (default: "loop"). */
+  loop?: AnimationLoopMode;
+}
+
+export interface AnimationRuntimeApi {
+  /** True once the runtime is up and the clips are loaded. */
+  ready: boolean;
+  /**
+   * Latest store snapshot. A track's current sampled value is at
+   * `values[animatableId]` in the Vizij `ValueJSON` vocabulary.
+   */
+  values: Record<string, ValueJSON | null>;
+  /** Decoded per-tick player feedback (time / length / state / speed). */
+  players: AnimationPlayerState[];
+  /** Resume (or start) playback. */
+  play: () => void;
+  /** Hold the playhead. */
+  pause: () => void;
+  /** Reset the playhead to the clip start. */
+  stop: () => void;
+  /** Move the playhead to `seconds`. */
+  seek: (seconds: number) => void;
+  /** Set the playback speed multiplier. */
+  setSpeed: (speed: number) => void;
+  /** A setup error message, or null. */
+  error: string | null;
+}
+
+const EMPTY_VALUES: Record<string, ValueJSON | null> = {};
+const EMPTY_PLAYERS: AnimationPlayerState[] = [];
+
+function normalizeClips(
+  clips: StoredAnimation[] | StoredAnimation | null | undefined,
+): StoredAnimation[] {
+  if (!clips) {
+    return [];
+  }
+  return Array.isArray(clips) ? clips : [clips];
+}
+
+/**
+ * Run `clips` through a `@vizij/runtime` runtime with the animation module and
+ * surface the sampled outputs + player transport. The runtime is (re)built
+ * whenever the `clips` identity changes — that is the reload path. Transport
+ * calls dispatch on the next runtime step, which the running loop takes.
+ */
+export function useAnimationRuntime(
+  clips: StoredAnimation[] | StoredAnimation | null | undefined,
+  options: UseAnimationRuntimeOptions = {},
+): AnimationRuntimeApi {
+  const { autoplay = true, loop = "loop" } = options;
+
+  const [ready, setReady] = useState(false);
+  const [values, setValues] =
+    useState<Record<string, ValueJSON | null>>(EMPTY_VALUES);
+  const [players, setPlayers] = useState<AnimationPlayerState[]>(EMPTY_PLAYERS);
+  const [error, setError] = useState<string | null>(null);
+
+  // The live runtime + its single player id, shared with the transport methods.
+  const runtimeRef = useRef<AroraDevice | null>(null);
+  const playerIdRef = useRef<number | null>(null);
+
+  const clipList = normalizeClips(clips);
+
+  useEffect(() => {
+    let cancelled = false;
+    let raf = 0;
+    let runtime: AroraDevice | null = null;
+    const accumulated: Record<string, ValueJSON | null> = {};
+
+    setReady(false);
+    setValues(EMPTY_VALUES);
+    setPlayers(EMPTY_PLAYERS);
+    setError(null);
+    runtimeRef.current = null;
+    playerIdRef.current = null;
+
+    (async () => {
+      try {
+        await init();
+        const module = await loadAnimationModule();
+        if (cancelled) return;
+        runtime = await startDevice(buildAnimationGraph(), undefined, [module]);
+        if (cancelled) {
+          runtime.dispose();
+          return;
+        }
+
+        // Issue a call, take the pending step that dispatches it, and await it.
+        const callSync = async (call: Parameters<AroraDevice["call"]>[0]) => {
+          const pending = runtime!.call(call);
+          runtime!.step(0);
+          return pending;
+        };
+
+        const playerResult = await callSync(createPlayerCall("default"));
+        const playerId = callResultU32(playerResult);
+        if (cancelled) return;
+        if (playerId === null) {
+          throw new Error("create_player did not return a player id");
+        }
+
+        for (const clip of clipList) {
+          const animResult = await callSync(
+            loadAnimationCall(storedClipToModuleValue(clip)),
+          );
+          if (cancelled) return;
+          const animId = callResultU32(animResult);
+          if (animId === null) continue;
+          await callSync(addInstanceCall(playerId, animId));
+          if (cancelled) return;
+        }
+
+        await callSync(setLoopCall(playerId, loop));
+        if (cancelled) return;
+        if (autoplay) {
+          await callSync(playCall(playerId));
+          if (cancelled) return;
+        }
+
+        runtimeRef.current = runtime;
+        playerIdRef.current = playerId;
+        setReady(true);
+
+        // Advance the runtime and mirror the store into React each frame.
+        let last =
+          typeof performance !== "undefined" ? performance.now() : Date.now();
+        const tick = () => {
+          if (cancelled || !runtime) return;
+          const now =
+            typeof performance !== "undefined" ? performance.now() : Date.now();
+          const dtMs = Math.max(0, now - last);
+          last = now;
+          runtime.step(dtMs);
+          const changes = runtime.drainChanges();
+          let dirty = false;
+          for (const [key, value] of Object.entries(changes)) {
+            accumulated[key] = value;
+            dirty = true;
+          }
+          if (dirty) {
+            setValues({ ...accumulated });
+            setPlayers(decodePlayerStates(accumulated[ANIMATION_PLAYERS_PATH]));
+          }
+          raf = requestAnimationFrame(tick);
+        };
+        raf = requestAnimationFrame(tick);
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      if (raf) cancelAnimationFrame(raf);
+      runtimeRef.current = null;
+      playerIdRef.current = null;
+      try {
+        runtime?.dispose();
+      } catch {
+        // A disposed runtime is unusable; nothing to recover.
+      }
+    };
+    // The clips array identity is the reload trigger; loop/autoplay are read at
+    // setup time. Consumers pass a stable clips reference and change it to reload.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clips]);
+
+  return useMemo<AnimationRuntimeApi>(() => {
+    const withPlayer = (
+      build: (player: number) => Parameters<AroraDevice["call"]>[0],
+    ) => {
+      const runtime = runtimeRef.current;
+      const player = playerIdRef.current;
+      if (!runtime || player === null) return;
+      // The running RAF loop takes the step that dispatches this call.
+      void runtime.call(build(player)).catch(() => {
+        // A failed transport call means the runtime was torn down mid-issue.
+      });
+    };
+    return {
+      ready,
+      values,
+      players,
+      play: () => withPlayer((player) => playCall(player)),
+      pause: () => withPlayer((player) => pauseCall(player)),
+      stop: () => withPlayer((player) => stopCall(player)),
+      seek: (seconds: number) =>
+        withPlayer((player) => seekCall(player, seconds * 1e9)),
+      setSpeed: (speed: number) =>
+        withPlayer((player) => setSpeedCall(player, speed)),
+      error,
+    };
+  }, [ready, values, players, error]);
+}

--- a/apps/minimal-demo-animation-graph/src/data/ikAnimation.ts
+++ b/apps/minimal-demo-animation-graph/src/data/ikAnimation.ts
@@ -1,4 +1,4 @@
-import type { StoredAnimation } from "@vizij/animation-wasm";
+import type { StoredAnimation } from "../animationRuntime";
 import { makeTypedPath } from "../utils/typedPath";
 
 export const JOINT_IDS = [

--- a/apps/minimal-demo-animation-graph/src/data/slewAnimation.ts
+++ b/apps/minimal-demo-animation-graph/src/data/slewAnimation.ts
@@ -1,4 +1,4 @@
-import type { StoredAnimation } from "@vizij/animation-wasm";
+import type { StoredAnimation } from "../animationRuntime";
 import { makeTypedPath } from "../utils/typedPath";
 
 export const slewPaths = {

--- a/apps/minimal-demo-animation-graph/src/demos/IkGraphDemo.tsx
+++ b/apps/minimal-demo-animation-graph/src/demos/IkGraphDemo.tsx
@@ -1,10 +1,5 @@
 import React, { useCallback, useEffect, useEffectEvent, useMemo } from "react";
 import {
-  AnimationProvider,
-  useAnimTarget,
-  valueAsNumber as animationValueAsNumber,
-} from "@vizij/animation-react";
-import {
   GraphProvider,
   useGraphRuntime,
   useGraphOutputs,
@@ -13,8 +8,12 @@ import {
   valueAsVector,
   useGraphLoaded,
 } from "@vizij/node-graph-react";
-import { toValueJSON } from "@vizij/value-json";
+import {
+  toValueJSON,
+  valueAsNumber as animationValueAsNumber,
+} from "@vizij/value-json";
 import { minimalDemoTheme } from "@vizij/minimal-demo-ui";
+import { useAnimationRuntime } from "../animationRuntime";
 import { TimeSeriesChart } from "../components/TimeSeriesChart";
 import {
   UrdfIkPanel,
@@ -45,12 +44,13 @@ function IkGraphInner() {
   const runtime = useGraphRuntime();
   const { graphLoaded, waitForGraphReady } = useGraphLoaded();
 
-  const joint1Anim = useAnimTarget(ikPaths.jointAnimation.joint1);
-  const joint2Anim = useAnimTarget(ikPaths.jointAnimation.joint2);
-  const joint3Anim = useAnimTarget(ikPaths.jointAnimation.joint3);
-  const joint4Anim = useAnimTarget(ikPaths.jointAnimation.joint4);
-  const joint5Anim = useAnimTarget(ikPaths.jointAnimation.joint5);
-  const joint6Anim = useAnimTarget(ikPaths.jointAnimation.joint6);
+  const anim = useAnimationRuntime(ikAnimation);
+  const joint1Anim = anim.values[ikPaths.jointAnimation.joint1];
+  const joint2Anim = anim.values[ikPaths.jointAnimation.joint2];
+  const joint3Anim = anim.values[ikPaths.jointAnimation.joint3];
+  const joint4Anim = anim.values[ikPaths.jointAnimation.joint4];
+  const joint5Anim = anim.values[ikPaths.jointAnimation.joint5];
+  const joint6Anim = anim.values[ikPaths.jointAnimation.joint6];
 
   const jointInputs = useMemo(() => {
     const values = [
@@ -331,35 +331,28 @@ function IkGraphInner() {
 
 export function IkGraphDemo() {
   return (
-    <AnimationProvider
-      animations={ikAnimation}
-      prebind={(path) => path}
-      autostart
+    <GraphProvider
+      spec={ikGraphSpec}
+      waitForGraph
+      initialParams={{
+        fk: {
+          urdf_xml: sampleUrdf,
+          root_link: "base_link",
+          tip_link: "tool",
+        },
+        ik_solver: {
+          urdf_xml: sampleUrdf,
+          root_link: "base_link",
+          tip_link: "tool",
+        },
+      }}
+      initialInputs={{
+        [ikPaths.jointInput]: { vector: [0, 0, 0, 0, 0, 0] },
+      }}
+      autoStart={false}
       updateHz={60}
     >
-      <GraphProvider
-        spec={ikGraphSpec}
-        waitForGraph
-        initialParams={{
-          fk: {
-            urdf_xml: sampleUrdf,
-            root_link: "base_link",
-            tip_link: "tool",
-          },
-          ik_solver: {
-            urdf_xml: sampleUrdf,
-            root_link: "base_link",
-            tip_link: "tool",
-          },
-        }}
-        initialInputs={{
-          [ikPaths.jointInput]: { vector: [0, 0, 0, 0, 0, 0] },
-        }}
-        autoStart={false}
-        updateHz={60}
-      >
-        <IkGraphInner />
-      </GraphProvider>
-    </AnimationProvider>
+      <IkGraphInner />
+    </GraphProvider>
   );
 }

--- a/apps/minimal-demo-animation-graph/src/demos/SlewDampDemo.tsx
+++ b/apps/minimal-demo-animation-graph/src/demos/SlewDampDemo.tsx
@@ -1,9 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
-import {
-  AnimationProvider,
-  useAnimTarget,
-  valueAsNumber as animationValueAsNumber,
-} from "@vizij/animation-react";
+import { valueAsNumber as animationValueAsNumber } from "@vizij/value-json";
 import {
   GraphProvider,
   useGraphRuntime,
@@ -11,6 +7,7 @@ import {
   valueAsNumber,
 } from "@vizij/node-graph-react";
 import { minimalDemoTheme } from "@vizij/minimal-demo-ui";
+import { useAnimationRuntime } from "../animationRuntime";
 import { animationValueToValueJSON } from "../utils/animationValueToGraph";
 import { TimeSeriesChart } from "../components/TimeSeriesChart";
 import { slewAnimation, slewPaths } from "../data/slewAnimation";
@@ -20,7 +17,8 @@ import { ParamEditor } from "../components/ParamEditor";
 
 function SlewDampInner() {
   const runtime = useGraphRuntime();
-  const driverValue = useAnimTarget(slewPaths.driver);
+  const anim = useAnimationRuntime(slewAnimation);
+  const driverValue = anim.values[slewPaths.driver];
   const driverNumber = animationValueAsNumber(driverValue);
 
   const [maxRate, setMaxRate] = useState(1.5);
@@ -188,20 +186,8 @@ function SlewDampInner() {
 
 export function SlewDampDemo() {
   return (
-    <AnimationProvider
-      animations={slewAnimation}
-      prebind={(path) => path}
-      autostart
-      updateHz={60}
-    >
-      <GraphProvider
-        spec={slewGraphSpec}
-        autoStart
-        autoMode="raf"
-        updateHz={60}
-      >
-        <SlewDampInner />
-      </GraphProvider>
-    </AnimationProvider>
+    <GraphProvider spec={slewGraphSpec} autoStart autoMode="raf" updateHz={60}>
+      <SlewDampInner />
+    </GraphProvider>
   );
 }

--- a/apps/minimal-demo-animation-graph/src/utils/animationValueToGraph.ts
+++ b/apps/minimal-demo-animation-graph/src/utils/animationValueToGraph.ts
@@ -1,10 +1,17 @@
-import { type Value } from "@vizij/animation-react";
-import { toValueJSON } from "@vizij/value-json";
+import {
+  toValueJSON,
+  type ValueJSON as DeviceValueJSON,
+} from "@vizij/value-json";
 import type { ValueJSON } from "@vizij/node-graph-wasm";
 
+/**
+ * Re-key a value the animation device wrote to the store (Vizij `ValueJSON`)
+ * into the node-graph's `ValueJSON` for `stageInput`. The two vocabularies are
+ * structurally the same; `toValueJSON` normalizes the shape.
+ */
 export function animationValueToValueJSON(
-  value?: Value,
+  value?: DeviceValueJSON | null,
 ): ValueJSON | undefined {
-  if (!value) return undefined;
-  return toValueJSON(value);
+  if (value === undefined || value === null) return undefined;
+  return toValueJSON(value) as ValueJSON;
 }

--- a/apps/minimal-demo-animation-graph/vite.config.ts
+++ b/apps/minimal-demo-animation-graph/vite.config.ts
@@ -7,7 +7,8 @@ export default defineConfig({
     watch: {
       ignored: [
         "**/node_modules/**",
-        "!**/node_modules/@vizij/animation-wasm/**",
+        "!**/node_modules/@vizij/runtime/**",
+        "!**/node_modules/@vizij/animation-module/**",
         "!**/node_modules/@vizij/node-graph-wasm/**",
       ],
     },
@@ -17,6 +18,10 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
-    exclude: ["@vizij/animation-wasm", "@vizij/node-graph-wasm"],
+    exclude: [
+      "@vizij/runtime",
+      "@vizij/animation-module",
+      "@vizij/node-graph-wasm",
+    ],
   },
 });

--- a/apps/minimal-demo-animation/package.json
+++ b/apps/minimal-demo-animation/package.json
@@ -18,9 +18,11 @@
   },
   "dependencies": {
     "@eslint/plugin-kit": "0.4.0",
-    "@vizij/animation-react": "workspace:*",
+    "@vizij/animation-module": "^0.2.0",
     "@vizij/minimal-demo-ui": "workspace:*",
+    "@vizij/runtime": "^1.1.0",
     "@vizij/utils": "workspace:*",
+    "@vizij/value-json": "^0.2.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3"
   },

--- a/apps/minimal-demo-animation/src/App.tsx
+++ b/apps/minimal-demo-animation/src/App.tsx
@@ -1,46 +1,26 @@
 import React from "react";
-import type { ChangeEvent, Dispatch } from "react";
-import {
-  AnimationProvider,
-  useAnimTarget,
-  valueAsNumber,
-  useAnimation,
-  samples as animationSamples,
-} from "@vizij/animation-react";
+import type { ChangeEvent } from "react";
+import { valueAsNumber, type ValueJSON } from "@vizij/value-json";
 import {
   MinimalDemoChrome,
   MinimalDemoSection,
   minimalDemoTheme,
 } from "@vizij/minimal-demo-ui";
 import { cloneDeepSafe } from "@vizij/utils";
+import {
+  useAnimationRuntime,
+  type AnimationRuntimeApi,
+  type StoredAnimation,
+} from "./animationRuntime";
+import { listSamples, loadSample } from "./samples";
 
 const toPretty = (value: unknown) => JSON.stringify(value, null, 2);
-
-type StoredAnimation = Record<string, unknown>;
-type PlayerInfo = {
-  id: number;
-  name?: string;
-  time: number;
-  length: number;
-  start_time?: number;
-  end_time?: number | null;
-};
-
-const normalizeAnimations = (
-  source: StoredAnimation[] | StoredAnimation,
-): StoredAnimation[] => (Array.isArray(source) ? source : [source]);
-
-const cloneAnimationsList = (anims: StoredAnimation[]): StoredAnimation[] => {
-  return cloneDeepSafe(anims);
-};
 
 const clamp = (value: number, min: number, max: number) =>
   Math.min(Math.max(value, min), max);
 
 type AnimationSummary = {
   primaryAnimationId?: string | number;
-  primaryTrackAnimatableId?: string;
-  primaryTrackLabel?: string | number;
   animatableIds: string[];
 };
 
@@ -50,8 +30,12 @@ type AnimationValidationResult = {
   summary: AnimationSummary;
 };
 
+const normalizeAnimations = (
+  source: StoredAnimation[] | StoredAnimation,
+): StoredAnimation[] => (Array.isArray(source) ? source : [source]);
+
 const describeAnimation = (anim: StoredAnimation, index: number): string => {
-  const candidate = anim as any;
+  const candidate = anim as { id?: unknown; name?: unknown };
   if (typeof candidate?.id === "string" && candidate.id.trim() !== "") {
     return `animation "${candidate.id}"`;
   }
@@ -62,22 +46,6 @@ const describeAnimation = (anim: StoredAnimation, index: number): string => {
     return `animation "${candidate.name}"`;
   }
   return `animation[${index}]`;
-};
-
-const describeTrack = (
-  anim: StoredAnimation,
-  animIndex: number,
-  track: unknown,
-  trackIndex: number,
-): string => {
-  const trackObj = track as any;
-  if (typeof trackObj?.id === "string" && trackObj.id.trim() !== "") {
-    return `track "${trackObj.id}" of ${describeAnimation(anim, animIndex)}`;
-  }
-  if (typeof trackObj?.id === "number") {
-    return `track ${trackObj.id} of ${describeAnimation(anim, animIndex)}`;
-  }
-  return `track[${trackIndex}] of ${describeAnimation(anim, animIndex)}`;
 };
 
 const validateAnimations = (
@@ -94,7 +62,7 @@ const validateAnimations = (
       return;
     }
 
-    const animObj = anim as any;
+    const animObj = anim as { id?: unknown; tracks?: unknown };
     const animId = animObj.id;
     if (summary.primaryAnimationId === undefined) {
       if (typeof animId === "string" && animId.trim() !== "") {
@@ -117,24 +85,14 @@ const validateAnimations = (
       return;
     }
 
-    tracks.forEach((track: any, trackIndex: number) => {
-      if (!track || typeof track !== "object") {
-        errors.push(
-          `${describeTrack(anim, animIndex, track, trackIndex)} must be an object.`,
-        );
-        return;
-      }
-      const animatableId =
-        track.animatableId ?? track.animatable_id ?? track.target ?? undefined;
+    tracks.forEach((track: unknown) => {
+      const trackObj = track as { animatableId?: unknown };
+      const animatableId = trackObj?.animatableId;
       if (typeof animatableId !== "string" || animatableId.trim() === "") {
         errors.push(
-          `${describeTrack(anim, animIndex, track, trackIndex)} is missing a valid animatableId.`,
+          `${describeAnimation(anim, animIndex)} has a track missing a valid animatableId.`,
         );
         return;
-      }
-      if (!summary.primaryTrackAnimatableId) {
-        summary.primaryTrackAnimatableId = animatableId;
-        summary.primaryTrackLabel = track.id ?? trackIndex;
       }
       animatableIdSet.add(animatableId);
     });
@@ -171,25 +129,8 @@ function parseAnimations(text: string): StoredAnimation[] {
   throw new Error("Expected a StoredAnimation object or an array of them.");
 }
 
-type PanelProps = {
-  animations: StoredAnimation[];
-  setAnimations: Dispatch<StoredAnimation[] | null>;
-  initialAnimations: StoredAnimation[];
-  sampleOptions: string[];
-  selectedSample: string | null;
-  baselineSampleId: string | null;
-  onRequestSample: (id: string) => Promise<StoredAnimation[]>;
-  onSampleApplied: (id: string | null, baseline: StoredAnimation[]) => void;
-  onCustomSpec: () => void;
-  loadingSamples: boolean;
-};
-
-type TrackedKeyValueProps = {
-  targetKey: string;
-};
-
-const formatValue = (value: unknown) => {
-  const numeric = valueAsNumber(value as any);
+const formatValue = (value: ValueJSON | null | undefined) => {
+  const numeric = valueAsNumber(value ?? undefined);
   if (typeof numeric === "number" && Number.isFinite(numeric)) {
     return numeric.toFixed(4);
   }
@@ -205,8 +146,13 @@ const formatValue = (value: unknown) => {
   }
 };
 
-function TrackedKeyValue({ targetKey }: TrackedKeyValueProps) {
-  const value = useAnimTarget(targetKey);
+function TrackedKeyValue({
+  targetKey,
+  value,
+}: {
+  targetKey: string;
+  value: ValueJSON | null | undefined;
+}) {
   return (
     <div
       style={{
@@ -219,13 +165,7 @@ function TrackedKeyValue({ targetKey }: TrackedKeyValueProps) {
         color: minimalDemoTheme.text,
       }}
     >
-      <code
-        style={{
-          fontSize: 11,
-          opacity: 0.7,
-          wordBreak: "break-word",
-        }}
-      >
+      <code style={{ fontSize: 11, opacity: 0.7, wordBreak: "break-word" }}>
         {targetKey}
       </code>
       <strong
@@ -242,28 +182,31 @@ function TrackedKeyValue({ targetKey }: TrackedKeyValueProps) {
   );
 }
 
+type PanelProps = {
+  anim: AnimationRuntimeApi;
+  animations: StoredAnimation[];
+  setAnimations: (next: StoredAnimation[]) => void;
+  sampleOptions: string[];
+  selectedSample: string | null;
+  setSelectedSample: (id: string | null) => void;
+};
+
 function Panel({
+  anim,
   animations,
   setAnimations,
-  initialAnimations,
   sampleOptions,
   selectedSample,
-  baselineSampleId,
-  onRequestSample,
-  onSampleApplied,
-  onCustomSpec,
-  loadingSamples,
+  setSelectedSample,
 }: PanelProps) {
   const currentValidation = React.useMemo(
     () => validateAnimations(animations),
     [animations],
   );
   const allTrackedKeys = currentValidation.summary.animatableIds;
-  const primaryKey = allTrackedKeys[0];
-  const primaryValue = useAnimTarget(primaryKey);
   const currentAnimationId =
     currentValidation.summary.primaryAnimationId ?? undefined;
-  const animApi = useAnimation();
+
   const [warnings, setWarnings] = React.useState<string[]>(() =>
     currentValidation.warnings.slice(),
   );
@@ -272,24 +215,21 @@ function Panel({
   );
   const [error, setError] = React.useState<string | null>(null);
   const [status, setStatus] = React.useState<string | null>(null);
-  const [isSampleLoading, setIsSampleLoading] = React.useState(false);
-  const players = animApi.listPlayers?.() ?? [];
-  const primaryPlayer = players[0] as PlayerInfo | undefined;
-  const playerStart = Number(primaryPlayer?.start_time ?? 0) || 0;
-  const playerLengthRaw = Number(primaryPlayer?.length ?? 0) || 0;
-  const playerLength =
-    playerLengthRaw > playerStart
-      ? playerLengthRaw
-      : playerStart + (playerLengthRaw > 0 ? playerLengthRaw : 1);
-  const playerTimeRaw = Number(primaryPlayer?.time ?? playerStart) || 0;
-  const clampedTime = clamp(playerTimeRaw, playerStart, playerLength);
+
+  const primaryPlayer = anim.players[0];
+  const playerLength = Math.max(
+    Number(primaryPlayer?.duration ?? 0) || 0,
+    0.01,
+  );
+  const playerTime = clamp(
+    Number(primaryPlayer?.time ?? 0) || 0,
+    0,
+    playerLength,
+  );
 
   React.useEffect(() => {
     const { warnings: nextWarnings } = validateAnimations(animations);
     setWarnings(nextWarnings.slice());
-  }, [animations]);
-
-  React.useEffect(() => {
     setEditorText(
       toPretty(animations.length === 1 ? animations[0] : animations),
     );
@@ -298,7 +238,7 @@ function Panel({
   const applyAnimations = React.useCallback(
     (
       nextInput: StoredAnimation[] | StoredAnimation,
-      opts?: { source?: "sample" | "custom"; sampleId?: string | null },
+      opts?: { sampleId?: string | null },
     ) => {
       setStatus(null);
       setError(null);
@@ -319,70 +259,28 @@ function Panel({
         return false;
       }
 
-      const clonedList = cloneAnimationsList(normalizedList);
-
-      if (animApi.ready) {
-        try {
-          animApi.reload(clonedList);
-        } catch (err: unknown) {
-          setError(
-            `Animation engine rejected payload: ${
-              err instanceof Error ? err.message : String(err)
-            }`,
-          );
-          setWarnings(validationWarnings.slice());
-          return false;
-        }
-      }
-
-      setAnimations(clonedList);
+      // A new clips identity reloads the runtime inside the hook.
+      setAnimations(cloneDeepSafe(normalizedList));
+      setSelectedSample(opts?.sampleId ?? null);
 
       const segments: string[] = [];
-      if (normalizedList.length === 1) {
-        segments.push("Loaded 1 animation clip.");
-      } else {
-        segments.push(`Loaded ${normalizedList.length} animation clips.`);
-      }
-      if (summary.primaryAnimationId !== undefined) {
-        segments.push(`Animation ID: ${summary.primaryAnimationId}.`);
-      }
+      segments.push(
+        normalizedList.length === 1
+          ? "Loaded 1 animation clip."
+          : `Loaded ${normalizedList.length} animation clips.`,
+      );
       if (summary.animatableIds.length > 0) {
-        const keysPreview =
-          summary.animatableIds.length > 3
-            ? `${summary.animatableIds.slice(0, 3).join(", ")} (+${
-                summary.animatableIds.length - 3
-              } more)`
-            : summary.animatableIds.join(", ");
         segments.push(
           `Tracking ${summary.animatableIds.length} key${
             summary.animatableIds.length === 1 ? "" : "s"
-          }: ${keysPreview}.`,
+          }: ${summary.animatableIds.join(", ")}.`,
         );
-      } else {
-        segments.push("No animatableId detected.");
       }
-      if (validationWarnings.length > 0) {
-        const warningText =
-          validationWarnings.length === 1
-            ? `Warning: ${validationWarnings[0]}`
-            : `Warnings: ${validationWarnings.join(" ")}`;
-        segments.push(warningText);
-      }
-      if (!animApi.ready) {
-        segments.push("Engine is initialising; clip will load when ready.");
-      }
-
       setStatus(segments.join(" "));
       setWarnings(validationWarnings.slice());
-      setError(null);
-      if (opts?.source === "sample") {
-        onSampleApplied(opts.sampleId ?? null, clonedList);
-      } else if (opts?.source === "custom") {
-        onCustomSpec();
-      }
       return true;
     },
-    [animApi, setAnimations, onSampleApplied, onCustomSpec],
+    [setAnimations, setSelectedSample],
   );
 
   const onFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
@@ -391,17 +289,12 @@ function Panel({
     const file = e.target.files?.[0];
     if (!file) return;
     try {
-      const text = await new Promise<string>((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onerror = () => reject(new Error("Failed to read file"));
-        reader.onload = () => resolve(String(reader.result ?? ""));
-        reader.readAsText(file);
-      });
+      const text = await file.text();
       const parsed = parseAnimations(text);
       setEditorText(toPretty(parsed.length === 1 ? parsed[0] : parsed));
-      applyAnimations(parsed, { source: "custom" });
-    } catch (err: any) {
-      setError(err?.message ?? String(err));
+      applyAnimations(parsed, { sampleId: null });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
       setStatus(null);
     } finally {
       e.currentTarget.value = "";
@@ -412,10 +305,9 @@ function Panel({
     setStatus(null);
     setError(null);
     try {
-      const parsed = parseAnimations(editorText);
-      applyAnimations(parsed, { source: "custom" });
-    } catch (err: any) {
-      setError(err?.message ?? String(err));
+      applyAnimations(parseAnimations(editorText), { sampleId: null });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
     }
   };
 
@@ -423,9 +315,8 @@ function Panel({
     try {
       const parsed = parseAnimations(editorText);
       setEditorText(toPretty(parsed.length === 1 ? parsed[0] : parsed));
-    } catch (err: any) {
-      setError(err?.message ?? String(err));
-      setStatus(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
     }
   };
 
@@ -434,78 +325,27 @@ function Panel({
     setStatus("Saved animation JSON.");
   };
 
-  const sampleSelectValue = selectedSample ?? "__custom__";
-
-  const handleSampleSelect = React.useCallback(
-    async (event: ChangeEvent<HTMLSelectElement>) => {
-      const id = event.target.value;
-      if (!id || id === "__custom__" || id === selectedSample) {
-        return;
-      }
-      setStatus(null);
-      setError(null);
-      setIsSampleLoading(true);
-      try {
-        const payload = await onRequestSample(id);
-        const ok = applyAnimations(payload, {
-          source: "sample",
-          sampleId: id,
-        });
-        if (!ok) {
-          return;
-        }
-      } catch (err: any) {
-        const message = err instanceof Error ? err.message : String(err);
-        setError(`Failed to load sample "${id}": ${message}`);
-        setStatus(null);
-      } finally {
-        setIsSampleLoading(false);
-      }
-    },
-    [applyAnimations, onRequestSample, selectedSample],
-  );
-
-  const onRestoreInitial = () => {
-    const restored = applyAnimations(initialAnimations, {
-      source: "sample",
-      sampleId: baselineSampleId ?? null,
-    });
-    if (restored) {
-      setEditorText(
-        toPretty(
-          initialAnimations.length === 1
-            ? initialAnimations[0]
-            : initialAnimations,
-        ),
-      );
+  const handleSampleSelect = (event: ChangeEvent<HTMLSelectElement>) => {
+    const id = event.target.value;
+    if (!id || id === "__custom__") return;
+    try {
+      const payload = loadSample(id);
+      setEditorText(toPretty(payload));
+      applyAnimations(payload, { sampleId: id });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
     }
   };
 
-  const playerId = primaryPlayer?.id as number | undefined;
-
-  const sendCommand = React.useCallback(
-    (cmd: unknown) => {
-      if (playerId === undefined) return;
-      animApi.step(0, { player_cmds: [cmd] });
-      animApi.step(1 / 120);
-    },
-    [animApi, playerId],
-  );
-
-  const onSeek = React.useCallback(
-    (nextTime: number) => {
-      if (playerId === undefined) return;
-      const clamped = clamp(nextTime, playerStart, playerLength);
-      sendCommand({ Seek: { player: playerId, time: clamped } });
-    },
-    [playerId, playerStart, playerLength, sendCommand],
-  );
+  const onSeek = (nextTime: number) => {
+    anim.seek(clamp(nextTime, 0, playerLength));
+  };
 
   return (
     <MinimalDemoChrome
       title="Vizij animation demo"
-      subtitle="Minimal Vizij sample"
-      description="Load StoredAnimation clips, scrub them, and watch tracked keys update in real time."
+      subtitle="Minimal Vizij sample (runtime path)"
+      description="Load StoredAnimation clips, scrub them, and watch tracked keys update — driven by @vizij/animation-module running in a @vizij/runtime instance."
     >
       <MinimalDemoSection
         title="Active clip"
@@ -522,12 +362,10 @@ function Panel({
               {allTrackedKeys.length > 0 ? allTrackedKeys.join(", ") : "—"}
             </code>
           </p>
-          {primaryKey ? (
-            <p style={{ margin: 0 }}>
-              Primary value ({primaryKey}):{" "}
-              <strong>{formatValue(primaryValue)}</strong>
-            </p>
-          ) : null}
+          <p style={{ margin: 0, opacity: 0.7 }}>
+            Runtime: {anim.ready ? "running" : "starting…"}
+            {anim.error ? ` — error: ${anim.error}` : ""}
+          </p>
         </div>
       </MinimalDemoSection>
 
@@ -544,54 +382,31 @@ function Panel({
             background: minimalDemoTheme.card,
           }}
         >
-          <button
-            type="button"
-            onClick={() => sendCommand({ Play: { player: playerId } })}
-            disabled={playerId === undefined}
-          >
+          <button type="button" onClick={anim.play} disabled={!anim.ready}>
             Play
           </button>
-          <button
-            type="button"
-            onClick={() => sendCommand({ Pause: { player: playerId } })}
-            disabled={playerId === undefined}
-          >
+          <button type="button" onClick={anim.pause} disabled={!anim.ready}>
             Pause
           </button>
-          <button
-            type="button"
-            onClick={() => sendCommand({ Stop: { player: playerId } })}
-            disabled={playerId === undefined}
-          >
+          <button type="button" onClick={anim.stop} disabled={!anim.ready}>
             Reset
           </button>
           <div style={{ marginLeft: "auto", minWidth: 160 }}>
-            <div
+            <input
+              type="range"
+              min={0}
+              max={playerLength}
+              step={playerLength / 200}
+              value={playerTime}
+              onChange={(event) => onSeek(Number(event.target.value))}
+              disabled={!anim.ready}
               style={{
-                display: "grid",
-                gap: 4,
+                appearance: "none",
+                width: "100%",
+                cursor: anim.ready ? "pointer" : "not-allowed",
+                accentColor: "#ef4444",
               }}
-            >
-              <input
-                type="range"
-                min={playerStart}
-                max={playerLength}
-                step={
-                  playerLength - playerStart > 0
-                    ? (playerLength - playerStart) / 200
-                    : 0.01
-                }
-                value={clampedTime}
-                onChange={(event) => onSeek(Number(event.target.value))}
-                disabled={playerId === undefined}
-                style={{
-                  appearance: "none",
-                  width: "100%",
-                  cursor: playerId === undefined ? "not-allowed" : "pointer",
-                  accentColor: "#ef4444",
-                }}
-              />
-            </div>
+            />
             <div
               style={{
                 display: "flex",
@@ -600,12 +415,12 @@ function Panel({
                 marginTop: 6,
               }}
             >
-              <span>{playerStart.toFixed(2)}s</span>
+              <span>0.00s</span>
               <span>{playerLength.toFixed(2)}s</span>
             </div>
           </div>
           <div style={{ fontSize: 12, opacity: 0.75 }}>
-            Time: {clampedTime.toFixed(2)}s
+            Time: {playerTime.toFixed(2)}s
           </div>
         </div>
       </MinimalDemoSection>
@@ -621,7 +436,11 @@ function Panel({
             }}
           >
             {allTrackedKeys.map((key) => (
-              <TrackedKeyValue key={key} targetKey={key} />
+              <TrackedKeyValue
+                key={key}
+                targetKey={key}
+                value={anim.values[key]}
+              />
             ))}
           </div>
         ) : (
@@ -644,19 +463,10 @@ function Panel({
           <label style={{ display: "flex", gap: 8, alignItems: "center" }}>
             <strong>Sample</strong>
             <select
-              value={sampleSelectValue}
+              value={selectedSample ?? "__custom__"}
               onChange={handleSampleSelect}
-              disabled={
-                loadingSamples || isSampleLoading || sampleOptions.length === 0
-              }
             >
-              <option value="__custom__">
-                {loadingSamples
-                  ? "Loading samples…"
-                  : sampleOptions.length === 0
-                    ? "No samples available"
-                    : "Custom (editor/file)"}
-              </option>
+              <option value="__custom__">Custom (editor/file)</option>
               {sampleOptions.map((name) => (
                 <option key={name} value={name}>
                   {name}
@@ -681,14 +491,6 @@ function Panel({
           <button type="button" onClick={onDownload}>
             Save JSON
           </button>
-          <button type="button" onClick={onRestoreInitial}>
-            Restore initial clip
-          </button>
-          {isSampleLoading ? (
-            <span style={{ color: minimalDemoTheme.muted }}>
-              Loading sample…
-            </span>
-          ) : null}
         </div>
         <textarea
           value={editorText}
@@ -717,8 +519,8 @@ function Panel({
         ) : null}
         <p style={{ opacity: 0.65, fontSize: 14, margin: 0 }}>
           Paste or load a StoredAnimation JSON payload, tweak it, then apply to
-          reload the WASM engine. The provider will stream updates to the value
-          above.
+          reload the runtime. The tracked values above stream from the runtime
+          store each frame.
         </p>
       </section>
     </MinimalDemoChrome>
@@ -726,134 +528,30 @@ function Panel({
 }
 
 export default function App() {
-  const [animations, setAnimations] = React.useState<StoredAnimation[] | null>(
-    null,
-  );
-  const [initialAnimations, setInitialAnimations] = React.useState<
-    StoredAnimation[]
-  >([]);
-  const [sampleOptions, setSampleOptions] = React.useState<string[]>([]);
+  const sampleOptions = React.useMemo(() => listSamples(), []);
+  const [animations, setAnimations] = React.useState<StoredAnimation[]>(() => [
+    loadSample(
+      sampleOptions.includes("simple-scalar-ramp")
+        ? "simple-scalar-ramp"
+        : sampleOptions[0],
+    ),
+  ]);
   const [selectedSample, setSelectedSample] = React.useState<string | null>(
-    null,
-  );
-  const [baselineSampleId, setBaselineSampleId] = React.useState<string | null>(
-    null,
-  );
-  const [loadingSamples, setLoadingSamples] = React.useState(true);
-  const [loadError, setLoadError] = React.useState<string | null>(null);
-  const mountedRef = React.useRef(true);
-
-  React.useEffect(() => {
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
-
-  const requestSample = React.useCallback(async (id: string) => {
-    const payload = (await animationSamples.load(id)) as
-      | StoredAnimation
-      | StoredAnimation[];
-    const normalized = normalizeAnimations(payload);
-    return cloneAnimationsList(normalized);
-  }, []);
-
-  React.useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const names = await animationSamples.list();
-        if (cancelled || !mountedRef.current) return;
-        const sorted = names.slice().sort((a, b) => a.localeCompare(b));
-        setSampleOptions(sorted);
-        if (sorted.length > 0) {
-          const preferred = sorted.includes("simple-scalar-ramp")
-            ? "simple-scalar-ramp"
-            : sorted[0];
-          const normalized = await requestSample(preferred);
-          if (cancelled || !mountedRef.current) return;
-          setAnimations(cloneAnimationsList(normalized));
-          setInitialAnimations(cloneAnimationsList(normalized));
-          setSelectedSample(preferred);
-          setBaselineSampleId(preferred);
-        } else {
-          setAnimations([]);
-          setInitialAnimations([]);
-          setBaselineSampleId(null);
-        }
-      } catch (err: any) {
-        if (cancelled || !mountedRef.current) return;
-        const message =
-          err instanceof Error ? err.message : String(err ?? "unknown");
-        setLoadError(`Failed to load animation samples: ${message}`);
-      } finally {
-        if (!cancelled && mountedRef.current) {
-          setLoadingSamples(false);
-        }
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [requestSample]);
-
-  const handleSampleApplied = React.useCallback(
-    (sampleId: string | null, baseline: StoredAnimation[]) => {
-      setInitialAnimations(cloneAnimationsList(baseline));
-      if (sampleId) {
-        setSelectedSample(sampleId);
-        setBaselineSampleId(sampleId);
-      } else {
-        setSelectedSample(null);
-        setBaselineSampleId(null);
-      }
-    },
-    [],
+    sampleOptions.includes("simple-scalar-ramp")
+      ? "simple-scalar-ramp"
+      : (sampleOptions[0] ?? null),
   );
 
-  const handleCustomSpec = React.useCallback(() => {
-    setSelectedSample(null);
-  }, []);
-
-  if (animations === null) {
-    return (
-      <div
-        style={{
-          fontFamily: "Inter, system-ui, sans-serif",
-          maxWidth: 640,
-          margin: "2rem auto",
-          padding: "0 1rem",
-        }}
-      >
-        <h1 style={{ margin: "0 0 1rem" }}>Vizij Animation Demo</h1>
-        <p style={{ color: minimalDemoTheme.muted }}>
-          {loadingSamples
-            ? "Loading animation samples…"
-            : (loadError ??
-              "Unable to load animation samples. Check the console for details.")}
-        </p>
-      </div>
-    );
-  }
+  const anim = useAnimationRuntime(animations, { autoplay: true });
 
   return (
-    <AnimationProvider
+    <Panel
+      anim={anim}
       animations={animations}
-      prebind={(path) => path}
-      autostart
-      updateHz={60}
-    >
-      <Panel
-        animations={animations}
-        setAnimations={setAnimations}
-        initialAnimations={initialAnimations}
-        sampleOptions={sampleOptions}
-        selectedSample={selectedSample}
-        baselineSampleId={baselineSampleId}
-        onRequestSample={requestSample}
-        onSampleApplied={handleSampleApplied}
-        onCustomSpec={handleCustomSpec}
-        loadingSamples={loadingSamples}
-      />
-    </AnimationProvider>
+      setAnimations={setAnimations}
+      sampleOptions={sampleOptions}
+      selectedSample={selectedSample}
+      setSelectedSample={setSelectedSample}
+    />
   );
 }

--- a/apps/minimal-demo-animation/src/animationRuntime.ts
+++ b/apps/minimal-demo-animation/src/animationRuntime.ts
@@ -1,0 +1,758 @@
+/**
+ * Local helper: run stored animation clips through a `@vizij/runtime` runtime
+ * with the `@vizij/animation-module` guest, in place of the standalone
+ * `@vizij/animation-wasm` engine + `@vizij/animation-react` provider.
+ *
+ * The runtime (`@vizij/runtime`'s `startDevice`/`AroraDevice` — "device" is the
+ * package's own term for a running Arora instance) executes a small behavior
+ * graph: an `ExternalFunction` node calls the module's `step(dt_ns)` every tick
+ * (fed the golden `arora/dt`), a path-less `output` node applies the returned
+ * `[TrackOutput]` batch onto the store keys each record names (its authored
+ * `default_key`, decided at clip load), and a second `ExternalFunction` /
+ * `output` pair writes `player_states()` to `ANIMATION_PLAYERS_PATH`. Clips
+ * load into a single player as data through the module's call surface, and a
+ * `requestAnimationFrame` loop advances the runtime and drains the store.
+ *
+ * Call arguments/returns use the Arora `Value` JSON encoding (`{ str }`,
+ * `{ f32 }`, `{ u32 }`, `{ struct }`, `{ structs }`, …); sampled outputs land in
+ * the store as Vizij `ValueJSON`, read back with `@vizij/value-json` helpers.
+ *
+ * This is a demo-local copy — the same glue exists (unexported) inside
+ * `@vizij/runtime-react`; the demos keep a small copy rather than depend on the
+ * full renderer runtime. The reusable home for it is upstream in
+ * `@vizij/runtime` / `@vizij/animation-module`.
+ */
+import { useEffect, useMemo, useRef, useState } from "react";
+import { init, startDevice, type AroraDevice } from "@vizij/runtime";
+import { loadAnimationModule } from "@vizij/animation-module";
+import type { ValueJSON } from "@vizij/value-json";
+
+// --- declared function + parameter ids (module.yaml) -------------------------
+export const ANIMATION_MODULE_FN = {
+  loadAnimation: "76697a69-6a00-0000-0f00-000000000001",
+  createPlayer: "76697a69-6a00-0000-0f00-000000000002",
+  addInstance: "76697a69-6a00-0000-0f00-000000000003",
+  step: "76697a69-6a00-0000-0f00-000000000004",
+  play: "76697a69-6a00-0000-0f00-000000000005",
+  pause: "76697a69-6a00-0000-0f00-000000000006",
+  stop: "76697a69-6a00-0000-0f00-000000000007",
+  seek: "76697a69-6a00-0000-0f00-000000000008",
+  setSpeed: "76697a69-6a00-0000-0f00-000000000009",
+  setLoop: "76697a69-6a00-0000-0f00-00000000000a",
+  setWeight: "76697a69-6a00-0000-0f00-00000000000b",
+  removeInstance: "76697a69-6a00-0000-0f00-00000000000c",
+  playerStates: "76697a69-6a00-0000-0f00-00000000000d",
+} as const;
+
+export const ANIMATION_MODULE_PARAM = {
+  clip: "76697a69-6a00-0000-0f01-000000000001",
+  playerName: "76697a69-6a00-0000-0f02-000000000001",
+  player: "76697a69-6a00-0000-0f03-000000000001",
+  anim: "76697a69-6a00-0000-0f03-000000000002",
+  dtNs: "76697a69-6a00-0000-0f04-000000000001",
+  playPlayer: "76697a69-6a00-0000-0f05-000000000001",
+  pausePlayer: "76697a69-6a00-0000-0f06-000000000001",
+  stopPlayer: "76697a69-6a00-0000-0f07-000000000001",
+  seekPlayer: "76697a69-6a00-0000-0f08-000000000001",
+  seekTimeNs: "76697a69-6a00-0000-0f08-000000000002",
+  speedPlayer: "76697a69-6a00-0000-0f09-000000000001",
+  speedValue: "76697a69-6a00-0000-0f09-000000000002",
+  loopPlayer: "76697a69-6a00-0000-0f0a-000000000001",
+  loopMode: "76697a69-6a00-0000-0f0a-000000000002",
+} as const;
+
+// --- declared structure ids (records/structure/*.yaml) -----------------------
+export const ANIMATION_MODULE_TYPE = {
+  clip: "76697a69-6a00-0000-0000-000000000100",
+  track: "76697a69-6a00-0000-0000-000000000101",
+  keypoint: "76697a69-6a00-0000-0000-000000000102",
+  transitionHandle: "76697a69-6a00-0000-0000-000000000103",
+} as const;
+
+export const ANIMATION_MODULE_FIELD = {
+  clipName: "76697a69-6a00-0000-0100-000000000001",
+  clipDuration: "76697a69-6a00-0000-0100-000000000002",
+  clipTracks: "76697a69-6a00-0000-0100-000000000003",
+  trackId: "76697a69-6a00-0000-0101-000000000001",
+  trackName: "76697a69-6a00-0000-0101-000000000002",
+  trackAnimatable: "76697a69-6a00-0000-0101-000000000003",
+  trackPoints: "76697a69-6a00-0000-0101-000000000004",
+  keypointId: "76697a69-6a00-0000-0102-000000000001",
+  keypointStamp: "76697a69-6a00-0000-0102-000000000002",
+  keypointValue: "76697a69-6a00-0000-0102-000000000003",
+  keypointTransitionsIn: "76697a69-6a00-0000-0102-000000000004",
+  keypointTransitionsOut: "76697a69-6a00-0000-0102-000000000005",
+  handleX: "76697a69-6a00-0000-0103-000000000001",
+  handleY: "76697a69-6a00-0000-0103-000000000002",
+  outputDefaultKey: "76697a69-6a00-0000-0110-000000000002",
+  outputValue: "76697a69-6a00-0000-0110-000000000003",
+  statePlayer: "76697a69-6a00-0000-0111-000000000001",
+  stateState: "76697a69-6a00-0000-0111-000000000002",
+  stateTimeNs: "76697a69-6a00-0000-0111-000000000003",
+  stateDurationNs: "76697a69-6a00-0000-0111-000000000004",
+  stateSpeed: "76697a69-6a00-0000-0111-000000000005",
+} as const;
+
+// --- the Arora `Value` JSON encoding (narrow, only what this seam needs) -----
+export interface AroraField {
+  id: string;
+  value: AroraValueJSON;
+}
+
+export interface AroraStruct {
+  id: string;
+  fields: AroraField[];
+}
+
+export type AroraValueJSON =
+  | { str: string }
+  | { f32: number }
+  | { u32: number }
+  | { u64: number }
+  | { struct: AroraStruct }
+  | { structs: { id: string; elements: Array<{ fields: AroraField[] }> } }
+  | Record<string, unknown>;
+
+/** An Arora `Call` payload for `AroraDevice.call`. */
+export interface AnimationModuleCall {
+  id: string;
+  args: AroraField[];
+}
+
+export type AnimationLoopMode = "once" | "loop" | "ping_pong";
+
+// --- the stored-clip shape ----------------------------------------------------
+
+/** One authored keyframe: a normalized stamp (0..1) and a scalar value. */
+export interface StoredKeypoint {
+  id?: string;
+  stamp: number;
+  value: number;
+  /** Authored timing handles (`linear`/`step` ride through; absent = default ease). */
+  transitions?: {
+    in?: { x: number; y: number };
+    out?: { x: number; y: number };
+  };
+}
+
+/** One authored track: the store path it drives plus its keyframes. */
+export interface StoredTrack {
+  id?: string;
+  name?: string;
+  animatableId: string;
+  points: StoredKeypoint[];
+  /** Ignored by the module; carried for demo UIs (e.g. `{ color }`). */
+  settings?: unknown;
+}
+
+/**
+ * A stored animation clip — the JSON shape the demos author and the standalone
+ * `@vizij/animation-wasm` engine also loads (`duration` in ms, per-track
+ * keypoints with normalized 0..1 stamps). Extra fields are ignored.
+ */
+export interface StoredAnimation {
+  id?: string | number;
+  name?: string;
+  duration?: number;
+  tracks: StoredTrack[];
+  groups?: unknown;
+}
+
+const field = (id: string, value: AroraValueJSON): AroraField => ({
+  id,
+  value,
+});
+
+/** One target path per authored track key; identity when no resolver is given. */
+export type ResolveTrackKeys = (animatableId: string) => string[];
+
+/**
+ * Convert a stored clip into the module's declared `AnimationClip` value.
+ *
+ * `resolveKeys` decides the final store keys at load time: each track is
+ * emitted once per resolved target path, with that path as its `animatable_id`
+ * — so the module's `[TrackOutput]` names the store keys the graph's path-less
+ * `output` node applies, and no per-tick re-keying exists anywhere. Authored
+ * `cubic` keyframes carry no explicit handles in the stored form, so they
+ * sample the engine's default ease (`linear`/`step` ride through as handles).
+ */
+export function storedClipToModuleValue(
+  clip: StoredAnimation,
+  resolveKeys?: ResolveTrackKeys,
+): AroraValueJSON {
+  const name =
+    typeof clip.name === "string" && clip.name.trim().length > 0
+      ? clip.name.trim()
+      : typeof clip.id === "string"
+        ? clip.id
+        : "";
+  const durationMs = Number(clip.duration);
+  const duration =
+    Number.isFinite(durationMs) && durationMs > 0 ? Math.round(durationMs) : 1;
+
+  const tracks = (Array.isArray(clip.tracks) ? clip.tracks : [])
+    .map((rawTrack, index) => {
+      if (!rawTrack || typeof rawTrack !== "object") {
+        return null;
+      }
+      const animatableId =
+        typeof rawTrack.animatableId === "string"
+          ? rawTrack.animatableId.trim()
+          : "";
+      if (!animatableId) {
+        return null;
+      }
+      const trackId =
+        typeof rawTrack.id === "string" && rawTrack.id.trim().length > 0
+          ? rawTrack.id.trim()
+          : `track-${index}`;
+      const trackName =
+        typeof rawTrack.name === "string" && rawTrack.name.trim().length > 0
+          ? rawTrack.name.trim()
+          : trackId;
+
+      const points = (Array.isArray(rawTrack.points) ? rawTrack.points : [])
+        .map((rawPoint, pointIndex) => {
+          if (!rawPoint || typeof rawPoint !== "object") {
+            return null;
+          }
+          const stamp = Number(rawPoint.stamp);
+          const value = Number(rawPoint.value);
+          if (!Number.isFinite(stamp) || !Number.isFinite(value)) {
+            return null;
+          }
+          const pointId =
+            typeof rawPoint.id === "string" && rawPoint.id.trim().length > 0
+              ? rawPoint.id.trim()
+              : `${trackId}:point-${pointIndex}`;
+          const handles = (
+            handle: { x: number; y: number } | undefined,
+          ): AroraValueJSON => ({
+            structs: {
+              id: ANIMATION_MODULE_TYPE.transitionHandle,
+              elements: handle
+                ? [
+                    {
+                      fields: [
+                        field(ANIMATION_MODULE_FIELD.handleX, {
+                          f32: handle.x,
+                        }),
+                        field(ANIMATION_MODULE_FIELD.handleY, {
+                          f32: handle.y,
+                        }),
+                      ],
+                    },
+                  ]
+                : [],
+            },
+          });
+          return {
+            fields: [
+              field(ANIMATION_MODULE_FIELD.keypointId, { str: pointId }),
+              field(ANIMATION_MODULE_FIELD.keypointStamp, {
+                f32: Math.max(0, Math.min(1, stamp)),
+              }),
+              field(ANIMATION_MODULE_FIELD.keypointValue, { f32: value }),
+              field(
+                ANIMATION_MODULE_FIELD.keypointTransitionsIn,
+                handles(rawPoint.transitions?.in),
+              ),
+              field(
+                ANIMATION_MODULE_FIELD.keypointTransitionsOut,
+                handles(rawPoint.transitions?.out),
+              ),
+            ],
+          };
+        })
+        .filter(Boolean) as Array<{ fields: AroraField[] }>;
+
+      if (points.length === 0) {
+        return null;
+      }
+
+      const targets = resolveKeys?.(animatableId) ?? [animatableId];
+      return targets.map((target, targetIndex) => ({
+        fields: [
+          field(ANIMATION_MODULE_FIELD.trackId, {
+            str: targetIndex === 0 ? trackId : `${trackId}~${targetIndex}`,
+          }),
+          field(ANIMATION_MODULE_FIELD.trackName, { str: trackName }),
+          field(ANIMATION_MODULE_FIELD.trackAnimatable, { str: target }),
+          field(ANIMATION_MODULE_FIELD.trackPoints, {
+            structs: {
+              id: ANIMATION_MODULE_TYPE.keypoint,
+              elements: points,
+            },
+          }),
+        ],
+      }));
+    })
+    .filter(Boolean)
+    .flat() as Array<{ fields: AroraField[] }>;
+
+  return {
+    struct: {
+      id: ANIMATION_MODULE_TYPE.clip,
+      fields: [
+        field(ANIMATION_MODULE_FIELD.clipName, { str: name }),
+        field(ANIMATION_MODULE_FIELD.clipDuration, { u32: duration }),
+        field(ANIMATION_MODULE_FIELD.clipTracks, {
+          structs: {
+            id: ANIMATION_MODULE_TYPE.track,
+            elements: tracks,
+          },
+        }),
+      ],
+    },
+  };
+}
+
+// --- call builders ------------------------------------------------------------
+
+/** `load_animation(clip) → { u32: AnimId }`. */
+export function loadAnimationCall(
+  clipValue: AroraValueJSON,
+): AnimationModuleCall {
+  return {
+    id: ANIMATION_MODULE_FN.loadAnimation,
+    args: [field(ANIMATION_MODULE_PARAM.clip, clipValue)],
+  };
+}
+
+/** `create_player(name) → { u32: PlayerId }`. */
+export function createPlayerCall(name: string): AnimationModuleCall {
+  return {
+    id: ANIMATION_MODULE_FN.createPlayer,
+    args: [field(ANIMATION_MODULE_PARAM.playerName, { str: name })],
+  };
+}
+
+/** `add_instance(player, anim) → { u32: InstId }`. */
+export function addInstanceCall(
+  player: number,
+  anim: number,
+): AnimationModuleCall {
+  return {
+    id: ANIMATION_MODULE_FN.addInstance,
+    args: [
+      field(ANIMATION_MODULE_PARAM.player, { u32: player }),
+      field(ANIMATION_MODULE_PARAM.anim, { u32: anim }),
+    ],
+  };
+}
+
+/** `play(player)`: resume or start playback at the next step. */
+export function playCall(player: number): AnimationModuleCall {
+  return {
+    id: ANIMATION_MODULE_FN.play,
+    args: [field(ANIMATION_MODULE_PARAM.playPlayer, { u32: player })],
+  };
+}
+
+/** `pause(player)`: hold the playhead at the next step. */
+export function pauseCall(player: number): AnimationModuleCall {
+  return {
+    id: ANIMATION_MODULE_FN.pause,
+    args: [field(ANIMATION_MODULE_PARAM.pausePlayer, { u32: player })],
+  };
+}
+
+/** `stop(player)`: reset the playhead to the window start at the next step. */
+export function stopCall(player: number): AnimationModuleCall {
+  return {
+    id: ANIMATION_MODULE_FN.stop,
+    args: [field(ANIMATION_MODULE_PARAM.stopPlayer, { u32: player })],
+  };
+}
+
+/** `seek(player, time_ns)`: move the playhead (nanoseconds, the dt_ns base). */
+export function seekCall(player: number, timeNs: number): AnimationModuleCall {
+  return {
+    id: ANIMATION_MODULE_FN.seek,
+    args: [
+      field(ANIMATION_MODULE_PARAM.seekPlayer, { u32: player }),
+      field(ANIMATION_MODULE_PARAM.seekTimeNs, {
+        u64: Math.max(0, Math.round(timeNs)),
+      }),
+    ],
+  };
+}
+
+/** `set_speed(player, speed)`: playback speed multiplier. */
+export function setSpeedCall(
+  player: number,
+  speed: number,
+): AnimationModuleCall {
+  return {
+    id: ANIMATION_MODULE_FN.setSpeed,
+    args: [
+      field(ANIMATION_MODULE_PARAM.speedPlayer, { u32: player }),
+      field(ANIMATION_MODULE_PARAM.speedValue, { f32: speed }),
+    ],
+  };
+}
+
+/** `set_loop(player, mode)`: `"once" | "loop" | "ping_pong"`. */
+export function setLoopCall(
+  player: number,
+  mode: AnimationLoopMode,
+): AnimationModuleCall {
+  return {
+    id: ANIMATION_MODULE_FN.setLoop,
+    args: [
+      field(ANIMATION_MODULE_PARAM.loopPlayer, { u32: player }),
+      field(ANIMATION_MODULE_PARAM.loopMode, { str: mode }),
+    ],
+  };
+}
+
+/** The `{ u32 }` a setup call returns, or `null` on any other shape. */
+export function callResultU32(result: { ret: unknown }): number | null {
+  const ret = result.ret;
+  if (ret && typeof ret === "object" && "u32" in ret) {
+    const value = Number((ret as { u32: unknown }).u32);
+    return Number.isFinite(value) ? value : null;
+  }
+  return null;
+}
+
+// --- the behavior graph -------------------------------------------------------
+
+/**
+ * Store path the graph writes the module's per-tick `[PlayerState]` feedback
+ * to. Not an `arora/` golden key, so it reads back like any store value.
+ */
+export const ANIMATION_PLAYERS_PATH = "vizij/animations/players";
+
+/** A Vizij graph spec, structurally (what `startDevice` accepts). */
+export interface AnimationGraphSpec {
+  nodes: Array<Record<string, unknown>>;
+  edges: Array<Record<string, unknown>>;
+}
+
+/**
+ * The behavior graph that ticks the animation module: an `ExternalFunction`
+ * node calls the module's `step` every tick, fed the golden `arora/dt`
+ * (nanoseconds); a path-less `output` node applies the returned `[TrackOutput]`
+ * batch onto the store keys each record names (`default_key` — the final store
+ * paths, decided at clip load); and a second `ExternalFunction` / `output` pair
+ * writes `player_states()` to `ANIMATION_PLAYERS_PATH`.
+ */
+export function buildAnimationGraph(): AnimationGraphSpec {
+  return {
+    nodes: [
+      { id: "dt", type: "input", params: { path: "arora/dt" } },
+      {
+        id: "step",
+        type: "externalfunction",
+        params: {
+          function: ANIMATION_MODULE_FN.step,
+          param_ids: [ANIMATION_MODULE_PARAM.dtNs],
+        },
+      },
+      {
+        id: "apply",
+        type: "output",
+        params: {
+          key_field: ANIMATION_MODULE_FIELD.outputDefaultKey,
+          value_field: ANIMATION_MODULE_FIELD.outputValue,
+        },
+      },
+      {
+        id: "states",
+        type: "externalfunction",
+        params: { function: ANIMATION_MODULE_FN.playerStates, param_ids: [] },
+      },
+      {
+        id: "states-out",
+        type: "output",
+        params: { path: ANIMATION_PLAYERS_PATH },
+      },
+    ],
+    edges: [
+      { from: { node_id: "dt" }, to: { node_id: "step", input: "args_0" } },
+      { from: { node_id: "step" }, to: { node_id: "apply", input: "in" } },
+      {
+        from: { node_id: "states" },
+        to: { node_id: "states-out", input: "in" },
+      },
+    ],
+  };
+}
+
+// --- PlayerState decoding -------------------------------------------------------
+
+export interface AnimationPlayerState {
+  /** The module `PlayerId` (correlate via the loaded clips' player ids). */
+  player: number;
+  /** `"playing" | "paused" | "stopped"` — the engine's derived state. */
+  state: string;
+  /** Playhead in seconds. */
+  time: number;
+  /** Full player length in seconds. */
+  duration: number;
+  /** Playback speed multiplier. */
+  speed: number;
+}
+
+function fieldNumber(value: AroraValueJSON | undefined): number | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  for (const key of ["u64", "u32", "f32", "f64"]) {
+    if (key in value) {
+      const parsed = Number((value as Record<string, unknown>)[key]);
+      return Number.isFinite(parsed) ? parsed : null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Decode the `[PlayerState]` value the graph writes to `ANIMATION_PLAYERS_PATH`
+ * (a `structs` of the declared PlayerState type). Tolerant: unknown shapes
+ * decode to an empty list.
+ */
+export function decodePlayerStates(raw: unknown): AnimationPlayerState[] {
+  if (!raw || typeof raw !== "object" || !("structs" in raw)) {
+    return [];
+  }
+  const structs = (raw as { structs?: { elements?: unknown } }).structs;
+  const elements = Array.isArray(structs?.elements) ? structs.elements : [];
+  const states: AnimationPlayerState[] = [];
+  for (const element of elements) {
+    const fields = (element as { fields?: unknown })?.fields;
+    if (!Array.isArray(fields)) {
+      continue;
+    }
+    const byId = new Map<string, AroraValueJSON>();
+    for (const entry of fields) {
+      const id = (entry as { id?: unknown })?.id;
+      const value = (entry as { value?: unknown })?.value;
+      if (typeof id === "string" && value && typeof value === "object") {
+        byId.set(id, value as AroraValueJSON);
+      }
+    }
+    const player = fieldNumber(byId.get(ANIMATION_MODULE_FIELD.statePlayer));
+    if (player === null) {
+      continue;
+    }
+    const stateValue = byId.get(ANIMATION_MODULE_FIELD.stateState);
+    states.push({
+      player,
+      state:
+        stateValue && "str" in stateValue
+          ? String((stateValue as { str: unknown }).str)
+          : "",
+      time:
+        (fieldNumber(byId.get(ANIMATION_MODULE_FIELD.stateTimeNs)) ?? 0) / 1e9,
+      duration:
+        (fieldNumber(byId.get(ANIMATION_MODULE_FIELD.stateDurationNs)) ?? 0) /
+        1e9,
+      speed: fieldNumber(byId.get(ANIMATION_MODULE_FIELD.stateSpeed)) ?? 1,
+    });
+  }
+  return states;
+}
+
+// --- the React hook -----------------------------------------------------------
+
+export interface UseAnimationRuntimeOptions {
+  /** Start playback as soon as the clips are loaded (default: true). */
+  autoplay?: boolean;
+  /** How player time maps into clip time (default: "loop"). */
+  loop?: AnimationLoopMode;
+}
+
+export interface AnimationRuntimeApi {
+  /** True once the runtime is up and the clips are loaded. */
+  ready: boolean;
+  /**
+   * Latest store snapshot. A track's current sampled value is at
+   * `values[animatableId]` in the Vizij `ValueJSON` vocabulary.
+   */
+  values: Record<string, ValueJSON | null>;
+  /** Decoded per-tick player feedback (time / length / state / speed). */
+  players: AnimationPlayerState[];
+  /** Resume (or start) playback. */
+  play: () => void;
+  /** Hold the playhead. */
+  pause: () => void;
+  /** Reset the playhead to the clip start. */
+  stop: () => void;
+  /** Move the playhead to `seconds`. */
+  seek: (seconds: number) => void;
+  /** Set the playback speed multiplier. */
+  setSpeed: (speed: number) => void;
+  /** A setup error message, or null. */
+  error: string | null;
+}
+
+const EMPTY_VALUES: Record<string, ValueJSON | null> = {};
+const EMPTY_PLAYERS: AnimationPlayerState[] = [];
+
+function normalizeClips(
+  clips: StoredAnimation[] | StoredAnimation | null | undefined,
+): StoredAnimation[] {
+  if (!clips) {
+    return [];
+  }
+  return Array.isArray(clips) ? clips : [clips];
+}
+
+/**
+ * Run `clips` through a `@vizij/runtime` runtime with the animation module and
+ * surface the sampled outputs + player transport. The runtime is (re)built
+ * whenever the `clips` identity changes — that is the reload path. Transport
+ * calls dispatch on the next runtime step, which the running loop takes.
+ */
+export function useAnimationRuntime(
+  clips: StoredAnimation[] | StoredAnimation | null | undefined,
+  options: UseAnimationRuntimeOptions = {},
+): AnimationRuntimeApi {
+  const { autoplay = true, loop = "loop" } = options;
+
+  const [ready, setReady] = useState(false);
+  const [values, setValues] =
+    useState<Record<string, ValueJSON | null>>(EMPTY_VALUES);
+  const [players, setPlayers] = useState<AnimationPlayerState[]>(EMPTY_PLAYERS);
+  const [error, setError] = useState<string | null>(null);
+
+  // The live runtime + its single player id, shared with the transport methods.
+  const runtimeRef = useRef<AroraDevice | null>(null);
+  const playerIdRef = useRef<number | null>(null);
+
+  const clipList = normalizeClips(clips);
+
+  useEffect(() => {
+    let cancelled = false;
+    let raf = 0;
+    let runtime: AroraDevice | null = null;
+    const accumulated: Record<string, ValueJSON | null> = {};
+
+    setReady(false);
+    setValues(EMPTY_VALUES);
+    setPlayers(EMPTY_PLAYERS);
+    setError(null);
+    runtimeRef.current = null;
+    playerIdRef.current = null;
+
+    (async () => {
+      try {
+        await init();
+        const module = await loadAnimationModule();
+        if (cancelled) return;
+        runtime = await startDevice(buildAnimationGraph(), undefined, [module]);
+        if (cancelled) {
+          runtime.dispose();
+          return;
+        }
+
+        // Issue a call, take the pending step that dispatches it, and await it.
+        const callSync = async (call: Parameters<AroraDevice["call"]>[0]) => {
+          const pending = runtime!.call(call);
+          runtime!.step(0);
+          return pending;
+        };
+
+        const playerResult = await callSync(createPlayerCall("default"));
+        const playerId = callResultU32(playerResult);
+        if (cancelled) return;
+        if (playerId === null) {
+          throw new Error("create_player did not return a player id");
+        }
+
+        for (const clip of clipList) {
+          const animResult = await callSync(
+            loadAnimationCall(storedClipToModuleValue(clip)),
+          );
+          if (cancelled) return;
+          const animId = callResultU32(animResult);
+          if (animId === null) continue;
+          await callSync(addInstanceCall(playerId, animId));
+          if (cancelled) return;
+        }
+
+        await callSync(setLoopCall(playerId, loop));
+        if (cancelled) return;
+        if (autoplay) {
+          await callSync(playCall(playerId));
+          if (cancelled) return;
+        }
+
+        runtimeRef.current = runtime;
+        playerIdRef.current = playerId;
+        setReady(true);
+
+        // Advance the runtime and mirror the store into React each frame.
+        let last =
+          typeof performance !== "undefined" ? performance.now() : Date.now();
+        const tick = () => {
+          if (cancelled || !runtime) return;
+          const now =
+            typeof performance !== "undefined" ? performance.now() : Date.now();
+          const dtMs = Math.max(0, now - last);
+          last = now;
+          runtime.step(dtMs);
+          const changes = runtime.drainChanges();
+          let dirty = false;
+          for (const [key, value] of Object.entries(changes)) {
+            accumulated[key] = value;
+            dirty = true;
+          }
+          if (dirty) {
+            setValues({ ...accumulated });
+            setPlayers(decodePlayerStates(accumulated[ANIMATION_PLAYERS_PATH]));
+          }
+          raf = requestAnimationFrame(tick);
+        };
+        raf = requestAnimationFrame(tick);
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      if (raf) cancelAnimationFrame(raf);
+      runtimeRef.current = null;
+      playerIdRef.current = null;
+      try {
+        runtime?.dispose();
+      } catch {
+        // A disposed runtime is unusable; nothing to recover.
+      }
+    };
+    // The clips array identity is the reload trigger; loop/autoplay are read at
+    // setup time. Consumers pass a stable clips reference and change it to reload.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clips]);
+
+  return useMemo<AnimationRuntimeApi>(() => {
+    const withPlayer = (
+      build: (player: number) => Parameters<AroraDevice["call"]>[0],
+    ) => {
+      const runtime = runtimeRef.current;
+      const player = playerIdRef.current;
+      if (!runtime || player === null) return;
+      // The running RAF loop takes the step that dispatches this call.
+      void runtime.call(build(player)).catch(() => {
+        // A failed transport call means the runtime was torn down mid-issue.
+      });
+    };
+    return {
+      ready,
+      values,
+      players,
+      play: () => withPlayer((player) => playCall(player)),
+      pause: () => withPlayer((player) => pauseCall(player)),
+      stop: () => withPlayer((player) => stopCall(player)),
+      seek: (seconds: number) =>
+        withPlayer((player) => seekCall(player, seconds * 1e9)),
+      setSpeed: (speed: number) =>
+        withPlayer((player) => setSpeedCall(player, speed)),
+      error,
+    };
+  }, [ready, values, players, error]);
+}

--- a/apps/minimal-demo-animation/src/samples.ts
+++ b/apps/minimal-demo-animation/src/samples.ts
@@ -1,0 +1,87 @@
+import type { StoredAnimation } from "./animationRuntime";
+
+/**
+ * Inline StoredAnimation samples for the demo.
+ *
+ * The standalone `@vizij/animation-wasm` engine shipped fixture clips; the
+ * device path loads plain StoredAnimation JSON, so the demo carries a couple of
+ * its own. Each track's `animatableId` is the store key its sampled value lands
+ * on and the demo reads back.
+ */
+export const SAMPLES: Record<string, StoredAnimation> = {
+  "simple-scalar-ramp": {
+    id: "simple-scalar-ramp",
+    name: "Simple scalar ramp",
+    duration: 1000,
+    tracks: [
+      {
+        id: "ramp",
+        name: "ramp",
+        animatableId: "node/x",
+        points: [
+          { id: "k0", stamp: 0, value: 0 },
+          { id: "k1", stamp: 1, value: 1 },
+        ],
+      },
+    ],
+  },
+  "bounce-scalar": {
+    id: "bounce-scalar",
+    name: "Bounce scalar",
+    duration: 2000,
+    tracks: [
+      {
+        id: "bounce",
+        name: "bounce",
+        animatableId: "node/y",
+        points: [
+          { id: "b0", stamp: 0, value: 0 },
+          { id: "b1", stamp: 0.25, value: 1 },
+          { id: "b2", stamp: 0.5, value: 0 },
+          { id: "b3", stamp: 0.75, value: 0.5 },
+          { id: "b4", stamp: 1, value: 0 },
+        ],
+      },
+    ],
+  },
+  "two-track": {
+    id: "two-track",
+    name: "Two tracks",
+    duration: 1500,
+    tracks: [
+      {
+        id: "x",
+        name: "x",
+        animatableId: "node/x",
+        points: [
+          { id: "x0", stamp: 0, value: -1 },
+          { id: "x1", stamp: 1, value: 1 },
+        ],
+      },
+      {
+        id: "y",
+        name: "y",
+        animatableId: "node/y",
+        points: [
+          { id: "y0", stamp: 0, value: 1 },
+          { id: "y1", stamp: 0.5, value: -1 },
+          { id: "y2", stamp: 1, value: 1 },
+        ],
+      },
+    ],
+  },
+};
+
+/** Sample ids in a stable, sorted order. */
+export function listSamples(): string[] {
+  return Object.keys(SAMPLES).sort((a, b) => a.localeCompare(b));
+}
+
+/** Load a sample clip by id (deep-cloned so the editor can mutate it freely). */
+export function loadSample(id: string): StoredAnimation {
+  const clip = SAMPLES[id];
+  if (!clip) {
+    throw new Error(`Unknown sample "${id}"`);
+  }
+  return structuredClone(clip);
+}

--- a/apps/minimal-demo-animation/vite.config.ts
+++ b/apps/minimal-demo-animation/vite.config.ts
@@ -7,7 +7,8 @@ export default defineConfig({
     watch: {
       ignored: [
         "**/node_modules/**",
-        "!**/node_modules/@vizij/animation-wasm/**",
+        "!**/node_modules/@vizij/runtime/**",
+        "!**/node_modules/@vizij/animation-module/**",
       ],
     },
     headers: {
@@ -16,7 +17,8 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
-    // Prevent pre-bundling the wasm ESM shim in dev; let Vite handle it directly
-    exclude: ["@vizij/animation-wasm"],
+    // The device + module wasm packages are excluded from pre-bundling so Vite
+    // handles their `new URL(..., import.meta.url)` wasm assets directly.
+    exclude: ["@vizij/runtime", "@vizij/animation-module"],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,15 +196,21 @@ importers:
       '@eslint/plugin-kit':
         specifier: 0.4.0
         version: 0.4.0
-      '@vizij/animation-react':
-        specifier: workspace:*
-        version: link:../../packages/@vizij/animation-react
+      '@vizij/animation-module':
+        specifier: ^0.2.0
+        version: 0.2.0
       '@vizij/minimal-demo-ui':
         specifier: workspace:*
         version: link:../../packages/@vizij/minimal-demo-ui
+      '@vizij/runtime':
+        specifier: ^1.1.0
+        version: 1.1.0
       '@vizij/utils':
         specifier: workspace:*
         version: link:../../packages/@vizij/utils
+      '@vizij/value-json':
+        specifier: ^0.2.0
+        version: 0.2.0
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -242,12 +248,9 @@ importers:
 
   apps/minimal-demo-animation-graph:
     dependencies:
-      '@vizij/animation-react':
-        specifier: workspace:*
-        version: link:../../packages/@vizij/animation-react
-      '@vizij/animation-wasm':
-        specifier: ^0.4.0
-        version: 0.4.0
+      '@vizij/animation-module':
+        specifier: ^0.2.0
+        version: 0.2.0
       '@vizij/minimal-demo-ui':
         specifier: workspace:*
         version: link:../../packages/@vizij/minimal-demo-ui
@@ -257,6 +260,9 @@ importers:
       '@vizij/node-graph-wasm':
         specifier: ^0.7.0
         version: 0.7.0
+      '@vizij/runtime':
+        specifier: ^1.1.0
+        version: 1.1.0
       '@vizij/utils':
         specifier: workspace:*
         version: link:../../packages/@vizij/utils


### PR DESCRIPTION
## What

Migrates **two of the three** standalone-animation demos off `@vizij/animation-react` + `@vizij/animation-wasm` onto the runtime path — `@vizij/animation-module` loaded into a `@vizij/runtime` runtime — per VIZ-61 (animation now runs *through* the runtime).

- ✅ `apps/minimal-demo-animation` — migrated + `vite build` green
- ✅ `apps/minimal-demo-animation-graph` — animation half migrated (node-graph half untouched) + `vite build` green
- ⛔ `apps/demo-animation-studio` — **NOT migrated** (blocked, see below)

Because the studio still depends on the standalone packages, **they are not yet orphaned and this PR does not retire them.**

## Migration shape — the driving graph

`@vizij/animation-module` exposes only `loadAnimationModule()`; there is **no exported graph-builder** anywhere. The driving-graph + ABI glue exists (unexported) inside `@vizij/runtime-react/src/engine/animationModule.ts`, but that lives behind the heavy renderer provider and isn't a lightweight surface. So each demo carries a small **local, non-published** helper: `apps/<app>/src/animationRuntime.ts` (identical copy in both — copy is fine for 2 demos, no new released package).

The runtime runs this behavior graph (mirrors the proof in `@vizij/runtime/tests/animation-module.mjs`):

```
input  "arora/dt"                    ─┐
externalfunction step(dt_ns)         ─┴─> output { key_field: default_key, value_field: value }
externalfunction player_states()     ───> output { path: "vizij/animations/players" }
```

- The `step` node calls the module's `step` every tick, fed the golden `arora/dt` (ns).
- The **path-less** `output` node applies the returned `[TrackOutput]` batch onto the store keys each record names (its authored `default_key` = the clip's `animatableId`, decided at clip load) — no per-tick re-keying.
- A second `externalfunction`/`output` pair writes `player_states()` to a store path for transport feedback.

The helper's `useAnimationRuntime(clips)` hook: `init()` → `startDevice(buildAnimationGraph(), undefined, [await loadAnimationModule()])` → loads clips into one player through the call surface (`load_animation`/`create_player`/`add_instance`) → advances the runtime from a `requestAnimationFrame` loop and mirrors `drainChanges()` into React each frame. Transport (`play`/`pause`/`stop`/`seek`/`setSpeed`) issues runtime calls that dispatch on the next step. Sampled values read back as Vizij `ValueJSON` via `@vizij/value-json`.

> Naming: everything I named is runtime-flavored (`useAnimationRuntime`, `AnimationRuntimeApi`, `buildAnimationGraph`, …). The only "device" names are the package's own API (`startDevice`, `AroraDevice`), which are unavoidable.

## Why not a shared package / why not runtime-react

- A **new shared `@vizij/animation-*` package** to retire two others is close to a wash and adds release burden — rejected.
- **Exporting the builder from `@vizij/runtime-react`** would widen its public API with ~15 low-level ABI symbols *and* pull the minimal demos onto the heavy renderer package (the original task explicitly avoided it) with bundle-bloat risk — rejected.
- **Local copy in each demo** — self-contained (a virtue for demos), zero new packages, guaranteed-lean bundle. Chosen.

The genuinely DRY long-term home for this glue is **upstream in `@vizij/runtime` / `@vizij/animation-module`** (a `buildAnimationGraph()` + call builders next to `loadAnimationModule()`), so runtime-react and any demo dedupe against one source. That's a `vizij-rs` change, out of scope here.

## Per-demo notes

**minimal-demo-animation** — same UI (sample picker, JSON editor, file load/save, transport, live tracked outputs) rewired onto the hook. Sample clips are now **inlined** (`src/samples.ts`) because the previous fixtures came from `@vizij/animation-wasm`.

**minimal-demo-animation-graph** — the `<AnimationProvider>` wrapper is dropped; `IkGraphInner`/`SlewDampInner` call `useAnimationRuntime(clip)` and read `anim.values[path]`. The node-graph half (`@vizij/node-graph-react` + `@vizij/node-graph-wasm`) is unchanged. Data-file `StoredAnimation` type imports moved to the local helper; `valueAsNumber` now comes from `@vizij/value-json`.

## The studio blocker (why the third demo isn't migrated)

`demo-animation-studio` centrally exercises engine features the animation-module ABI does not expose:

- **Baking** — `bakeAnimation` / `bakeAnimationWithDerivatives` (`BakedAnimationPlot`)
- **Events** — `CoreEvent` (`EventsLog`)
- **Derivatives** — `OutputsWithDerivatives`, per-key derivative subscriptions (`ChartsView`)
- plus `abi_version`.

The module ABI is only: `load_animation`/`create_player`/`add_instance`/`step`/transport/`player_states`. No bake, no events, no derivatives. Migrating the studio would mean deleting those panels (≈40% of the demo) or reimplementing baking/events/derivatives on top of the module. That's not a clean mechanical migration, so per the task's "don't force a messy migration" it is left for a maintainer decision (extend the module ABI upstream, accept feature loss, or keep the studio on the standalone engine).

## Verification

- `pnpm --filter minimal-demo-animation build` → green (bundles `vizij_arora_web` + `vizij_animation_module.wasm`)
- `pnpm --filter minimal-demo-animation-graph build` → green (bundles the above **and** `vizij_graph_wasm`)
- `prettier` + `eslint --fix` clean on all touched files
- **Not** verified: runtime behavior in a browser — `vite build` is a compile-time gate only. The setup sequence and graph mirror the proven `@vizij/runtime` test, but a manual `pnpm dev` smoke of both demos is advisable before merge.

## Orphaned packages — NOT YET

`@vizij/animation-react` and `@vizij/animation-wasm` (npm) and the Rust `vizij-animation-wasm` crate are **still used by `demo-animation-studio`** (and `@vizij/animation-react` depends on `@vizij/animation-wasm`). They are **not orphaned** and must not be deleted while the studio consumes them.

`apps/vizij-authoring/vite.config.ts` also names them in `optimizeDeps.exclude` / watch globs, but its `package.json` has no such dependency — those are stale build-config entries (harmless no-ops; could be cleaned up separately).

`vizij-animation-core` stays regardless — it backs `@vizij/animation-module`.

### Delete commands — only after the studio stops using them

Do **not** run these now. Once `demo-animation-studio` is migrated or retired:

```bash
# npm packages (vizij-web)
rm -rf packages/@vizij/animation-react
# then drop its workspace deps and re-run: pnpm install

# Rust crate (vizij-rs)
rm -rf crates/interop/vizij-animation-wasm   # confirm exact path in vizij-rs
```

`@vizij/animation-wasm`'s package dir lives in `vizij-rs` (symlinked here via the wasm-links script), so its deletion happens in that repo too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
