### PR TITLE
chore: rename @vizij/node-graph-wasm → @vizij/node-graph

### DIFF
--- a/.changeset/node-graph-npm-rename.md
+++ b/.changeset/node-graph-npm-rename.md
@@ -1,0 +1,7 @@
+---
+"@vizij/node-graph-authoring": patch
+"@vizij/node-graph-react": patch
+---
+
+Track the `@vizij/node-graph-wasm` → `@vizij/node-graph` dependency rename (same
+package, bare-domain npm name; no API change).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **TypeScript packages, React integrations, and demo applications that showcase Vizij’s real-time animation platform.**
 
-This workspace consumes the Rust artefacts from [`vizij-rs`](../vizij-rs) via the published `@vizij/*` bindings (the `@vizij/animation` and `@vizij/node-graph-wasm` engines plus the `@vizij/runtime` runtime) and exposes production-ready packages plus a suite of internal apps.
+This workspace consumes the Rust artefacts from [`vizij-rs`](../vizij-rs) via the published `@vizij/*` bindings (the `@vizij/animation` and `@vizij/node-graph` engines plus the `@vizij/runtime` runtime) and exposes production-ready packages plus a suite of internal apps.
 
 ---
 
@@ -186,7 +186,7 @@ When you need edits from the Rust workspace:
 
    ```bash
    # link a subset
-   pnpm run wasm:link -- --pkgs "node-graph-wasm runtime"
+   pnpm run wasm:link -- --pkgs "node-graph runtime"
    # or link everything
    pnpm run wasm:link -- --pkgs all
 

--- a/apps/demo-graph-studio/README.md
+++ b/apps/demo-graph-studio/README.md
@@ -1,7 +1,7 @@
 # demo-graph-studio
 
 > **Work-in-progress Vizij node graph editor.**  
-> Provides a developer-facing canvas for building GraphSpecs using `@vizij/node-graph-react` and `@vizij/node-graph-wasm`.
+> Provides a developer-facing canvas for building GraphSpecs using `@vizij/node-graph-react` and `@vizij/node-graph`.
 
 ---
 
@@ -19,7 +19,7 @@
 
 - Built with Vite + React + React Flow.
 - Stores graph state in a Zustand editor store capable of exporting/importing normalised `GraphSpec` JSON.
-- Integrates with the node registry provided by `@vizij/node-graph-wasm` for palette metadata.
+- Integrates with the node registry provided by `@vizij/node-graph` for palette metadata.
 - Still under active development—expect missing polish and advanced tooling.
 
 ---

--- a/apps/demo-graph-studio/package.json
+++ b/apps/demo-graph-studio/package.json
@@ -2,7 +2,7 @@
   "name": "demo-graph-studio",
   "version": "0.1.1",
   "private": true,
-  "description": "Demo Node Graph Editor app — built on @vizij/node-graph-react and node-graph-wasm",
+  "description": "Demo Node Graph Editor app — built on @vizij/node-graph-react and node-graph",
   "main": "src/main.tsx",
   "scripts": {
     "dev": "vite",
@@ -22,7 +22,7 @@
     "@eslint/plugin-kit": "0.4.0",
     "@vizij/node-graph-authoring": "workspace:*",
     "@vizij/node-graph-react": "workspace:*",
-    "@vizij/node-graph-wasm": "^0.7.0",
+    "@vizij/node-graph": "^0.7.0",
     "@vizij/value-json": "^0.2.0",
     "@vizij/utils": "workspace:*",
     "react": "^19.2.3",

--- a/apps/demo-graph-studio/src/components/ExpressionAuthoringPanel.tsx
+++ b/apps/demo-graph-studio/src/components/ExpressionAuthoringPanel.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from "react";
 import type { ChangeEvent, KeyboardEvent, SyntheticEvent } from "react";
-import type { GraphSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec } from "@vizij/node-graph";
 import {
   EXPRESSION_FUNCTION_VOCABULARY,
   RESERVED_EXPRESSION_VARIABLES,

--- a/apps/demo-graph-studio/src/contexts/RegistryProvider.tsx
+++ b/apps/demo-graph-studio/src/contexts/RegistryProvider.tsx
@@ -8,7 +8,7 @@ import React, {
 } from "react";
 import type { FC, PropsWithChildren } from "react";
 import { init as initGraphWasm, getNodeSchemas } from "@vizij/node-graph-react";
-import type { Registry as WasmRegistry } from "@vizij/node-graph-wasm";
+import type { Registry as WasmRegistry } from "@vizij/node-graph";
 import { useEditorStore } from "../store/useEditorStore";
 
 export type Registry = WasmRegistry;

--- a/apps/demo-graph-studio/src/store/useEditorStore.spec.ts
+++ b/apps/demo-graph-studio/src/store/useEditorStore.spec.ts
@@ -1,5 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { loadNodeGraphSpec } from "@vizij/node-graph-wasm";
+import { loadNodeGraphSpec } from "@vizij/node-graph";
 import { useEditorStore } from "./useEditorStore";
 
 let WEIGHTED_BLEND_FIXTURE: unknown;

--- a/apps/demo-graph-studio/src/store/useEditorStore.ts
+++ b/apps/demo-graph-studio/src/store/useEditorStore.ts
@@ -5,7 +5,7 @@ import type {
   NodeSpec,
   NodeParams,
   ValueJSON,
-} from "@vizij/node-graph-wasm";
+} from "@vizij/node-graph";
 
 /**
  * Minimal editor store for the node-graph-editor app.

--- a/apps/demo-graph-studio/vite.config.ts
+++ b/apps/demo-graph-studio/vite.config.ts
@@ -17,7 +17,7 @@ const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, "../../.."); // vizij_ws
 // const localWasmPkg = path.resolve(
 //   __dirname,
-//   "../../vizij-rs/npm/@vizij/node-graph-wasm",
+//   "../../vizij-rs/npm/@vizij/node-graph",
 // );
 // const localWasmPkgPkg = path.resolve(localWasmPkg, "pkg");
 
@@ -42,7 +42,7 @@ export default defineConfig({
     watch: {
       ignored: [
         "**/node_modules/**",
-        "!**/node_modules/@vizij/node-graph-wasm/**",
+        "!**/node_modules/@vizij/node-graph/**",
       ],
     },
   },
@@ -51,7 +51,7 @@ export default defineConfig({
   },
   optimizeDeps: {
     // Keep the wasm shim out of the esbuild prebundle so its relative pkg/ URLs remain valid
-    exclude: ["@vizij/node-graph-wasm"],
+    exclude: ["@vizij/node-graph"],
   },
   assetsInclude: ["**/*.wasm"],
 });

--- a/apps/demo-graph-studio/vite.config.ts
+++ b/apps/demo-graph-studio/vite.config.ts
@@ -40,10 +40,7 @@ export default defineConfig({
       allow: [repoRoot],
     },
     watch: {
-      ignored: [
-        "**/node_modules/**",
-        "!**/node_modules/@vizij/node-graph/**",
-      ],
+      ignored: ["**/node_modules/**", "!**/node_modules/@vizij/node-graph/**"],
     },
   },
   build: {

--- a/apps/demo-vizij-player/vite.config.ts
+++ b/apps/demo-vizij-player/vite.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
     watch: {
       ignored: [
         "**/node_modules/**",
-        "!**/node_modules/@vizij/node-graph-wasm/**",
+        "!**/node_modules/@vizij/node-graph/**",
         "!**/node_modules/@vizij/render/**",
         "!**/node_modules/@vizij/utils/**",
       ],
@@ -40,7 +40,7 @@ export default defineConfig({
   },
   optimizeDeps: {
     exclude: [
-      "@vizij/node-graph-wasm",
+      "@vizij/node-graph",
       "@vizij/runtime",
       "@vizij/animation-module",
     ],

--- a/apps/demo-vizij-player/vite.config.ts
+++ b/apps/demo-vizij-player/vite.config.ts
@@ -39,11 +39,7 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
-    exclude: [
-      "@vizij/node-graph",
-      "@vizij/runtime",
-      "@vizij/animation-module",
-    ],
+    exclude: ["@vizij/node-graph", "@vizij/runtime", "@vizij/animation-module"],
     include: ["@vizij/render"],
   },
 });

--- a/apps/minimal-demo-animation-graph/package.json
+++ b/apps/minimal-demo-animation-graph/package.json
@@ -22,7 +22,7 @@
     "@vizij/minimal-demo-ui": "workspace:*",
     "@vizij/value-json": "^0.2.0",
     "@vizij/node-graph-react": "workspace:*",
-    "@vizij/node-graph-wasm": "^0.7.0",
+    "@vizij/node-graph": "^0.7.0",
     "@vizij/utils": "workspace:*",
     "react": "^19.2.3",
     "react-dom": "^19.2.3"

--- a/apps/minimal-demo-animation-graph/src/__tests__/IkGraphDemo-init.test.ts
+++ b/apps/minimal-demo-animation-graph/src/__tests__/IkGraphDemo-init.test.ts
@@ -15,8 +15,7 @@ let mode: "ok" | "fail" = "ok";
 let lastGraph: any = null;
 
 vi.mock("@vizij/node-graph", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@vizij/node-graph")>();
+  const actual = await importOriginal<typeof import("@vizij/node-graph")>();
   const {
     listNodeGraphFixtures,
     loadNodeGraphBundle,

--- a/apps/minimal-demo-animation-graph/src/__tests__/IkGraphDemo-init.test.ts
+++ b/apps/minimal-demo-animation-graph/src/__tests__/IkGraphDemo-init.test.ts
@@ -3,20 +3,20 @@ import { describe, it, expect, vi, afterAll } from "vitest";
 import { act, render, waitFor } from "@testing-library/react";
 import { GraphProvider } from "@vizij/node-graph-react";
 import { useGraphRuntime } from "@vizij/node-graph-react";
-import type { GraphSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec } from "@vizij/node-graph";
 import { cloneDeepSafe } from "@vizij/utils";
 import { ikGraphSpec } from "../data/ikGraph";
 import { slewGraphSpec } from "../data/slewGraph";
 import { makeTypedPath } from "../utils/typedPath";
 
-// Local mock of @vizij/node-graph-wasm for this app test scope.
+// Local mock of @vizij/node-graph for this app test scope.
 // We keep semantics consistent with the package tests but scoped to the app.
 let mode: "ok" | "fail" = "ok";
 let lastGraph: any = null;
 
-vi.mock("@vizij/node-graph-wasm", async (importOriginal) => {
+vi.mock("@vizij/node-graph", async (importOriginal) => {
   const actual =
-    await importOriginal<typeof import("@vizij/node-graph-wasm")>();
+    await importOriginal<typeof import("@vizij/node-graph")>();
   const {
     listNodeGraphFixtures,
     loadNodeGraphBundle,
@@ -126,7 +126,7 @@ describe("Demo (animation-graph) init behavior with declarative seeds", () => {
     });
 
     // Assert seeds were applied to the underlying graph
-    const wasm: any = await import("@vizij/node-graph-wasm");
+    const wasm: any = await import("@vizij/node-graph");
     const g = wasm.__getLastGraph?.();
     expect(g).toBeTruthy();
     expect(g.setParam).toHaveBeenCalled();

--- a/apps/minimal-demo-animation-graph/src/components/UrdfIkPanel.tsx
+++ b/apps/minimal-demo-animation-graph/src/components/UrdfIkPanel.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 import type { ChangeEvent } from "react";
-import type { ValueJSON } from "@vizij/node-graph-wasm";
+import type { ValueJSON } from "@vizij/node-graph";
 import {
   useGraphRuntime,
   useNodeOutput,

--- a/apps/minimal-demo-animation-graph/src/data/ikGraph.ts
+++ b/apps/minimal-demo-animation-graph/src/data/ikGraph.ts
@@ -1,4 +1,4 @@
-import type { GraphSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec } from "@vizij/node-graph";
 import { ikPaths, JOINT_IDS, JOINT_SAMPLES } from "./ikAnimation";
 import { sampleUrdf } from "./urdf-samples/sampleUrdf";
 

--- a/apps/minimal-demo-animation-graph/src/data/slewGraph.ts
+++ b/apps/minimal-demo-animation-graph/src/data/slewGraph.ts
@@ -1,4 +1,4 @@
-import type { GraphSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec } from "@vizij/node-graph";
 import { slewPaths } from "./slewAnimation";
 
 export const slewGraphSpec: GraphSpec = {

--- a/apps/minimal-demo-animation-graph/src/utils/animationValueToGraph.ts
+++ b/apps/minimal-demo-animation-graph/src/utils/animationValueToGraph.ts
@@ -1,6 +1,6 @@
 import { type Value } from "@vizij/animation-react";
 import { toValueJSON } from "@vizij/value-json";
-import type { ValueJSON } from "@vizij/node-graph-wasm";
+import type { ValueJSON } from "@vizij/node-graph";
 
 export function animationValueToValueJSON(
   value?: Value,

--- a/apps/minimal-demo-animation-graph/vite.config.ts
+++ b/apps/minimal-demo-animation-graph/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
       ignored: [
         "**/node_modules/**",
         "!**/node_modules/@vizij/animation/**",
-        "!**/node_modules/@vizij/node-graph-wasm/**",
+        "!**/node_modules/@vizij/node-graph/**",
       ],
     },
     headers: {
@@ -17,6 +17,6 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
-    exclude: ["@vizij/animation", "@vizij/node-graph-wasm"],
+    exclude: ["@vizij/animation", "@vizij/node-graph"],
   },
 });

--- a/apps/minimal-demo-animation-graph/vitest.config.ts
+++ b/apps/minimal-demo-animation-graph/vitest.config.ts
@@ -13,10 +13,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      "@vizij/node-graph": resolveFromRoot(
-        "test-shims",
-        "node-graph-wasm.ts",
-      ),
+      "@vizij/node-graph": resolveFromRoot("test-shims", "node-graph-wasm.ts"),
     },
   },
 });

--- a/apps/minimal-demo-animation-graph/vitest.config.ts
+++ b/apps/minimal-demo-animation-graph/vitest.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      "@vizij/node-graph-wasm": resolveFromRoot(
+      "@vizij/node-graph": resolveFromRoot(
         "test-shims",
         "node-graph-wasm.ts",
       ),

--- a/apps/minimal-demo-graph/AGENTS.md
+++ b/apps/minimal-demo-graph/AGENTS.md
@@ -12,6 +12,6 @@ Lightweight node-graph playground that exercises staging behaviour, input editor
 
 ## Integration Tips
 
-- Keep sample graph specs (`src/data`) in sync with `@vizij/node-graph-wasm`.
+- Keep sample graph specs (`src/data`) in sync with `@vizij/node-graph`.
 - Validate UI tweaks with both play and pause modes; the demo intentionally exercises continuous re-staging.
 - Update README tables/sections when adding new panels or input types.

--- a/apps/minimal-demo-graph/README.md
+++ b/apps/minimal-demo-graph/README.md
@@ -20,7 +20,7 @@
 ## Overview
 
 - Built with Vite + React.
-- Uses `@vizij/node-graph-react` (provider + hooks) which in turn wraps the WASM runtime (`@vizij/node-graph-wasm`).
+- Uses `@vizij/node-graph-react` (provider + hooks) which in turn wraps the WASM runtime (`@vizij/node-graph`).
 - Demonstrates staging behaviour: inputs are re-staged every frame when playback is active, ensuring `Input` nodes always see host values.
 - Includes sample graphs from the npm package plus a local URDF IK position example.
 
@@ -34,7 +34,7 @@ pnpm install
 
 # Ensure the WASM package is built (if you are linking locally)
 node ../vizij-rs/scripts/build-graph-wasm.mjs
-cd ../vizij-rs/npm/@vizij/node-graph-wasm && pnpm run build
+cd ../vizij-rs/npm/@vizij/node-graph && pnpm run build
 cd ../../../vizij-web
 
 # Run the demo
@@ -111,7 +111,7 @@ The loader accepts a few shapes and normalises them to the canonical `GraphSpec`
    { "spec": { "nodes": [...] } }
    ```
 
-All formats are normalised through `@vizij/node-graph-wasm` before loading.
+All formats are normalised through `@vizij/node-graph` before loading.
 
 ---
 
@@ -126,7 +126,7 @@ All formats are normalised through `@vizij/node-graph-wasm` before loading.
 
 ## Troubleshooting
 
-- **WASM module errors** – Ensure `@vizij/node-graph-wasm` has been built (`pkg/` present) and the wrapper points to `dist/src/index.js`. Linked packages must be rebuilt after Rust changes.
+- **WASM module errors** – Ensure `@vizij/node-graph` has been built (`pkg/` present) and the wrapper points to `dist/src/index.js`. Linked packages must be rebuilt after Rust changes.
 - **No output updates when playing** – Confirm playback is enabled and that the per-frame staging effect runs (check logs in `App.tsx`). Verify input paths match existing `Input` nodes.
 - **React hook warnings when switching graphs** – The demo uses dedicated components for output subscriptions. If you replicate the pattern, avoid calling hooks inside arrays where the number of iterations can change between renders.
 - **Missing inputs** – Graphs without explicit `Input` nodes won’t show controls; ensure your spec exposes host-modifiable data through dedicated nodes.

--- a/apps/minimal-demo-graph/package.json
+++ b/apps/minimal-demo-graph/package.json
@@ -20,7 +20,7 @@
     "@eslint/plugin-kit": "0.4.0",
     "@vizij/minimal-demo-ui": "workspace:*",
     "@vizij/node-graph-react": "workspace:*",
-    "@vizij/node-graph-wasm": "^0.7.0",
+    "@vizij/node-graph": "^0.7.0",
     "@vizij/utils": "workspace:*",
     "@vizij/value-json": "^0.2.0",
     "react": "^19.2.3",

--- a/apps/minimal-demo-graph/src/App.tsx
+++ b/apps/minimal-demo-graph/src/App.tsx
@@ -16,7 +16,7 @@ import {
   useGraphOutputs,
   samples as graphSamples,
 } from "@vizij/node-graph-react";
-import type { GraphSpec, ValueJSON, ShapeJSON } from "@vizij/node-graph-wasm";
+import type { GraphSpec, ValueJSON, ShapeJSON } from "@vizij/node-graph";
 import {
   fromAroraValueJSON,
   isNormalizedValue,

--- a/apps/minimal-demo-graph/vite.config.ts
+++ b/apps/minimal-demo-graph/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     watch: {
       ignored: [
         "**/node_modules/**",
-        "!**/node_modules/@vizij/node-graph-wasm/**",
+        "!**/node_modules/@vizij/node-graph/**",
       ],
     },
     headers: {
@@ -17,6 +17,6 @@ export default defineConfig({
   },
   optimizeDeps: {
     // Prevent pre-bundling the wasm ESM shim in dev; let Vite handle it directly
-    exclude: ["@vizij/node-graph-wasm"],
+    exclude: ["@vizij/node-graph"],
   },
 });

--- a/apps/minimal-demo-graph/vite.config.ts
+++ b/apps/minimal-demo-graph/vite.config.ts
@@ -5,10 +5,7 @@ export default defineConfig({
   plugins: [react()],
   server: {
     watch: {
-      ignored: [
-        "**/node_modules/**",
-        "!**/node_modules/@vizij/node-graph/**",
-      ],
+      ignored: ["**/node_modules/**", "!**/node_modules/@vizij/node-graph/**"],
     },
     headers: {
       "Cross-Origin-Opener-Policy": "same-origin",

--- a/apps/vizij-authoring/package.json
+++ b/apps/vizij-authoring/package.json
@@ -31,7 +31,7 @@
     "@radix-ui/react-icons": "^1.3.2",
     "@vizij/node-graph-authoring": "workspace:*",
     "@vizij/node-graph-react": "workspace:*",
-    "@vizij/node-graph-wasm": "^0.7.0",
+    "@vizij/node-graph": "^0.7.0",
     "@vizij/render": "workspace:*",
     "@vizij/runtime-react": "workspace:*",
     "@vizij/utils": "workspace:*",

--- a/apps/vizij-authoring/src/components/binding/BindingEditor.tsx
+++ b/apps/vizij-authoring/src/components/binding/BindingEditor.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, useCallback, useEffect, useRef } from "react";
 import type { ReactNode } from "react";
-import { requireNodeSignature } from "@vizij/node-graph-wasm/metadata";
+import { requireNodeSignature } from "@vizij/node-graph/metadata";
 import {
   SELF_BINDING_ID,
   type StandardRigInput,

--- a/apps/vizij-authoring/src/components/panels/DebugPanel.tsx
+++ b/apps/vizij-authoring/src/components/panels/DebugPanel.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from "react";
 import type { VizijBundleExtension } from "@vizij/render";
 import { useDialogQueue } from "@vizij/authoring-shared";
 import { compileIrGraph, type IrGraph } from "@vizij/node-graph-authoring";
-import type { GraphSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec } from "@vizij/node-graph";
 import {
   Activity,
   Play,

--- a/apps/vizij-authoring/src/hooks/__tests__/graphRuntime.test.ts
+++ b/apps/vizij-authoring/src/hooks/__tests__/graphRuntime.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { StandardRigInput } from "@vizij/utils";
-import type { GraphSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec } from "@vizij/node-graph";
 import { createGraphRuntimeStore } from "../../state/graphRuntimeStore";
 import {
   buildFallbackGraphPath,

--- a/apps/vizij-authoring/src/hooks/__tests__/runtimeGraphGating.test.ts
+++ b/apps/vizij-authoring/src/hooks/__tests__/runtimeGraphGating.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { GraphSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec } from "@vizij/node-graph";
 import type { BuildGraphResult } from "@vizij/node-graph-authoring";
 import { resolveRuntimeGraphSpec } from "../runtimeGraphSpec";
 

--- a/apps/vizij-authoring/src/hooks/__tests__/usePoseGraphImport.test.ts
+++ b/apps/vizij-authoring/src/hooks/__tests__/usePoseGraphImport.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { GraphSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec } from "@vizij/node-graph";
 import type { StandardRigInput } from "@vizij/utils";
 import { cloneDeepSafe } from "@vizij/utils";
 import {

--- a/apps/vizij-authoring/src/hooks/__tests__/useVizijExport.test.tsx
+++ b/apps/vizij-authoring/src/hooks/__tests__/useVizijExport.test.tsx
@@ -15,9 +15,9 @@ import type {
   AnimatableValue,
   StandardRigInput,
 } from "@vizij/utils";
-import type { GraphSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec } from "@vizij/node-graph";
 import { exportScene } from "@vizij/render";
-import { normalizeGraphSpec } from "@vizij/node-graph-wasm";
+import { normalizeGraphSpec } from "@vizij/node-graph";
 import { buildRigGraphSpec } from "@vizij/node-graph-authoring";
 import { downloadJsonFile } from "@vizij/authoring-shared";
 import { useVizijExport } from "../useVizijExport";
@@ -47,9 +47,9 @@ vi.mock("@vizij/node-graph-authoring", async () => {
   };
 });
 
-vi.mock("@vizij/node-graph-wasm", async () => {
-  const actual = await vi.importActual<typeof import("@vizij/node-graph-wasm")>(
-    "@vizij/node-graph-wasm",
+vi.mock("@vizij/node-graph", async () => {
+  const actual = await vi.importActual<typeof import("@vizij/node-graph")>(
+    "@vizij/node-graph",
   );
   return {
     ...actual,

--- a/apps/vizij-authoring/src/hooks/__tests__/useVizijExport.test.tsx
+++ b/apps/vizij-authoring/src/hooks/__tests__/useVizijExport.test.tsx
@@ -48,9 +48,10 @@ vi.mock("@vizij/node-graph-authoring", async () => {
 });
 
 vi.mock("@vizij/node-graph", async () => {
-  const actual = await vi.importActual<typeof import("@vizij/node-graph")>(
-    "@vizij/node-graph",
-  );
+  const actual =
+    await vi.importActual<typeof import("@vizij/node-graph")>(
+      "@vizij/node-graph",
+    );
   return {
     ...actual,
     normalizeGraphSpec: vi.fn(),

--- a/apps/vizij-authoring/src/hooks/runtimeGraphSpec.ts
+++ b/apps/vizij-authoring/src/hooks/runtimeGraphSpec.ts
@@ -1,5 +1,5 @@
 import type { BuildGraphResult } from "@vizij/node-graph-authoring";
-import type { GraphSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec } from "@vizij/node-graph";
 
 let lastIrCompileWarningSignature: string | null = null;
 

--- a/apps/vizij-authoring/src/hooks/useBundleSynchronizer.ts
+++ b/apps/vizij-authoring/src/hooks/useBundleSynchronizer.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 import type { VizijBundleExtension } from "@vizij/render";
-import { normalizeGraphSpec, type GraphSpec } from "@vizij/node-graph-wasm";
+import { normalizeGraphSpec, type GraphSpec } from "@vizij/node-graph";
 import type { PoseRigConfigFile } from "../poseRig/types";
 import type { AnimationClipIR } from "../types/animationClipIr";
 import {

--- a/apps/vizij-authoring/src/hooks/useExportDirtyState.ts
+++ b/apps/vizij-authoring/src/hooks/useExportDirtyState.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { BindingMap, InputBindingMap } from "@vizij/node-graph-authoring";
-import type { GraphSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec } from "@vizij/node-graph";
 import type {
   AnimatableComponent,
   AnimatableValue,

--- a/apps/vizij-authoring/src/hooks/usePoseGraphImport.ts
+++ b/apps/vizij-authoring/src/hooks/usePoseGraphImport.ts
@@ -1,5 +1,5 @@
 import { useCallback, useState } from "react";
-import type { GraphSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec } from "@vizij/node-graph";
 import {
   normalizeStandardRigInputPath,
   type StandardRigInput,

--- a/apps/vizij-authoring/src/hooks/useRigGraphImport.ts
+++ b/apps/vizij-authoring/src/hooks/useRigGraphImport.ts
@@ -7,7 +7,7 @@ import {
   type InputBindingMap,
   type StandardInputValues,
 } from "@vizij/node-graph-authoring";
-import { normalizeGraphSpec, type GraphSpec } from "@vizij/node-graph-wasm";
+import { normalizeGraphSpec, type GraphSpec } from "@vizij/node-graph";
 import {
   SELF_BINDING_ID,
   createStandardRigInputFromPath,

--- a/apps/vizij-authoring/src/hooks/useVizijExport.ts
+++ b/apps/vizij-authoring/src/hooks/useVizijExport.ts
@@ -12,7 +12,7 @@ import {
   type BindingMap,
   type InputBindingMap,
 } from "@vizij/node-graph-authoring";
-import { normalizeGraphSpec, type GraphSpec } from "@vizij/node-graph-wasm";
+import { normalizeGraphSpec, type GraphSpec } from "@vizij/node-graph";
 import type {
   AnimatableComponent,
   AnimatableValue,

--- a/apps/vizij-authoring/src/poseRig/graphBuilder.ts
+++ b/apps/vizij-authoring/src/poseRig/graphBuilder.ts
@@ -1,4 +1,4 @@
-import type { GraphSpec, NodeSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec, NodeSpec } from "@vizij/node-graph";
 import type { StandardRigInput } from "@vizij/utils";
 import {
   buildPoseControlRelativePath,

--- a/apps/vizij-authoring/src/poseRig/graphImport.ts
+++ b/apps/vizij-authoring/src/poseRig/graphImport.ts
@@ -1,4 +1,4 @@
-import type { GraphSpec, NodeSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec, NodeSpec } from "@vizij/node-graph";
 
 type EdgeSpec = NonNullable<GraphSpec["edges"]>[number];
 

--- a/apps/vizij-authoring/src/poseRig/graphParser.ts
+++ b/apps/vizij-authoring/src/poseRig/graphParser.ts
@@ -1,4 +1,4 @@
-import type { GraphSpec, NodeSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec, NodeSpec } from "@vizij/node-graph";
 import {
   fromAroraValueJSON,
   isNormalizedValue,

--- a/apps/vizij-authoring/src/poseRig/graphTransforms.test.ts
+++ b/apps/vizij-authoring/src/poseRig/graphTransforms.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { GraphSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec } from "@vizij/node-graph";
 import { remapPoseGraphInputIds } from "./graphTransforms";
 
 function buildRecord(values: Record<string, number>) {

--- a/apps/vizij-authoring/src/poseRig/graphTransforms.ts
+++ b/apps/vizij-authoring/src/poseRig/graphTransforms.ts
@@ -1,4 +1,4 @@
-import type { GraphSpec, NodeSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec, NodeSpec } from "@vizij/node-graph";
 
 export interface PoseGraphInputIdRemap {
   fromId: string;

--- a/apps/vizij-authoring/src/poseRig/services/poseGraphService.test.ts
+++ b/apps/vizij-authoring/src/poseRig/services/poseGraphService.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import type { GraphSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec } from "@vizij/node-graph";
 import type { StandardRigInput } from "@vizij/utils";
 import {
   POSE_IR_SYNTHETIC_BOUNDARY_CONTRACT,

--- a/apps/vizij-authoring/src/poseRig/services/poseGraphService.ts
+++ b/apps/vizij-authoring/src/poseRig/services/poseGraphService.ts
@@ -1,4 +1,4 @@
-import type { GraphSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec } from "@vizij/node-graph";
 import type { StandardRigInput } from "@vizij/utils";
 import type {
   PoseRigConfigFile,

--- a/apps/vizij-authoring/src/poseRig/store.tsx
+++ b/apps/vizij-authoring/src/poseRig/store.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useSyncExternalStore } from "react";
 import type { ReactNode } from "react";
-import type { GraphSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec } from "@vizij/node-graph";
 import type { StandardRigInput } from "@vizij/utils";
 import type {
   PoseCrossGroupChannelOverride,

--- a/apps/vizij-authoring/src/poseRig/topologyGolden.test.ts
+++ b/apps/vizij-authoring/src/poseRig/topologyGolden.test.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
-import type { GraphSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec } from "@vizij/node-graph";
 import type { StandardRigInput } from "@vizij/utils";
 import { buildPoseGraphSpecFromIr } from "./graphBuilder";
 import type { PoseDiagnostic, PoseRigConfigFile } from "./types";

--- a/apps/vizij-authoring/src/poseRig/usePoseRigAuthoring.test.tsx
+++ b/apps/vizij-authoring/src/poseRig/usePoseRigAuthoring.test.tsx
@@ -2,7 +2,7 @@ import { act, useCallback, useEffect, useState } from "react";
 import type { ReactElement } from "react";
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { createRoot } from "react-dom/client";
-import type { GraphSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec } from "@vizij/node-graph";
 import type { StandardRigInput } from "@vizij/utils";
 import {
   createGraphRuntimeStore,

--- a/apps/vizij-authoring/src/poseRig/usePoseRigAuthoring.ts
+++ b/apps/vizij-authoring/src/poseRig/usePoseRigAuthoring.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from "react";
-import type { GraphSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec } from "@vizij/node-graph";
 import type { StandardRigInput } from "@vizij/utils";
 import type {
   LowLevelRigSummary,

--- a/apps/vizij-authoring/src/rig/graphBuilder.test.ts
+++ b/apps/vizij-authoring/src/rig/graphBuilder.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { GraphSpec, NodeSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec, NodeSpec } from "@vizij/node-graph";
 import type {
   AnimatableComponent,
   AnimatableValue,

--- a/apps/vizij-authoring/src/rig/importer.test.ts
+++ b/apps/vizij-authoring/src/rig/importer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { GraphSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec } from "@vizij/node-graph";
 import type {
   AnimatableBinding,
   GraphBindingSummary,

--- a/apps/vizij-authoring/src/rig/importer.ts
+++ b/apps/vizij-authoring/src/rig/importer.ts
@@ -1,4 +1,4 @@
-import type { GraphSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec } from "@vizij/node-graph";
 import {
   createDefaultBinding,
   bindingTargetFromComponent,

--- a/apps/vizij-authoring/src/state/PoseRigProvider.test.tsx
+++ b/apps/vizij-authoring/src/state/PoseRigProvider.test.tsx
@@ -6,7 +6,7 @@ import { PoseRigProvider } from "./PoseRigProvider";
 
 const mockNormalizeGraphSpec = vi.fn(async (spec: unknown) => spec);
 
-vi.mock("@vizij/node-graph-wasm", () => ({
+vi.mock("@vizij/node-graph", () => ({
   normalizeGraphSpec: (spec: unknown) => mockNormalizeGraphSpec(spec),
 }));
 

--- a/apps/vizij-authoring/src/state/PoseRigProvider.tsx
+++ b/apps/vizij-authoring/src/state/PoseRigProvider.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect, useMemo, useRef } from "react";
 import type { ReactNode } from "react";
-import { normalizeGraphSpec } from "@vizij/node-graph-wasm";
+import { normalizeGraphSpec } from "@vizij/node-graph";
 import {
   normalizeStandardRigInputPath,
   type StandardRigInput,

--- a/apps/vizij-authoring/src/state/graphRuntimeStore.tsx
+++ b/apps/vizij-authoring/src/state/graphRuntimeStore.tsx
@@ -4,7 +4,7 @@ import type {
   BuildGraphResult,
   MachineReport,
 } from "@vizij/node-graph-authoring";
-import type { GraphSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec } from "@vizij/node-graph";
 import type { PoseRigConfig } from "@vizij/runtime-react";
 import type { VizijStoreSetter, World } from "@vizij/render";
 import type { AnimatableValue, RawValue } from "@vizij/utils";

--- a/apps/vizij-authoring/src/utils/bundleAudit.ts
+++ b/apps/vizij-authoring/src/utils/bundleAudit.ts
@@ -1,6 +1,6 @@
 import type { VizijBundleExtension } from "@vizij/render";
-import type { GraphSpec } from "@vizij/node-graph-wasm";
-import { normalizeGraphSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec } from "@vizij/node-graph";
+import { normalizeGraphSpec } from "@vizij/node-graph";
 import { compileIrGraph, type IrGraph } from "@vizij/node-graph-authoring";
 import type { GraphDiffResult } from "../types/discrepancy";
 import { diffGraphSpecs } from "./graphDiff";

--- a/apps/vizij-authoring/src/utils/rigRoundtripAudit.ts
+++ b/apps/vizij-authoring/src/utils/rigRoundtripAudit.ts
@@ -3,7 +3,7 @@ import {
   type BindingMap,
   type InputBindingMap,
 } from "@vizij/node-graph-authoring";
-import { normalizeGraphSpec, type GraphSpec } from "@vizij/node-graph-wasm";
+import { normalizeGraphSpec, type GraphSpec } from "@vizij/node-graph";
 import {
   getLookup,
   cloneRawValue,

--- a/apps/vizij-authoring/src/utils/runtimeBundle.ts
+++ b/apps/vizij-authoring/src/utils/runtimeBundle.ts
@@ -1,4 +1,4 @@
-import type { GraphSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec } from "@vizij/node-graph";
 import type { VizijBundleExtension } from "@vizij/render";
 import type { VizijAssetBundle } from "@vizij/runtime-react";
 import type { PoseRigConfig } from "@vizij/runtime-react";

--- a/apps/vizij-authoring/tsconfig.json
+++ b/apps/vizij-authoring/tsconfig.json
@@ -18,7 +18,7 @@
       "@vizij/utils/*": ["../../packages/@vizij/utils/src/*"],
       "@vizij/authoring-shared": ["./src/shared/index.ts"],
       "@vizij/authoring-shared/*": ["./src/shared/*"],
-      "@vizij/node-graph-wasm/metadata": [
+      "@vizij/node-graph/metadata": [
         "../../packages/@vizij/node-graph-authoring/src/metadata-shim.d.ts"
       ]
     },

--- a/apps/vizij-authoring/vite.config.ts
+++ b/apps/vizij-authoring/vite.config.ts
@@ -68,7 +68,7 @@ export default defineConfig(({ mode }) => {
           "**/node_modules/**",
           "!**/node_modules/@vizij/animation/**",
           "!**/node_modules/@vizij/animation-react/**",
-          "!**/node_modules/@vizij/node-graph-wasm/**",
+          "!**/node_modules/@vizij/node-graph/**",
           "!**/node_modules/@vizij/node-graph-react/**",
           "!**/node_modules/@vizij/node-graph-authoring/**",
         ],
@@ -81,7 +81,7 @@ export default defineConfig(({ mode }) => {
     optimizeDeps: {
       exclude: [
         "@vizij/animation",
-        "@vizij/node-graph-wasm",
+        "@vizij/node-graph",
         "@vizij/runtime",
         "@vizij/animation-module",
       ],

--- a/apps/vizij-showcase/vite.config.ts
+++ b/apps/vizij-showcase/vite.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
     watch: {
       ignored: [
         "**/node_modules/**",
-        "!**/node_modules/@vizij/node-graph-wasm/**",
+        "!**/node_modules/@vizij/node-graph/**",
         "!**/node_modules/@vizij/render/**",
         "!**/node_modules/@vizij/utils/**",
       ],
@@ -40,7 +40,7 @@ export default defineConfig({
   },
   optimizeDeps: {
     exclude: [
-      "@vizij/node-graph-wasm",
+      "@vizij/node-graph",
       "@vizij/runtime",
       "@vizij/animation-module",
     ],

--- a/apps/vizij-showcase/vite.config.ts
+++ b/apps/vizij-showcase/vite.config.ts
@@ -39,11 +39,7 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
-    exclude: [
-      "@vizij/node-graph",
-      "@vizij/runtime",
-      "@vizij/animation-module",
-    ],
+    exclude: ["@vizij/node-graph", "@vizij/runtime", "@vizij/animation-module"],
     include: ["@vizij/render"],
   },
 });

--- a/apps/vizij-standalone/package.json
+++ b/apps/vizij-standalone/package.json
@@ -19,7 +19,7 @@
     "@tauri-apps/plugin-log": "2.8.0",
     "@vizij/node-graph-authoring": "workspace:*",
     "@vizij/node-graph-react": "workspace:*",
-    "@vizij/node-graph-wasm": "^0.7.0",
+    "@vizij/node-graph": "^0.7.0",
     "@vizij/render": "workspace:*",
     "@vizij/runtime-react": "workspace:*",
     "@vizij/speech-react": "workspace:*",

--- a/apps/vizij-standalone/vite.config.ts
+++ b/apps/vizij-standalone/vite.config.ts
@@ -33,7 +33,7 @@ export default defineConfig(async () => ({
       ignored: [
         "**/src-tauri/**",
         "**/node_modules/**",
-        "!**/node_modules/@vizij/node-graph-wasm/**",
+        "!**/node_modules/@vizij/node-graph/**",
         "!**/node_modules/@vizij/node-graph-react/**",
         "!**/node_modules/@vizij/node-graph-authoring/**",
         "!**/node_modules/@vizij/render/**",
@@ -51,7 +51,7 @@ export default defineConfig(async () => ({
   },
   optimizeDeps: {
     exclude: [
-      "@vizij/node-graph-wasm",
+      "@vizij/node-graph",
       "@vizij/runtime",
       "@vizij/animation-module",
     ],

--- a/apps/vizij-standalone/vite.config.ts
+++ b/apps/vizij-standalone/vite.config.ts
@@ -50,11 +50,7 @@ export default defineConfig(async () => ({
     },
   },
   optimizeDeps: {
-    exclude: [
-      "@vizij/node-graph",
-      "@vizij/runtime",
-      "@vizij/animation-module",
-    ],
+    exclude: ["@vizij/node-graph", "@vizij/runtime", "@vizij/animation-module"],
     include: [
       "@vizij/node-graph-react",
       "@vizij/node-graph-authoring",

--- a/packages/@vizij/node-graph-authoring/package.json
+++ b/packages/@vizij/node-graph-authoring/package.json
@@ -47,7 +47,7 @@
     "prepack": "pnpm run build && pnpm run test && pnpm run typecheck"
   },
   "dependencies": {
-    "@vizij/node-graph-wasm": "^0.7.0",
+    "@vizij/node-graph": "^0.7.0",
     "@vizij/utils": "workspace:*"
   },
   "devDependencies": {

--- a/packages/@vizij/node-graph-authoring/src/__tests__/graphBuilder.test.ts
+++ b/packages/@vizij/node-graph-authoring/src/__tests__/graphBuilder.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { GraphSpec, NodeSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec, NodeSpec } from "@vizij/node-graph";
 import type {
   AnimatableComponent,
   AnimatableValue,

--- a/packages/@vizij/node-graph-authoring/src/__tests__/irCompiler.test.ts
+++ b/packages/@vizij/node-graph-authoring/src/__tests__/irCompiler.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { GraphSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec } from "@vizij/node-graph";
 import { compileIrGraph } from "../ir/compiler";
 import type { IrGraph, IrGraphMetadata, IrGraphSummary } from "../ir/types";
 

--- a/packages/@vizij/node-graph-authoring/src/expressionFunctions.ts
+++ b/packages/@vizij/node-graph-authoring/src/expressionFunctions.ts
@@ -1,5 +1,5 @@
-import { requireNodeSignature } from "@vizij/node-graph-wasm/metadata";
-import type { NodeType } from "@vizij/node-graph-wasm";
+import { requireNodeSignature } from "@vizij/node-graph/metadata";
+import type { NodeType } from "@vizij/node-graph";
 
 type NodeSignature = ReturnType<typeof requireNodeSignature>;
 

--- a/packages/@vizij/node-graph-authoring/src/graphBuilder.ts
+++ b/packages/@vizij/node-graph-authoring/src/graphBuilder.ts
@@ -1,4 +1,4 @@
-import type { GraphSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec } from "@vizij/node-graph";
 import type {
   AnimatableValue,
   RawValue,
@@ -19,7 +19,7 @@ import {
   resolveStandardRigInputId,
 } from "@vizij/utils";
 import { SELF_BINDING_ID } from "@vizij/utils";
-import { nodeRegistryVersion } from "@vizij/node-graph-wasm/metadata";
+import { nodeRegistryVersion } from "@vizij/node-graph/metadata";
 import type { BindingMap } from "./state";
 import {
   ensureBindingStructure,

--- a/packages/@vizij/node-graph-authoring/src/ir/builder.ts
+++ b/packages/@vizij/node-graph-authoring/src/ir/builder.ts
@@ -1,4 +1,4 @@
-import type { GraphSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec } from "@vizij/node-graph";
 import {
   type IrBindingSummary,
   type IrConstant,

--- a/packages/@vizij/node-graph-authoring/src/ir/compiler.ts
+++ b/packages/@vizij/node-graph-authoring/src/ir/compiler.ts
@@ -1,4 +1,4 @@
-import type { GraphSpec, NodeSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec, NodeSpec } from "@vizij/node-graph";
 import { cloneDeepSafe } from "@vizij/utils";
 import {
   type IrConstant,

--- a/packages/@vizij/node-graph-authoring/src/ir/inspection.test.ts
+++ b/packages/@vizij/node-graph-authoring/src/ir/inspection.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { GraphSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec } from "@vizij/node-graph";
 import { cloneDeepSafe } from "@vizij/utils";
 import type { BuildGraphResult } from "../graphBuilder";
 import type { MachineReport } from "./inspection";

--- a/packages/@vizij/node-graph-authoring/src/ir/inspection.ts
+++ b/packages/@vizij/node-graph-authoring/src/ir/inspection.ts
@@ -1,5 +1,5 @@
-import type { NodeType } from "@vizij/node-graph-wasm";
-import { findNodeSignature } from "@vizij/node-graph-wasm/metadata";
+import type { NodeType } from "@vizij/node-graph";
+import { findNodeSignature } from "@vizij/node-graph/metadata";
 import { type RigBindingMetadata, cloneDeepSafe } from "@vizij/utils";
 import type { BuildGraphResult, GraphBindingSummary } from "../graphBuilder";
 import type {

--- a/packages/@vizij/node-graph-authoring/src/ir/types.ts
+++ b/packages/@vizij/node-graph-authoring/src/ir/types.ts
@@ -1,4 +1,4 @@
-import type { GraphSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec } from "@vizij/node-graph";
 
 export type IrValueType =
   | "scalar"

--- a/packages/@vizij/node-graph-authoring/src/metadata-shim.d.ts
+++ b/packages/@vizij/node-graph-authoring/src/metadata-shim.d.ts
@@ -1,9 +1,5 @@
 declare module "@vizij/node-graph/metadata" {
-  import type {
-    Registry,
-    NodeSignature,
-    NodeType,
-  } from "@vizij/node-graph";
+  import type { Registry, NodeSignature, NodeType } from "@vizij/node-graph";
 
   export function getNodeRegistry(): Registry;
   export function findNodeSignature(

--- a/packages/@vizij/node-graph-authoring/src/metadata-shim.d.ts
+++ b/packages/@vizij/node-graph-authoring/src/metadata-shim.d.ts
@@ -1,9 +1,9 @@
-declare module "@vizij/node-graph-wasm/metadata" {
+declare module "@vizij/node-graph/metadata" {
   import type {
     Registry,
     NodeSignature,
     NodeType,
-  } from "@vizij/node-graph-wasm";
+  } from "@vizij/node-graph";
 
   export function getNodeRegistry(): Registry;
   export function findNodeSignature(

--- a/packages/@vizij/node-graph-react/AGENTS.md
+++ b/packages/@vizij/node-graph-react/AGENTS.md
@@ -1,7 +1,7 @@
 # Agent Notes · @vizij/node-graph-react
 
 - Run commands via `pnpm --filter "@vizij/node-graph-react"` (`build`, `test`, `typecheck`, `lint`, `clean`, `dev`). Bundles are produced with `tsup`; declarations live in `dist/`.
-- Coordinate ABI or API changes with `@vizij/node-graph-wasm` (from `vizij-rs`). Update dependency versions and ensure compatibility helpers (`compat.tsx`) evolve in lock-step.
+- Coordinate ABI or API changes with `@vizij/node-graph` (from `vizij-rs`). Update dependency versions and ensure compatibility helpers (`compat.tsx`) evolve in lock-step.
 - Maintain documentation and demos (`apps/demo-graph-studio`, `apps/minimal-demo-graph`, `apps/minimal-demo-animation-graph`) when adding or removing hooks.
 - Pre-publish checklist:
 

--- a/packages/@vizij/node-graph-react/README.md
+++ b/packages/@vizij/node-graph-react/README.md
@@ -2,7 +2,7 @@
 
 > **React provider and hook suite for Vizij node graphs – load WASM specs, stage inputs, and consume outputs with idiomatic patterns.**
 
-This package wraps `@vizij/node-graph-wasm` in a declarative React API. It handles WASM initialisation, graph loading, readiness promises, staged inputs, playback loops, and `useSyncExternalStore`-friendly subscriptions.
+This package wraps `@vizij/node-graph` in a declarative React API. It handles WASM initialisation, graph loading, readiness promises, staged inputs, playback loops, and `useSyncExternalStore`-friendly subscriptions.
 
 ---
 
@@ -22,7 +22,7 @@ This package wraps `@vizij/node-graph-wasm` in a declarative React API. It handl
 
 ## Overview
 
-- `GraphProvider` wraps your component tree with a graph runtime derived from `@vizij/node-graph-wasm`.
+- `GraphProvider` wraps your component tree with a graph runtime derived from `@vizij/node-graph`.
 - Hooks such as `useGraphRuntime`, `useGraphOutputs`, `useNodeOutput`, `useGraphPlayback`, and `useGraphInput` expose runtime controls and derived state.
 - Built-in readiness flow (`waitForGraph`, `waitForGraphReady`) ensures initial parameters and staged inputs land before evaluations begin.
 - Managed staged input store prevents redundant allocations and guards against invalid cleanups – `stageInput(path, undefined, …)` now removes entries safely.
@@ -34,18 +34,18 @@ This package wraps `@vizij/node-graph-wasm` in a declarative React API. It handl
 
 ```bash
 # pnpm
-pnpm add @vizij/node-graph-react @vizij/node-graph-wasm react react-dom
+pnpm add @vizij/node-graph-react @vizij/node-graph react react-dom
 
 # npm
-npm install @vizij/node-graph-react @vizij/node-graph-wasm react react-dom
+npm install @vizij/node-graph-react @vizij/node-graph react react-dom
 
 # yarn
-yarn add @vizij/node-graph-react @vizij/node-graph-wasm react react-dom
+yarn add @vizij/node-graph-react @vizij/node-graph react react-dom
 ```
 
 When consuming linked WASM packages during development, configure Vite (or your bundler) to preserve symlinks and exclude the wasm shim from prebundling. See the [vizij-web README](../../../README.md#local-wasm-development) for details.
 
-> **Bundler note:** The underlying `@vizij/node-graph-wasm` package emits a `.wasm` binary. Enable async WebAssembly and emit `.wasm` assets in your bundler. For Next.js:
+> **Bundler note:** The underlying `@vizij/node-graph` package emits a `.wasm` binary. Enable async WebAssembly and emit `.wasm` assets in your bundler. For Next.js:
 >
 > ```js
 > // next.config.js
@@ -64,7 +64,7 @@ When consuming linked WASM packages during development, configure Vite (or your 
 > };
 > ```
 >
-> Passing a string URL to `@vizij/node-graph-wasm`’s `init()` keeps Webpack’s URL wrapper from interfering.
+> Passing a string URL to `@vizij/node-graph`’s `init()` keeps Webpack’s URL wrapper from interfering.
 
 ---
 
@@ -72,7 +72,7 @@ When consuming linked WASM packages during development, configure Vite (or your 
 
 - `react >= 18`
 - `react-dom >= 18`
-- `@vizij/node-graph-wasm` (ensure the wasm package is published from `vizij-rs` before tagging a release)
+- `@vizij/node-graph` (ensure the wasm package is published from `vizij-rs` before tagging a release)
 
 Keep these versions aligned across Vizij packages to avoid duplicate React instances or ABI mismatches.
 
@@ -159,7 +159,7 @@ function Awaiter() {
 - `initialParams` / `initialInputs` – One-shot seeds applied after `loadGraph` succeeds.
 - `autoStart` / `autoMode` / `updateHz` – Control playback loops (`"manual"`, `"raf"`, `"interval"`).
 - `exposeGraphReadyPromise` (default `true`) – Expose `waitForGraphReady`, `on`, and `off` helpers on the runtime.
-- `wasmInitInput` – Forwards optional init input to `@vizij/node-graph-wasm.init`.
+- `wasmInitInput` – Forwards optional init input to `@vizij/node-graph.init`.
 
 ### Runtime Surface
 
@@ -179,7 +179,7 @@ function Awaiter() {
 
 ### WASM Initialisation (0.2.4+)
 
-- `GraphProvider` and `useGraphInstance` both await `@vizij/node-graph-wasm.init()` before constructing graphs.
+- `GraphProvider` and `useGraphInstance` both await `@vizij/node-graph.init()` before constructing graphs.
 - `normalizeSpec` is awaited before invoking wasm constructors to avoid passing unresolved promises (previous versions produced `{}` specs and confusing errors).
 
 ---
@@ -249,7 +249,7 @@ The action will build, test, and publish the package with provenance metadata.
 
 ## Related Packages
 
-- [`@vizij/node-graph-wasm`](../../../vizij-rs/npm/@vizij/node-graph-wasm/README.md) – wasm wrapper consumed by this package.
+- [`@vizij/node-graph`](../../../vizij-rs/npm/@vizij/node-graph/README.md) – wasm wrapper consumed by this package.
 - [`vizij-graph-wasm`](../../../vizij-rs/crates/node-graph/vizij-graph-wasm/README.md) – Rust crate providing the wasm binding.
 - [`vizij-graph-core`](../../../vizij-rs/crates/node-graph/vizij-graph-core/README.md) – Core evaluator that ultimately runs the graph.
 

--- a/packages/@vizij/node-graph-react/package.json
+++ b/packages/@vizij/node-graph-react/package.json
@@ -23,8 +23,8 @@
     "README.md"
   ],
   "scripts": {
-    "dev": "tsup src/index.ts --format esm,cjs --dts --watch --external react,@vizij/node-graph-wasm,@vizij/value-json",
-    "build": "tsup src/index.ts --format esm,cjs --dts --external react,@vizij/node-graph-wasm,@vizij/value-json",
+    "dev": "tsup src/index.ts --format esm,cjs --dts --watch --external react,@vizij/node-graph,@vizij/value-json",
+    "build": "tsup src/index.ts --format esm,cjs --dts --external react,@vizij/node-graph,@vizij/value-json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "pnpm --filter \"$npm_package_name\" exec eslint --ext .js,.jsx,.ts,.tsx -- .",
     "lint:fix": "pnpm --filter \"$npm_package_name\" exec eslint --ext .js,.jsx,.ts,.tsx --fix -- .",
@@ -37,7 +37,7 @@
     "prepack": "pnpm run build && pnpm run test && pnpm run typecheck"
   },
   "dependencies": {
-    "@vizij/node-graph-wasm": "^0.7.0",
+    "@vizij/node-graph": "^0.7.0",
     "@vizij/value-json": "^0.2.0"
   },
   "peerDependencies": {

--- a/packages/@vizij/node-graph-react/src/GraphProvider.tsx
+++ b/packages/@vizij/node-graph-react/src/GraphProvider.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState, useCallback } from "react";
-import * as wasm from "@vizij/node-graph-wasm";
-import type { Registry } from "@vizij/node-graph-wasm";
+import * as wasm from "@vizij/node-graph";
+import type { Registry } from "@vizij/node-graph";
 import { GraphContext } from "./GraphContext";
 import type {
   GraphRuntimeContextValue,
@@ -82,7 +82,7 @@ export function GraphProvider({
         setReady(true);
       } catch (err) {
         // eslint-disable-next-line no-console
-        console.error("Failed to init @vizij/node-graph-wasm:", err);
+        console.error("Failed to init @vizij/node-graph:", err);
         if (
           err instanceof TypeError &&
           typeof err.message === "string" &&
@@ -90,7 +90,7 @@ export function GraphProvider({
         ) {
           // eslint-disable-next-line no-console
           console.error(
-            "The Vite dev server could not resolve the wasm shim in pkg/. Exclude @vizij/node-graph-wasm from optimizeDeps and allow the pkg directory in server.fs.allow.",
+            "The Vite dev server could not resolve the wasm shim in pkg/. Exclude @vizij/node-graph from optimizeDeps and allow the pkg directory in server.fs.allow.",
           );
         }
       }
@@ -501,7 +501,7 @@ export function GraphProvider({
       const module = wasmModuleRef.current ?? wasm;
       if (!module || typeof (module as any).getNodeSchemas !== "function") {
         throw new Error(
-          "@vizij/node-graph-wasm does not expose getNodeSchemas(). Update to ^0.4.1 or newer.",
+          "@vizij/node-graph does not expose getNodeSchemas(). Update to ^0.4.1 or newer.",
         );
       }
       return await (module as any).getNodeSchemas();

--- a/packages/@vizij/node-graph-react/src/__tests__/GraphProvider-load.test.ts
+++ b/packages/@vizij/node-graph-react/src/__tests__/GraphProvider-load.test.ts
@@ -10,7 +10,7 @@ import {
 } from "vitest";
 import { render, waitFor, cleanup } from "@testing-library/react";
 
-// Mock @vizij/node-graph-wasm with a configurable createGraph
+// Mock @vizij/node-graph with a configurable createGraph
 let mode: "ok" | "fail" = "ok";
 let lastGraph: any = null;
 
@@ -51,7 +51,7 @@ afterEach(() => {
 
 beforeEach(async () => {
   vi.resetModules();
-  vi.doMock("@vizij/node-graph-wasm", () => {
+  vi.doMock("@vizij/node-graph", () => {
     const init = vi.fn(async () => {});
     const normalizeGraphSpec = vi.fn(async (spec: any) => spec);
     const createGraph = vi.fn(async (_spec: any) => {
@@ -128,7 +128,7 @@ describe("GraphProvider readiness", () => {
       expect(Boolean(runtimeRef.graphLoaded)).toBe(true);
     });
 
-    const wasm: any = await import("@vizij/node-graph-wasm");
+    const wasm: any = await import("@vizij/node-graph");
     const g = wasm.__getLastGraph?.();
     expect(g).toBeTruthy();
 
@@ -140,7 +140,7 @@ describe("GraphProvider readiness", () => {
   });
 
   it("waitForGraphReady rejects on load failure", async () => {
-    const wasm: any = await import("@vizij/node-graph-wasm");
+    const wasm: any = await import("@vizij/node-graph");
     wasm.__setMode?.("fail");
 
     const spec = { nodes: [], edges: [] };
@@ -166,7 +166,7 @@ describe("GraphProvider readiness", () => {
 
   it("does not resolve readiness after unmount", async () => {
     let resolveCreate: ((graph: any) => void) | null = null;
-    const wasm: any = await import("@vizij/node-graph-wasm");
+    const wasm: any = await import("@vizij/node-graph");
     wasm.createGraph.mockImplementation(
       () =>
         new Promise((resolve) => {

--- a/packages/@vizij/node-graph-react/src/__tests__/helpers.ts
+++ b/packages/@vizij/node-graph-react/src/__tests__/helpers.ts
@@ -7,7 +7,7 @@ const here = dirname(fileURLToPath(import.meta.url));
 export function getNodeGraphWasmInitInput(): Uint8Array {
   const wasmPath = resolve(
     here,
-    "../../node_modules/@vizij/node-graph-wasm/dist/pkg/vizij_graph_wasm_bg.wasm",
+    "../../node_modules/@vizij/node-graph/dist/pkg/vizij_graph_wasm_bg.wasm",
   );
 
   const bytes = readFileSync(wasmPath);

--- a/packages/@vizij/node-graph-react/src/__tests__/input-and-teardown.test.tsx
+++ b/packages/@vizij/node-graph-react/src/__tests__/input-and-teardown.test.tsx
@@ -1,7 +1,7 @@
 import type { FC } from "react";
 import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
 import { render, waitFor, cleanup, act } from "@testing-library/react";
-import type { GraphSpec } from "@vizij/node-graph-wasm";
+import type { GraphSpec } from "@vizij/node-graph";
 
 type MockGraphInstance = {
   loadGraph: Mock;
@@ -15,7 +15,7 @@ type MockGraphInstance = {
 
 const graphInstances: MockGraphInstance[] = [];
 
-vi.mock("@vizij/node-graph-wasm", () => {
+vi.mock("@vizij/node-graph", () => {
   const makeInstance = (): MockGraphInstance => {
     const instance: MockGraphInstance = {
       loadGraph: vi.fn(),

--- a/packages/@vizij/node-graph-react/src/__tests__/node-graph-provider.test.tsx
+++ b/packages/@vizij/node-graph-react/src/__tests__/node-graph-provider.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import type { FC } from "react";
 import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
-import type { EvalResult, GraphSpec } from "@vizij/node-graph-wasm";
+import type { EvalResult, GraphSpec } from "@vizij/node-graph";
 
 type MockGraphInstance = {
   loadGraph: Mock;
@@ -14,7 +14,7 @@ type MockGraphInstance = {
 
 const graphInstances: MockGraphInstance[] = [];
 
-vi.mock("@vizij/node-graph-wasm", () => {
+vi.mock("@vizij/node-graph", () => {
   const evalResult: EvalResult = {
     nodes: {
       const: {

--- a/packages/@vizij/node-graph-react/src/__tests__/playback-and-selectors.test.tsx
+++ b/packages/@vizij/node-graph-react/src/__tests__/playback-and-selectors.test.tsx
@@ -1,7 +1,7 @@
 import type { FC } from "react";
 import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
-import type { EvalResult, GraphSpec } from "@vizij/node-graph-wasm";
+import type { EvalResult, GraphSpec } from "@vizij/node-graph";
 
 type MockGraphInstance = {
   loadGraph: Mock;
@@ -13,7 +13,7 @@ type MockGraphInstance = {
 
 const graphInstances: MockGraphInstance[] = [];
 
-vi.mock("@vizij/node-graph-wasm", () => {
+vi.mock("@vizij/node-graph", () => {
   const evalResult: EvalResult = {
     nodes: {
       const: {

--- a/packages/@vizij/node-graph-react/src/__tests__/samples.test.tsx
+++ b/packages/@vizij/node-graph-react/src/__tests__/samples.test.tsx
@@ -2,7 +2,7 @@
 import type { FC } from "react";
 import { describe, it, expect, afterAll, vi } from "vitest";
 import { render, waitFor } from "@testing-library/react";
-import { init as initNodeGraphWasm } from "@vizij/node-graph-wasm";
+import { init as initNodeGraphWasm } from "@vizij/node-graph";
 import {
   GraphProvider,
   useGraphRuntime,

--- a/packages/@vizij/node-graph-react/src/__tests__/urdf-fk-ik.test.tsx
+++ b/packages/@vizij/node-graph-react/src/__tests__/urdf-fk-ik.test.tsx
@@ -6,7 +6,7 @@ import type { FC } from "react";
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { render, cleanup, waitFor, act } from "@testing-library/react";
 import { JSDOM } from "jsdom";
-import type { GraphSpec, ValueJSON } from "@vizij/node-graph-wasm";
+import type { GraphSpec, ValueJSON } from "@vizij/node-graph";
 import {
   fromAroraValueJSON,
   isNormalizedValue,
@@ -190,12 +190,12 @@ describe("URDF FK/IK integration", () => {
     };
 
     const candidatePaths = [
-      "node_modules/@vizij/node-graph-wasm/dist/pkg/vizij_graph_wasm_bg.wasm",
-      "node_modules/@vizij/node-graph-wasm/pkg/vizij_graph_wasm_bg.wasm",
-      "../node_modules/@vizij/node-graph-wasm/dist/pkg/vizij_graph_wasm_bg.wasm",
-      "../node_modules/@vizij/node-graph-wasm/pkg/vizij_graph_wasm_bg.wasm",
-      "../../node_modules/@vizij/node-graph-wasm/dist/pkg/vizij_graph_wasm_bg.wasm",
-      "../../node_modules/@vizij/node-graph-wasm/pkg/vizij_graph_wasm_bg.wasm",
+      "node_modules/@vizij/node-graph/dist/pkg/vizij_graph_wasm_bg.wasm",
+      "node_modules/@vizij/node-graph/pkg/vizij_graph_wasm_bg.wasm",
+      "../node_modules/@vizij/node-graph/dist/pkg/vizij_graph_wasm_bg.wasm",
+      "../node_modules/@vizij/node-graph/pkg/vizij_graph_wasm_bg.wasm",
+      "../../node_modules/@vizij/node-graph/dist/pkg/vizij_graph_wasm_bg.wasm",
+      "../../node_modules/@vizij/node-graph/pkg/vizij_graph_wasm_bg.wasm",
     ].map((entry) => resolvePath(process.cwd(), entry));
 
     let wasmBytes: Buffer | null = null;
@@ -215,7 +215,7 @@ describe("URDF FK/IK integration", () => {
 
     if (!wasmBytes) {
       throw new Error(
-        "vizij_graph_wasm_bg.wasm not found; install @vizij/node-graph-wasm or run pnpm install.",
+        "vizij_graph_wasm_bg.wasm not found; install @vizij/node-graph or run pnpm install.",
       );
     }
 

--- a/packages/@vizij/node-graph-react/src/index.ts
+++ b/packages/@vizij/node-graph-react/src/index.ts
@@ -4,7 +4,7 @@ import {
   loadNodeGraphSpec,
   loadNodeGraphSpecJson,
   loadNodeGraphStage,
-} from "@vizij/node-graph-wasm";
+} from "@vizij/node-graph";
 
 export { GraphProvider } from "./GraphProvider";
 export { useGraphRuntime } from "./useGraphRuntime";
@@ -53,4 +53,4 @@ export const samples = {
   loadStage: loadNodeGraphStage,
 } as const;
 
-export * from "@vizij/node-graph-wasm";
+export * from "@vizij/node-graph";

--- a/packages/@vizij/node-graph-react/src/types.ts
+++ b/packages/@vizij/node-graph-react/src/types.ts
@@ -1,6 +1,6 @@
 /**
  * Shared types for @vizij/node-graph-react
- * These bridge to @vizij/node-graph-wasm type exports and add local runtime types.
+ * These bridge to @vizij/node-graph type exports and add local runtime types.
  */
 import type { ReactNode } from "react";
 import type {
@@ -13,7 +13,7 @@ import type {
   PortSnapshot,
   InitInput,
   Registry,
-} from "@vizij/node-graph-wasm";
+} from "@vizij/node-graph";
 
 /* Playback types */
 export type PlaybackMode = "manual" | "raf" | "interval" | "timecode";

--- a/packages/@vizij/node-graph-react/src/useGraphInstance.ts
+++ b/packages/@vizij/node-graph-react/src/useGraphInstance.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useCallback } from "react";
-import * as wasm from "@vizij/node-graph-wasm";
+import * as wasm from "@vizij/node-graph";
 import { createGraphStore } from "./utils/createGraphStore";
 import { normalizeSpec } from "./utils/normalizeSpec";
 

--- a/packages/@vizij/node-graph-react/src/utils/normalizeSpec.ts
+++ b/packages/@vizij/node-graph-react/src/utils/normalizeSpec.ts
@@ -1,11 +1,11 @@
 /**
  * normalizeSpec
- * Thin wrapper for the normalizeGraphSpec helper from @vizij/node-graph-wasm.
+ * Thin wrapper for the normalizeGraphSpec helper from @vizij/node-graph.
  * Abstracting this behind our own function makes it easier to mock in tests and
  * to add additional normalization behavior later if needed.
  */
 
-import { normalizeGraphSpec as wasmNormalizeGraphSpec } from "@vizij/node-graph-wasm";
+import { normalizeGraphSpec as wasmNormalizeGraphSpec } from "@vizij/node-graph";
 
 export type GraphSpec = any;
 

--- a/packages/@vizij/node-graph-react/src/valueHelpers.ts
+++ b/packages/@vizij/node-graph-react/src/valueHelpers.ts
@@ -6,7 +6,7 @@
  * for completeness and future use.
  */
 
-import type { PortSnapshot } from "@vizij/node-graph-wasm";
+import type { PortSnapshot } from "@vizij/node-graph";
 import {
   valueAsNumber as sharedValueAsNumber,
   valueAsVec3 as sharedValueAsVec3,

--- a/packages/@vizij/node-graph-react/vitest.config.ts
+++ b/packages/@vizij/node-graph-react/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     pool: "forks",
   },
   optimizeDeps: {
-    exclude: ["@vizij/node-graph-wasm"], // ← important
+    exclude: ["@vizij/node-graph"], // ← important
   },
   assetsInclude: ["**/*.wasm"],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,15 +107,15 @@ importers:
       '@eslint/plugin-kit':
         specifier: 0.4.0
         version: 0.4.0
+      '@vizij/node-graph':
+        specifier: ^0.7.0
+        version: 0.7.0
       '@vizij/node-graph-authoring':
         specifier: workspace:*
         version: link:../../packages/@vizij/node-graph-authoring
       '@vizij/node-graph-react':
         specifier: workspace:*
         version: link:../../packages/@vizij/node-graph-react
-      '@vizij/node-graph-wasm':
-        specifier: ^0.7.0
-        version: 0.7.0
       '@vizij/utils':
         specifier: workspace:*
         version: link:../../packages/@vizij/utils
@@ -251,12 +251,12 @@ importers:
       '@vizij/minimal-demo-ui':
         specifier: workspace:*
         version: link:../../packages/@vizij/minimal-demo-ui
+      '@vizij/node-graph':
+        specifier: ^0.7.0
+        version: 0.7.0
       '@vizij/node-graph-react':
         specifier: workspace:*
         version: link:../../packages/@vizij/node-graph-react
-      '@vizij/node-graph-wasm':
-        specifier: ^0.7.0
-        version: 0.7.0
       '@vizij/utils':
         specifier: workspace:*
         version: link:../../packages/@vizij/utils
@@ -306,12 +306,12 @@ importers:
       '@vizij/minimal-demo-ui':
         specifier: workspace:*
         version: link:../../packages/@vizij/minimal-demo-ui
+      '@vizij/node-graph':
+        specifier: ^0.7.0
+        version: 0.7.0
       '@vizij/node-graph-react':
         specifier: workspace:*
         version: link:../../packages/@vizij/node-graph-react
-      '@vizij/node-graph-wasm':
-        specifier: ^0.7.0
-        version: 0.7.0
       '@vizij/utils':
         specifier: workspace:*
         version: link:../../packages/@vizij/utils
@@ -453,15 +453,15 @@ importers:
       '@radix-ui/react-icons':
         specifier: ^1.3.2
         version: 1.3.2(react@19.2.3)
+      '@vizij/node-graph':
+        specifier: ^0.7.0
+        version: 0.7.0
       '@vizij/node-graph-authoring':
         specifier: workspace:*
         version: link:../../packages/@vizij/node-graph-authoring
       '@vizij/node-graph-react':
         specifier: workspace:*
         version: link:../../packages/@vizij/node-graph-react
-      '@vizij/node-graph-wasm':
-        specifier: ^0.7.0
-        version: 0.7.0
       '@vizij/render':
         specifier: workspace:*
         version: link:../../packages/@vizij/render
@@ -602,15 +602,15 @@ importers:
       '@tauri-apps/plugin-log':
         specifier: 2.8.0
         version: 2.8.0
+      '@vizij/node-graph':
+        specifier: ^0.7.0
+        version: 0.7.0
       '@vizij/node-graph-authoring':
         specifier: workspace:*
         version: link:../../packages/@vizij/node-graph-authoring
       '@vizij/node-graph-react':
         specifier: workspace:*
         version: link:../../packages/@vizij/node-graph-react
-      '@vizij/node-graph-wasm':
-        specifier: ^0.7.0
-        version: 0.7.0
       '@vizij/render':
         specifier: workspace:*
         version: link:../../packages/@vizij/render
@@ -736,7 +736,7 @@ importers:
 
   packages/@vizij/node-graph-authoring:
     dependencies:
-      '@vizij/node-graph-wasm':
+      '@vizij/node-graph':
         specifier: ^0.7.0
         version: 0.7.0
       '@vizij/utils':
@@ -761,7 +761,7 @@ importers:
 
   packages/@vizij/node-graph-react:
     dependencies:
-      '@vizij/node-graph-wasm':
+      '@vizij/node-graph':
         specifier: ^0.7.0
         version: 0.7.0
       '@vizij/value-json':
@@ -2664,8 +2664,8 @@ packages:
   '@vizij/animation@0.4.0':
     resolution: {integrity: sha512-0yOCMbq2bGxL2TiiiLhMw5wWJtQnU7a46bnQqEwaeUomGIvOitqGw6qhlJ1xqVNLO6wletrV3daIMpcYruso/Q==}
 
-  '@vizij/node-graph-wasm@0.7.0':
-    resolution: {integrity: sha512-h9R+84qLxWn4G9fT2DumgWylg5eTgktMM02k+jlxaNZcKZa62ZaHnJijF+0TnTA+GEQEmKGuDdf+A6JBSh7HAw==}
+  '@vizij/node-graph@0.7.0':
+    resolution: {integrity: sha512-8EtlkEQyLlaEjMeQPJK4XmjB+Y/n4FsZ7U2Z2h7j1/Fob03F00kqVQU+O8ncHjODSwpzeMsJ1D/rulMupiydUA==}
 
   '@vizij/runtime@2.0.0':
     resolution: {integrity: sha512-DYBjC4j9eoy/l5/Hol8vpXaVqRE5/l0chG71B6oG6fjxW4aV2X3970a7Uokba/5k+jE4O+cVA2ff0tK6shBwOQ==}
@@ -6911,7 +6911,7 @@ snapshots:
       '@vizij/value-json': 0.2.0
       '@vizij/wasm-loader': 0.1.5
 
-  '@vizij/node-graph-wasm@0.7.0':
+  '@vizij/node-graph@0.7.0':
     dependencies:
       '@vizij/value-json': 0.2.0
       '@vizij/wasm-loader': 0.1.5

--- a/scripts/wasm-links.mjs
+++ b/scripts/wasm-links.mjs
@@ -22,7 +22,7 @@ const ALL_PACKAGES = [
   "animation-module",
   "animation",
   "runtime",
-  "node-graph-wasm",
+  "node-graph",
   "value-json",
   "wasm-loader",
   "test-fixtures",
@@ -37,12 +37,12 @@ Usage:
 
 Examples:
   pnpm run wasm:status
-  pnpm run wasm:link -- --pkgs "node-graph-wasm runtime"
+  pnpm run wasm:link -- --pkgs "node-graph runtime"
   WASM_PKGS="graph runtime" pnpm run wasm:link
   pnpm run wasm:unlink -- --pkgs "all"
 
 Notes:
-  - Packages are names without the scope. e.g. "node-graph-wasm" maps to "@vizij/node-graph-wasm".
+  - Packages are names without the scope. e.g. "node-graph" maps to "@vizij/node-graph".
   - By default, expects sibling repo at: ${DEFAULT_VIZIJ_RS}
   - Linking uses direct symlinks under vizij-web/node_modules/@vizij/* (no pnpm global linking).
   - This script always prints a status summary after link/unlink.
@@ -103,8 +103,8 @@ function normalizePackageToken(token) {
   const t = token.trim().toLowerCase();
   if (!t) return null;
   if (t === "all" || t === "*") return "all";
-  if (t === "graph") return "node-graph-wasm";
-  if (t === "node-graph") return "node-graph-wasm";
+  if (t === "graph") return "node-graph";
+  if (t === "node-graph") return "node-graph";
   if (t === "fixtures") return "test-fixtures";
   return t;
 }


### PR DESCRIPTION
## What

Follow the npm package rename from vizij-rs ([vizij-ai/vizij-rs#65](https://github.com/vizij-ai/vizij-rs/pull/65)): switch this repo's dependency `@vizij/node-graph-wasm` → `@vizij/node-graph`. The Rust crate `vizij-graph-wasm` keeps its name — only the npm dependency changes here.

## Details

- Bump the dependency in every consumer `package.json` to `@vizij/node-graph`, **range kept at `^0.7.0`** (lineage continues from `@vizij/node-graph-wasm 0.7.0`):
  - packages: `@vizij/node-graph-react`, `@vizij/node-graph-authoring`
  - apps: `demo-graph-studio`, `minimal-demo-graph`, `minimal-demo-animation-graph`, `vizij-authoring`, `vizij-standalone`
- Update all imports / type-imports across `packages/**` and `apps/**` src, including the `@vizij/node-graph/metadata` subpath export.
- Update the vite/vitest `optimizeDeps.exclude`, dev-server watch-ignore, `tsup --external` entries, and `tsconfig` path mapping.
- `scripts/wasm-links.mjs`: `ALL_PACKAGES` now lists `node-graph`; the `graph` shorthand alias maps to it, and the redundant `node-graph` self-alias is dropped (canonical short name is now `node-graph`).
- The vitest test-shim **alias key** changes to `@vizij/node-graph`, but the local shim file `apps/minimal-demo-animation-graph/test-shims/node-graph-wasm.ts` keeps its filename — it is a local test artifact, not the npm package.
- Historical CHANGELOG entries that mention `@vizij/node-graph-wasm` are left as-is (accurate record of what shipped).

## Lockfile

`pnpm-lock.yaml` is **intentionally not regenerated**: `@vizij/node-graph` is not on the registry until the maintainer's first publish from vizij-rs, so a fresh `pnpm install` would 404 on the new name. The lockfile updates on the next install after that publish.

## Verification

Verified locally by linking the sibling vizij-rs build (temporary `pnpm.overrides` link, reverted — not committed):

- `@vizij/node-graph-react` and `@vizij/node-graph-authoring` build (tsup ESM + CJS + DTS).
- `demo-graph-studio` and `minimal-demo-graph` build under vite (resolving `@vizij/node-graph`, including the wasm chunk).

(`minimal-demo-animation-graph` was not fully built in the link sandbox due to a stale sibling-branch `@vizij/animation-react` dist unrelated to this rename; its node-graph imports resolve.)

## Merge / publish order

Merge this **after** vizij-rs [#65](https://github.com/vizij-ai/vizij-rs/pull/65) is merged **and `@vizij/node-graph` is published** to the registry — otherwise this repo's CI `pnpm install` cannot resolve the new dependency name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
