### PR TITLE
refactor(runtime-react): rename arora 'golden' keys to 'built-in' (ARORA-59)

### DIFF
--- a/apps/vizij-standalone/src/hooks/useWebSocketSync.ts
+++ b/apps/vizij-standalone/src/hooks/useWebSocketSync.ts
@@ -365,7 +365,7 @@ export function useWebSocketSync() {
     let flushTimer: number | null = null;
     let cancelled = false;
 
-    // Internal keys stay device-side: arora's golden keys (`arora/…`) and the
+    // Internal keys stay device-side: arora's built-in keys (`arora/…`) and the
     // animation module's per-tick out-blob. Everything else publishes under
     // the canonical store key (leading slash stripped, "//" collapsed,
     // namespace dropped) — raw aliases yield empty Zenoh chunks once the

--- a/packages/@vizij/runtime-react/src/VizijRuntimeProvider.tsx
+++ b/packages/@vizij/runtime-react/src/VizijRuntimeProvider.tsx
@@ -18,7 +18,7 @@ import {
   DeviceSlot,
   RUN_PERIOD_MS,
   ensureWasmInit,
-  isGoldenPath,
+  isBuiltInPath,
 } from "./engine/aroraEngine";
 import { composeGraphSpecs, type GraphSource } from "./utils/composeGraph";
 import type {
@@ -1459,7 +1459,7 @@ function VizijRuntimeProviderInner({
    *   editor publishes its graph as a program so it evaluates on the device.
    * - **animations** — a single source (`animationsGraphSource`) registered
    *   whenever any clip is playing: an `ExternalFunction` node that steps the
-   *   animation module every device tick off the golden `arora/dt`. Clips
+   *   animation module every device tick off the built-in `arora/dt`. Clips
    *   register into the module as data (via the call surface) with their
    *   final store keys resolved at load, the module samples them inside the
    *   device, and the source's path-less `output` node applies the sampled
@@ -2661,7 +2661,7 @@ function VizijRuntimeProviderInner({
       const baseOutputs = baseOutputPathsRef.current;
       entries.forEach(([changedPath, changedValue]) => {
         // Cleared keys don't render; the runtime's clock keys never do.
-        if (changedValue === null || isGoldenPath(changedPath)) {
+        if (changedValue === null || isBuiltInPath(changedPath)) {
           return;
         }
         const path = normalisePath(changedPath);

--- a/packages/@vizij/runtime-react/src/__tests__/animationModule.test.ts
+++ b/packages/@vizij/runtime-react/src/__tests__/animationModule.test.ts
@@ -270,7 +270,7 @@ describe("call builders", () => {
 });
 
 describe("animationsGraphSource", () => {
-  it("steps the module off the golden dt and applies the batch onto its keys", () => {
+  it("steps the module off the built-in dt and applies the batch onto its keys", () => {
     const source = animationsGraphSource();
     expect(source.sourceId).toBe(ANIMATIONS_SOURCE_ID);
     const nodes = source.spec.nodes as Array<{

--- a/packages/@vizij/runtime-react/src/engine/animationModule.ts
+++ b/packages/@vizij/runtime-react/src/engine/animationModule.ts
@@ -5,7 +5,7 @@
  * The module's declared ABI (ids from its `module.yaml` and type records,
  * version 0.2.0) is mirrored here as constants:
  * - setup — `load_animation` / `create_player` / `add_instance`;
- * - per tick — `step(dt_ns)` (fed the runtime's golden `arora/dt`),
+ * - per tick — `step(dt_ns)` (fed the runtime's built-in `arora/dt`),
  *   returning `[TrackOutput]`: per-track identity plus the track's authored
  *   default key and sampled value. The device graph applies the batch onto
  *   its keys via a path-less `output` node (`key_field`/`value_field`), so
@@ -454,7 +454,7 @@ export function callResultU32(result: { ret: unknown }): number | null {
 
 /**
  * Store path the animations source writes the module's per-tick
- * `[PlayerState]` feedback to. Not an `arora/` golden key, so it carries
+ * `[PlayerState]` feedback to. Not an `arora/` built-in key, so it carries
  * across device restarts like any other store value.
  */
 export const ANIMATION_PLAYERS_PATH = "vizij/animations/players";
@@ -468,7 +468,7 @@ export const ANIMATIONS_SOURCE_ID = "animations";
 /**
  * The graph source that makes the animation module tick **inside the
  * device**: an `ExternalFunction` node calls the module's `step` every
- * device tick, fed the runtime's golden `arora/dt` (nanoseconds), and a
+ * device tick, fed the runtime's built-in `arora/dt` (nanoseconds), and a
  * path-less `output` node applies the returned `[TrackOutput]` batch onto
  * the store keys each record names (`default_key` — the final rig paths,
  * decided at clip load). A second `ExternalFunction` node writes the

--- a/packages/@vizij/runtime-react/src/engine/aroraEngine.ts
+++ b/packages/@vizij/runtime-react/src/engine/aroraEngine.ts
@@ -14,7 +14,7 @@
  * a live device cannot change is its **module set** — modules load at device
  * build — so a recompose that finds the slot's modules changed since boot
  * rebuilds the device, carrying the store across (snapshot minus the
- * runtime-owned `arora/*` golden keys). Boots wait for modules a
+ * runtime-owned `arora/*` built-in keys). Boots wait for modules a
  * `waitForModules` promise announces, so the supported flows never hit that
  * rebuild.
  *
@@ -37,10 +37,10 @@ import {
 export type { RuntimeModule };
 
 /** Store keys owned by the arora runtime itself (frame clock etc.). */
-const GOLDEN_PREFIX = "arora/";
+const BUILT_IN_PREFIX = "arora/";
 
-export function isGoldenPath(path: string): boolean {
-  return path.startsWith(GOLDEN_PREFIX);
+export function isBuiltInPath(path: string): boolean {
+  return path.startsWith(BUILT_IN_PREFIX);
 }
 
 /**
@@ -178,7 +178,7 @@ export class DeviceSlot {
   /**
    * Rebuild the device because its module set changed since boot — the one
    * change a live device cannot take. Carries the store across (snapshot
-   * minus golden keys) and replays module setup via `onDeviceStarted`. The
+   * minus built-in keys) and replays module setup via `onDeviceStarted`. The
    * old device's wrapper is freed; if it was self-paced its loop keeps
    * ticking unreachable — which is why boots wait for announced modules
    * instead of leaning on this path.
@@ -189,7 +189,7 @@ export class DeviceSlot {
   ): Promise<DeviceHandle> {
     const carried: Record<string, ValueJSON> = {};
     for (const [path, value] of Object.entries(old.device.snapshot())) {
-      if (!isGoldenPath(path)) {
+      if (!isBuiltInPath(path)) {
         carried[path] = value;
       }
     }


### PR DESCRIPTION
Part of ARORA-59 (rename the arora "golden" concept → "built-in"). Independent of the crate publish — these are vizij-web-local refs.

- `@vizij/runtime-react`: `GOLDEN_PREFIX` → `BUILT_IN_PREFIX`, `isGoldenPath` → `isBuiltInPath` (both **internal** — not in the package's public index, so no API change / no version bump), plus prose for the runtime's built-in `arora/*` keys (`arora/dt`, `arora/time`).
- `vizij-standalone`: one comment referencing arora's built-in keys.

**Left untouched:** the graph-topology **snapshot tests** (`topologyGolden.test.ts`, `golden_cases`, `golden_fixtures`) — that's a different, testing sense of "golden".

🤖 Generated with [Claude Code](https://claude.com/claude-code)