### PR TITLE
docs(runtime-react): how a composition change reaches the device

### DIFF
--- a/packages/@vizij/runtime-react/README.md
+++ b/packages/@vizij/runtime-react/README.md
@@ -152,6 +152,15 @@ The device runs **one** graph, composed from several sources
 Sources are namespaced by id (`source::node`) so nodes can't collide;
 **store paths are deliberately shared** — that is the cross-source contract.
 
+**How a change reaches the device.** When the composition changes — a program
+starts or stops, the rig or a source is swapped — the new composed spec is
+installed **in place** through the behavior interpreter's `loadGraph`: a
+whole-spec replace, not an incremental `apply(GraphDiff)`. The Vizij node graph
+rejects diffs and treats every edit as a `load` (see
+[`vizij-arora-behavior/docs/node-graph.md`](https://github.com/vizij-ai/vizij-rs/blob/main/crates/interop/vizij-arora-behavior/docs/node-graph.md)).
+The device, its store, and its loaded module set are untouched across the swap;
+the device is rebuilt only when the **module set** itself changes.
+
 ### Animations and the device
 
 Playback lives inside the device, end to end. Clips load into the animation


### PR DESCRIPTION
The runtime-react README's "Where the composed graph comes from" section describes the graph *sources* but not how a change is *applied* — the question that just came up about rig setup (colleagues had assumed `apply(GraphDiff)`).

Adds a short **"How a change reaches the device"** paragraph: when the composition changes (a program starts/stops, the rig or a source is swapped), the new composed spec is installed **in place** via the behavior interpreter's `loadGraph` — a whole-spec replace, **not** an incremental `apply(GraphDiff)` (the Vizij node graph rejects diffs and treats every edit as a `load`). The device is rebuilt only when the **module set** changes. Cross-links [`vizij-arora-behavior/docs/node-graph.md`](https://github.com/vizij-ai/vizij-rs/blob/main/crates/interop/vizij-arora-behavior/docs/node-graph.md), the authoritative page.

Verified against `aroraEngine.ts` `recompose` (`loadGraph` in place; `rebuild` only when `old.modules !== this.modules`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)