### PR TITLE
docs(runtime-react): stateful nodes stay warm across a recompose

### DIFF
--- a/packages/@vizij/runtime-react/README.md
+++ b/packages/@vizij/runtime-react/README.md
@@ -159,7 +159,9 @@ whole-spec replace, not an incremental `apply(GraphDiff)`. The Vizij node graph
 rejects diffs and treats every edit as a `load` (see
 [`vizij-arora-behavior/docs/node-graph.md`](https://github.com/vizij-ai/vizij-rs/blob/main/crates/interop/vizij-arora-behavior/docs/node-graph.md)).
 The device, its store, and its loaded module set are untouched across the swap;
-the device is rebuilt only when the **module set** itself changes.
+the device is rebuilt only when the **module set** itself changes. Stateful
+nodes keep their state across the swap too — springs, dampers, and the graph
+clock carry over, so a program starting or stopping does not reset them.
 
 ### Animations and the device
 


### PR DESCRIPTION
Follow-up to the warm behavior load ([vizij-rs#70](https://github.com/vizij-ai/vizij-rs/pull/70), merged).

The runtime-react README's "How a change reaches the device" note now adds that the in-place `loadGraph` swap keeps **stateful nodes warm** — springs, dampers, and the graph clock carry over, so a program starting/stopping no longer resets them. This is the frontend-facing statement of the vizij-rs change; the authoritative mechanism doc is [`node-graph.md`](https://github.com/vizij-ai/vizij-rs/blob/main/crates/interop/vizij-arora-behavior/docs/node-graph.md) (updated in vizij-rs#71).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)