### PR TITLE
Patch the running graph via applyGraphEdits; preserve edge selectors (VIZ-79)

### DIFF
--- a/apps/vizij-authoring/src/motiongraph/utils/buildGraphSpec.ts
+++ b/apps/vizij-authoring/src/motiongraph/utils/buildGraphSpec.ts
@@ -18,9 +18,13 @@ type SpecNode = {
   params?: Record<string, unknown>;
 };
 
+/** A field/index traversal read from the source value before delivery (VIZ-79). */
+type SelectorSegment = { field: string } | { index: number };
+
 type SpecEdge = {
   from: { node_id: string; output?: string };
   to: { node_id: string; input: string };
+  selector?: SelectorSegment[];
 };
 
 export interface BuiltGraphSpec {
@@ -216,7 +220,7 @@ function buildGraphSpecInternal(
       from.output = resolvedSourceHandle;
     }
 
-    specEdges.push({
+    const specEdge: SpecEdge = {
       from,
       to: {
         node_id: edge.target,
@@ -225,7 +229,14 @@ function buildGraphSpecInternal(
           edge.targetHandle,
         ),
       },
-    });
+    };
+    // Emit an edge selector the editor preserved on `edge.data` (VIZ-79).
+    const selector = (edge.data as { selector?: SelectorSegment[] } | undefined)
+      ?.selector;
+    if (Array.isArray(selector) && selector.length > 0) {
+      specEdge.selector = selector;
+    }
+    specEdges.push(specEdge);
   }
 
   // 5. Synthesize implicit Constant nodes for unconnected input ports

--- a/apps/vizij-authoring/src/motiongraph/utils/specToEditorState.ts
+++ b/apps/vizij-authoring/src/motiongraph/utils/specToEditorState.ts
@@ -16,9 +16,13 @@ interface SpecNode {
   params?: Record<string, unknown>;
 }
 
+/** A field/index traversal read from the source value before delivery (VIZ-79). */
+type SelectorSegment = { field: string } | { index: number };
+
 interface SpecEdge {
   from: { node_id: string; output?: string };
   to: { node_id: string; input: string };
+  selector?: SelectorSegment[];
 }
 
 /* ── Result ────────────────────────────────────────────────────────── */
@@ -166,6 +170,12 @@ export function specToEditorState(
       target: se.to.node_id,
       sourceHandle: sourceHandle ?? undefined,
       targetHandle,
+      // Preserve an edge selector (a field/index read of the source value)
+      // across import → edit → export, so editing a graph that has one no
+      // longer drops it (VIZ-79).
+      ...(se.selector && se.selector.length > 0
+        ? { data: { selector: se.selector } }
+        : {}),
     });
   }
 

--- a/packages/@vizij/runtime-react/README.md
+++ b/packages/@vizij/runtime-react/README.md
@@ -153,15 +153,19 @@ Sources are namespaced by id (`source::node`) so nodes can't collide;
 **store paths are deliberately shared** — that is the cross-source contract.
 
 **How a change reaches the device.** When the composition changes — a program
-starts or stops, the rig or a source is swapped — the new composed spec is
-installed **in place** through the behavior interpreter's `loadGraph`: a
-whole-spec replace, not an incremental `apply(GraphDiff)`. The Vizij node graph
-rejects diffs and treats every edit as a `load` (see
+starts or stops, the rig or a source is swapped — the runtime diffs the old and
+new composed specs and **patches the running graph in place** through the
+behavior interpreter's `apply(GraphDiff)`: only the nodes and edges the change
+touched are re-installed (VIZ-79). A structurally empty diff is a no-op; if a
+patch ever fails the runtime falls back to a whole-spec `loadGraph`. The Vizij
+node graph is a full behavior interpreter — it accepts both an incremental
+`apply(GraphDiff)` and a whole `load` (see
 [`vizij-arora-behavior/docs/node-graph.md`](https://github.com/vizij-ai/vizij-rs/blob/main/crates/interop/vizij-arora-behavior/docs/node-graph.md)).
-The device, its store, and its loaded module set are untouched across the swap;
-the device is rebuilt only when the **module set** itself changes. Stateful
-nodes keep their state across the swap too — springs, dampers, and the graph
-clock carry over, so a program starting or stopping does not reset them.
+The device, its store, and its loaded module set are untouched across the
+change; the device is rebuilt only when the **module set** itself changes.
+Stateful nodes keep their state too — springs, dampers, and the graph clock
+carry over, and a node the edit didn't touch keeps its integration state, so a
+program starting or stopping (or an unrelated edit) does not reset it.
 
 ### Animations and the device
 

--- a/packages/@vizij/runtime-react/package.json
+++ b/packages/@vizij/runtime-react/package.json
@@ -41,7 +41,7 @@
     "@vizij/animation-module": "^0.2.0",
     "@vizij/node-graph-authoring": "workspace:*",
     "@vizij/render": "workspace:*",
-    "@vizij/runtime": "^2.0.0",
+    "@vizij/runtime": "^2.1.0",
     "@vizij/utils": "workspace:*",
     "@vizij/value-json": "^0.2.0"
   },

--- a/packages/@vizij/runtime-react/src/__tests__/graphSpecDiff.test.ts
+++ b/packages/@vizij/runtime-react/src/__tests__/graphSpecDiff.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { graphSpecDiff } from "../engine/graphSpecDiff";
+
+const constant = (id: string, value: number) => ({
+  id,
+  type: "constant",
+  params: { value: { f32: value } },
+});
+const output = (id: string, path: string) => ({ id, type: "output", params: { path } });
+const edge = (from: string, to: string, input: string, selector?: unknown) => ({
+  from: { node_id: from, output: "out" },
+  to: { node_id: to, input },
+  ...(selector ? { selector } : {}),
+});
+
+describe("graphSpecDiff", () => {
+  it("returns null for structurally identical specs", () => {
+    const spec = { nodes: [constant("a", 1)], edges: [] };
+    expect(graphSpecDiff(spec, structuredClone(spec))).toBeNull();
+  });
+
+  it("is order-insensitive for node keys", () => {
+    const a = { nodes: [{ id: "a", type: "constant", params: { value: { f32: 1 } } }], edges: [] };
+    const b = { nodes: [{ params: { value: { f32: 1 } }, type: "constant", id: "a" }], edges: [] };
+    expect(graphSpecDiff(a, b)).toBeNull();
+  });
+
+  it("upserts an added node", () => {
+    const prev = { nodes: [constant("a", 1)], edges: [] };
+    const next = { nodes: [constant("a", 1), constant("b", 2)], edges: [] };
+    const diff = graphSpecDiff(prev, next)!;
+    expect(diff.upsert_nodes.map((n) => n.id)).toEqual(["b"]);
+    expect(diff.remove_nodes).toEqual([]);
+  });
+
+  it("upserts a node whose param changed", () => {
+    const prev = { nodes: [constant("a", 1)], edges: [] };
+    const next = { nodes: [constant("a", 2)], edges: [] };
+    const diff = graphSpecDiff(prev, next)!;
+    expect(diff.upsert_nodes.map((n) => n.id)).toEqual(["a"]);
+  });
+
+  it("removes a deleted node", () => {
+    const prev = { nodes: [constant("a", 1), constant("b", 2)], edges: [] };
+    const next = { nodes: [constant("a", 1)], edges: [] };
+    const diff = graphSpecDiff(prev, next)!;
+    expect(diff.remove_nodes).toEqual(["b"]);
+    expect(diff.upsert_nodes).toEqual([]);
+  });
+
+  it("adding an edge upserts both endpoints and carries the edge", () => {
+    const prev = { nodes: [constant("a", 1), output("out", "x/y")], edges: [] };
+    const next = {
+      nodes: [constant("a", 1), output("out", "x/y")],
+      edges: [edge("a", "out", "in")],
+    };
+    const diff = graphSpecDiff(prev, next)!;
+    expect(new Set(diff.upsert_nodes.map((n) => n.id))).toEqual(new Set(["a", "out"]));
+    // The upserted nodes are removed then re-added, so the edge must ride along.
+    expect(diff.upsert_edges).toHaveLength(1);
+    expect(diff.upsert_edges[0].to).toMatchObject({ node_id: "out", input: "in" });
+  });
+
+  it("removing an edge whose endpoints survive reflects it via the upsert, not remove_edges", () => {
+    const prev = {
+      nodes: [constant("a", 1), output("out", "x/y")],
+      edges: [edge("a", "out", "in")],
+    };
+    const next = { nodes: [constant("a", 1), output("out", "x/y")], edges: [] };
+    const diff = graphSpecDiff(prev, next)!;
+    // The edge change upserts its endpoints; `out` (removed+re-added) carries
+    // only its surviving incident edges (none) — no explicit unwiring needed.
+    expect(new Set(diff.upsert_nodes.map((n) => n.id))).toEqual(new Set(["a", "out"]));
+    expect(diff.upsert_edges).toEqual([]);
+    expect(diff.remove_edges).toEqual([]);
+  });
+
+  it("carries an edge selector, and a selector change upserts the edge", () => {
+    const sel = [{ field: "layers" }, { index: 0 }, { field: "gain" }];
+    const prev = {
+      nodes: [constant("a", 1), output("out", "x/y")],
+      edges: [edge("a", "out", "in", sel)],
+    };
+    const next = {
+      nodes: [constant("a", 1), output("out", "x/y")],
+      edges: [edge("a", "out", "in", [{ field: "layers" }, { index: 1 }, { field: "gain" }])],
+    };
+    const diff = graphSpecDiff(prev, next)!;
+    expect(diff.upsert_edges).toHaveLength(1);
+    expect(diff.upsert_edges[0].selector).toEqual([
+      { field: "layers" },
+      { index: 1 },
+      { field: "gain" },
+    ]);
+  });
+});

--- a/packages/@vizij/runtime-react/src/__tests__/graphSpecDiff.test.ts
+++ b/packages/@vizij/runtime-react/src/__tests__/graphSpecDiff.test.ts
@@ -6,7 +6,11 @@ const constant = (id: string, value: number) => ({
   type: "constant",
   params: { value: { f32: value } },
 });
-const output = (id: string, path: string) => ({ id, type: "output", params: { path } });
+const output = (id: string, path: string) => ({
+  id,
+  type: "output",
+  params: { path },
+});
 const edge = (from: string, to: string, input: string, selector?: unknown) => ({
   from: { node_id: from, output: "out" },
   to: { node_id: to, input },
@@ -20,8 +24,14 @@ describe("graphSpecDiff", () => {
   });
 
   it("is order-insensitive for node keys", () => {
-    const a = { nodes: [{ id: "a", type: "constant", params: { value: { f32: 1 } } }], edges: [] };
-    const b = { nodes: [{ params: { value: { f32: 1 } }, type: "constant", id: "a" }], edges: [] };
+    const a = {
+      nodes: [{ id: "a", type: "constant", params: { value: { f32: 1 } } }],
+      edges: [],
+    };
+    const b = {
+      nodes: [{ params: { value: { f32: 1 } }, type: "constant", id: "a" }],
+      edges: [],
+    };
     expect(graphSpecDiff(a, b)).toBeNull();
   });
 
@@ -55,10 +65,15 @@ describe("graphSpecDiff", () => {
       edges: [edge("a", "out", "in")],
     };
     const diff = graphSpecDiff(prev, next)!;
-    expect(new Set(diff.upsert_nodes.map((n) => n.id))).toEqual(new Set(["a", "out"]));
+    expect(new Set(diff.upsert_nodes.map((n) => n.id))).toEqual(
+      new Set(["a", "out"]),
+    );
     // The upserted nodes are removed then re-added, so the edge must ride along.
     expect(diff.upsert_edges).toHaveLength(1);
-    expect(diff.upsert_edges[0].to).toMatchObject({ node_id: "out", input: "in" });
+    expect(diff.upsert_edges[0].to).toMatchObject({
+      node_id: "out",
+      input: "in",
+    });
   });
 
   it("removing an edge whose endpoints survive reflects it via the upsert, not remove_edges", () => {
@@ -70,7 +85,9 @@ describe("graphSpecDiff", () => {
     const diff = graphSpecDiff(prev, next)!;
     // The edge change upserts its endpoints; `out` (removed+re-added) carries
     // only its surviving incident edges (none) — no explicit unwiring needed.
-    expect(new Set(diff.upsert_nodes.map((n) => n.id))).toEqual(new Set(["a", "out"]));
+    expect(new Set(diff.upsert_nodes.map((n) => n.id))).toEqual(
+      new Set(["a", "out"]),
+    );
     expect(diff.upsert_edges).toEqual([]);
     expect(diff.remove_edges).toEqual([]);
   });
@@ -83,7 +100,13 @@ describe("graphSpecDiff", () => {
     };
     const next = {
       nodes: [constant("a", 1), output("out", "x/y")],
-      edges: [edge("a", "out", "in", [{ field: "layers" }, { index: 1 }, { field: "gain" }])],
+      edges: [
+        edge("a", "out", "in", [
+          { field: "layers" },
+          { index: 1 },
+          { field: "gain" },
+        ]),
+      ],
     };
     const diff = graphSpecDiff(prev, next)!;
     expect(diff.upsert_edges).toHaveLength(1);

--- a/packages/@vizij/runtime-react/src/engine/aroraEngine.ts
+++ b/packages/@vizij/runtime-react/src/engine/aroraEngine.ts
@@ -33,6 +33,7 @@ import {
   type ValueJSON,
   type InitInput,
 } from "@vizij/runtime";
+import { graphSpecDiff } from "./graphSpecDiff";
 
 export type { RuntimeModule };
 
@@ -223,7 +224,22 @@ export class DeviceSlot {
       if (old.spec === spec) {
         return old;
       }
-      await old.device.loadGraph(spec);
+      // Patch the running graph with just the delta, so nodes the edit didn't
+      // touch keep their runtime state (VIZ-79). A `null` diff means the two
+      // specs are structurally identical (nothing to do); a failed apply falls
+      // back to a whole-graph load.
+      const edits = graphSpecDiff(old.spec, spec);
+      if (edits) {
+        try {
+          await old.device.applyGraphEdits(edits);
+        } catch (err) {
+          console.warn(
+            "[vizij-runtime] applyGraphEdits failed; reloading the whole graph",
+            err,
+          );
+          await old.device.loadGraph(spec);
+        }
+      }
       old.spec = spec;
       return old;
     });

--- a/packages/@vizij/runtime-react/src/engine/graphSpecDiff.ts
+++ b/packages/@vizij/runtime-react/src/engine/graphSpecDiff.ts
@@ -93,7 +93,10 @@ function edgeKey(edge: EdgeRecord): string {
  * identical (nothing to apply). Nodes/edges without a usable id are skipped
  * (the caller falls back to a whole-graph load if it needs those).
  */
-export function graphSpecDiff(prev: SpecLike, next: SpecLike): GraphSpecDiff | null {
+export function graphSpecDiff(
+  prev: SpecLike,
+  next: SpecLike,
+): GraphSpecDiff | null {
   const prevNodes = new Map<string, NodeRecord>();
   for (const node of asRecords<NodeRecord>(prev.nodes)) {
     const id = nodeId(node);
@@ -134,7 +137,10 @@ export function graphSpecDiff(prev: SpecLike, next: SpecLike): GraphSpecDiff | n
   const incidentToUpsert = (edge: EdgeRecord): boolean => {
     const from = endpointId(edge.from);
     const to = endpointId(edge.to);
-    return (from !== undefined && upsertIds.has(from)) || (to !== undefined && upsertIds.has(to));
+    return (
+      (from !== undefined && upsertIds.has(from)) ||
+      (to !== undefined && upsertIds.has(to))
+    );
   };
 
   const upsert_nodes = [...upsertIds].map((id) => nextNodes.get(id)!);

--- a/packages/@vizij/runtime-react/src/engine/graphSpecDiff.ts
+++ b/packages/@vizij/runtime-react/src/engine/graphSpecDiff.ts
@@ -1,0 +1,164 @@
+/**
+ * Compute a spec-level graph diff between two composed Vizij graph specs, in the
+ * shape the runtime's `applyGraphEdits` (VIZ-79) consumes. Feeding the delta
+ * (rather than the whole new spec) lets the device patch its running graph, so
+ * nodes the edit didn't touch keep their runtime state (springs/slew/URDF, the
+ * graph clock).
+ *
+ * The contract mirrors the Rust `GraphSpecDiff`: an **upserted node is removed
+ * then re-added**, so every edge incident to an upserted node must ride in
+ * `upsert_edges`. This helper guarantees that — a node is upserted when it (or
+ * any edge touching it) changed, and all of the *next* spec's edges incident to
+ * an upserted node are included.
+ *
+ * Specs are handled structurally (loose `{ nodes, edges }` records), the same
+ * form `composeGraphSpecs` produces.
+ */
+
+type NodeRecord = Record<string, unknown> & { id?: unknown };
+
+interface EdgeEndpoint {
+  node_id?: unknown;
+  output?: unknown;
+  input?: unknown;
+}
+
+type EdgeRecord = Record<string, unknown> & {
+  from?: EdgeEndpoint;
+  to?: EdgeEndpoint;
+  selector?: unknown;
+};
+
+interface SpecLike {
+  nodes?: unknown;
+  edges?: unknown;
+}
+
+/** A spec-level graph edit; the payload of `Runtime.applyGraphEdits`. */
+export interface GraphSpecDiff {
+  upsert_nodes: NodeRecord[];
+  remove_nodes: string[];
+  upsert_edges: EdgeRecord[];
+  remove_edges: { node_id: string; input: string }[];
+}
+
+function asRecords<T>(value: unknown): T[] {
+  return Array.isArray(value) ? (value as T[]) : [];
+}
+
+function nodeId(node: NodeRecord): string | undefined {
+  return typeof node.id === "string" ? node.id : undefined;
+}
+
+function endpointId(endpoint: EdgeEndpoint | undefined): string | undefined {
+  const id = endpoint?.node_id;
+  return typeof id === "string" ? id : undefined;
+}
+
+function endpointInput(endpoint: EdgeEndpoint | undefined): string | undefined {
+  const input = endpoint?.input;
+  return typeof input === "string" ? input : undefined;
+}
+
+/** Stable JSON (keys sorted at every level) so structural equality ignores key order. */
+function stable(value: unknown): string {
+  return JSON.stringify(sortKeys(value));
+}
+
+function sortKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeys);
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      out[key] = sortKeys((value as Record<string, unknown>)[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+/** Identity of an edge: source, target, and selector (order-sensitive). */
+function edgeKey(edge: EdgeRecord): string {
+  return stable([
+    endpointId(edge.from),
+    edge.from?.output ?? "out",
+    endpointId(edge.to),
+    endpointInput(edge.to),
+    edge.selector ?? null,
+  ]);
+}
+
+/**
+ * The delta from `prev` to `next`, or `null` when the two are structurally
+ * identical (nothing to apply). Nodes/edges without a usable id are skipped
+ * (the caller falls back to a whole-graph load if it needs those).
+ */
+export function graphSpecDiff(prev: SpecLike, next: SpecLike): GraphSpecDiff | null {
+  const prevNodes = new Map<string, NodeRecord>();
+  for (const node of asRecords<NodeRecord>(prev.nodes)) {
+    const id = nodeId(node);
+    if (id) prevNodes.set(id, node);
+  }
+  const nextNodes = new Map<string, NodeRecord>();
+  for (const node of asRecords<NodeRecord>(next.nodes)) {
+    const id = nodeId(node);
+    if (id) nextNodes.set(id, node);
+  }
+
+  const prevEdges = asRecords<EdgeRecord>(prev.edges);
+  const nextEdges = asRecords<EdgeRecord>(next.edges);
+
+  // Nodes removed, and nodes new-or-changed.
+  const remove_nodes = [...prevNodes.keys()].filter((id) => !nextNodes.has(id));
+  const upsertIds = new Set<string>();
+  for (const [id, node] of nextNodes) {
+    const before = prevNodes.get(id);
+    if (!before || stable(before) !== stable(node)) upsertIds.add(id);
+  }
+
+  // Edges added or removed. Either endpoint (that still exists in `next`) is
+  // upserted, so the change is reflected when its incident edges are re-added.
+  const prevEdgeKeys = new Set(prevEdges.map(edgeKey));
+  const nextEdgeKeys = new Set(nextEdges.map(edgeKey));
+  const removedEdges = prevEdges.filter((e) => !nextEdgeKeys.has(edgeKey(e)));
+  const changedEdges = [
+    ...nextEdges.filter((e) => !prevEdgeKeys.has(edgeKey(e))),
+    ...removedEdges,
+  ];
+  for (const edge of changedEdges) {
+    for (const id of [endpointId(edge.from), endpointId(edge.to)]) {
+      if (id && nextNodes.has(id)) upsertIds.add(id);
+    }
+  }
+
+  const incidentToUpsert = (edge: EdgeRecord): boolean => {
+    const from = endpointId(edge.from);
+    const to = endpointId(edge.to);
+    return (from !== undefined && upsertIds.has(from)) || (to !== undefined && upsertIds.has(to));
+  };
+
+  const upsert_nodes = [...upsertIds].map((id) => nextNodes.get(id)!);
+  const upsert_edges = nextEdges.filter(incidentToUpsert);
+
+  // A removed edge needs explicit unwiring only when its target survives and is
+  // not upserted (an upserted target is removed-then-re-added, so dropping the
+  // edge from `upsert_edges` already unwires it).
+  const removeNodeSet = new Set(remove_nodes);
+  const remove_edges = removedEdges.flatMap((edge) => {
+    const to = endpointId(edge.to);
+    const input = endpointInput(edge.to);
+    if (!to || !input || removeNodeSet.has(to) || upsertIds.has(to)) return [];
+    return [{ node_id: to, input }];
+  });
+
+  if (
+    upsert_nodes.length === 0 &&
+    remove_nodes.length === 0 &&
+    upsert_edges.length === 0 &&
+    remove_edges.length === 0
+  ) {
+    return null;
+  }
+
+  return { upsert_nodes, remove_nodes, upsert_edges, remove_edges };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -907,8 +907,8 @@ importers:
         specifier: workspace:*
         version: link:../render
       '@vizij/runtime':
-        specifier: ^2.0.0
-        version: 2.0.0
+        specifier: ^2.1.0
+        version: 2.1.0
       '@vizij/utils':
         specifier: workspace:*
         version: link:../utils
@@ -2725,8 +2725,8 @@ packages:
   '@vizij/node-graph@0.7.0':
     resolution: {integrity: sha512-8EtlkEQyLlaEjMeQPJK4XmjB+Y/n4FsZ7U2Z2h7j1/Fob03F00kqVQU+O8ncHjODSwpzeMsJ1D/rulMupiydUA==}
 
-  '@vizij/runtime@2.0.0':
-    resolution: {integrity: sha512-DYBjC4j9eoy/l5/Hol8vpXaVqRE5/l0chG71B6oG6fjxW4aV2X3970a7Uokba/5k+jE4O+cVA2ff0tK6shBwOQ==}
+  '@vizij/runtime@2.1.0':
+    resolution: {integrity: sha512-2OjmMdjyOolN9LRQK8xwCAp3E0cQ0j0+OsWcRe49qL/nIbMdarSPiJx5WzoWGFbfQNEX7j7fg+TakOh5iI+rUQ==}
 
   '@vizij/value-json@0.2.0':
     resolution: {integrity: sha512-1wNxYLm4DPBnkcciIY4YClweIfIQinefMPsE8pQeacv1u8/0ls/Y3+GNCb3Rwa1yvdvKodRFhIf69JE2LsUC1Q==}
@@ -7006,7 +7006,7 @@ snapshots:
       '@vizij/value-json': 0.2.0
       '@vizij/wasm-loader': 0.1.5
 
-  '@vizij/runtime@2.0.0':
+  '@vizij/runtime@2.1.0':
     dependencies:
       '@vizij/value-json': 0.2.0
       '@vizij/wasm-loader': 0.1.5


### PR DESCRIPTION
Third slice of [VIZ-79](https://linear.app/semio-ai/issue/VIZ-79): the Vizij apps now **patch the running graph** on an edit instead of reloading the whole spec. This is the front-end half of the work whose runtime half is [vizij-rs#73](https://github.com/vizij-ai/vizij-rs/pull/73) (`ProcessingGraph::apply(GraphDiff)` + `Runtime.applyGraphEdits`).

## What changes

- **`DeviceSlot.recompose`** (`@vizij/runtime-react`) now diffs the previous composed spec against the new one (`graphSpecDiff`) and sends only the delta through **`Runtime.applyGraphEdits`**, falling back to a whole-graph `loadGraph` if the runtime can't apply it. Nodes an edit didn't touch keep their runtime state (springs/slew/URDF, the graph clock). This is the **shared** recompose path, so it reaches **both** the authoring editor and the standalone player.
- **`graphSpecDiff(prev, next)`** produces the `GraphSpecDiff` the runtime consumes, matching the Rust contract: a node is upserted when it (or any edge touching it) changed, and an upserted node carries all its incident edges (it is removed then re-added on the device). Structural, key-order-insensitive.
- **Edge selectors are preserved through the editor** (`motiongraph`): `specToEditorState` used to drop an edge `selector` on import and `buildGraphSpec` never emitted one, so editing a graph that reads a field/index of a source value (e.g. a blend weight) silently corrupted it. The selector now rides `edge.data.selector` across import → edit → export.

## Validation

- **End-to-end through the actual wasm** ([vizij-rs#73](https://github.com/vizij-ai/vizij-rs/pull/73) adds `tests/apply-graph-edits.mjs`): load an input→output graph, `applyGraphEdits` to insert a constant and rewire the sink, and the next step writes the constant, not the sensor — the running graph was patched, the store survived.
- **`graphSpecDiff`**: 8 unit tests (add/change/remove node, add/remove edge with endpoints upserted, selector carry + change, identical → null). Full `@vizij/runtime-react` suite: **80/80**.
- Authoring app type-checks with the selector changes.

## Dependency

Needs `@vizij/runtime` with `applyGraphEdits` — added in [vizij-rs#73](https://github.com/vizij-ai/vizij-rs/pull/73). Validated locally against the workspace-symlinked build; merging waits for #73 to land and `@vizij/runtime` to republish. Merge order: vizij-rs #72 → #73 (+ npm publish) → this.

## Note

The base carries `3c691d4b` (a `runtime-react` docs note that stateful nodes stay warm across a recompose) from `docs/warm-load-state-continuity` — directly relevant context; happy to split it out if you'd rather it be its own PR.

## Not in scope

An inspector UI to *author* edge selectors (this PR only preserves existing ones); a Playwright browser run (the Node wasm test above is the equivalent end-to-end proof).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
