### PR TITLE
docs(standalone): note the native vizij app supersedes the Tauri wrapper (VIZ-84)

### DIFF
--- a/apps/vizij-standalone/README.md
+++ b/apps/vizij-standalone/README.md
@@ -2,6 +2,12 @@
 
 `vizij-standalone` is the desktop runtime app. It wraps `@vizij/runtime-react` in a Tauri shell, loads one face bundle at a time, exposes the runtime over local control surfaces, and optionally layers speech behavior on top when the loaded bundle includes `speechConfig`.
 
+## Status: maintenance-only wrapper
+
+The runtime going forward is the native [`vizij`](https://github.com/vizij-ai/vizij-rs/tree/main/crates/vizij) app: it renders the same faces over a natively-hosted arora and composes its bridges — the open local bridge, plus `--ros2` and `--studio` — directly onto the one device. So the store-mirror this Tauri shell maintains between `@vizij/runtime-react` and its Rust side dissolves there: bridges attach to _the_ device instead of mirroring its store ([VIZ-74](https://linear.app/semio-ai/issue/VIZ-74), [VIZ-84](https://linear.app/semio-ai/issue/VIZ-84)).
+
+`vizij-standalone` stays only as an installable desktop wrapper while native packaging (deb/RPM/Android, per the ros-viz-rs recipes) catches up. It gets no further feature investment — fixes only.
+
 ## Current Runtime Flow
 
 At runtime the app:


### PR DESCRIPTION
The standalone-demotion note from [VIZ-84](https://linear.app/semio-ai/issue/VIZ-84).

The native [`vizij`](https://github.com/vizij-ai/vizij-rs/tree/main/crates/vizij) app now renders the same faces over a natively-hosted arora and composes its bridges — the open local bridge, `--ros2`, `--studio` — directly onto the one device, so the Tauri store-mirror between `@vizij/runtime-react` and the Rust side dissolves there ([VIZ-74](https://linear.app/semio-ai/issue/VIZ-74)). This adds a short "maintenance-only wrapper" status to the standalone README: it stays as an installable desktop wrapper while native packaging catches up, no further feature investment.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)