### PR TITLE
feat(authoring): standard-profile import in the File menu (VIZ-92)

### DIFF
--- a/.changeset/render-single-bundle-export.md
+++ b/.changeset/render-single-bundle-export.md
@@ -1,0 +1,5 @@
+---
+"@vizij/render": patch
+---
+
+`applyVizijBundle` strips stale `VIZIJ_bundle` copies from descendant nodes for the export window (restoring them on detach). A face loaded from a GLB kept its load-time bundle in the cloned scene's `userData`, so every re-export carried two bundles — and first-match readers (the authoring app itself, the native runtime) saw the stale one, shadowing any edit made since load.

--- a/.changeset/runtime-react-runtime-22.md
+++ b/.changeset/runtime-react-runtime-22.md
@@ -1,0 +1,5 @@
+---
+"@vizij/runtime-react": patch
+---
+
+Require `@vizij/runtime` ^2.2.0 — the release that ships the standard-profile registry (`standardProfiles()` / `standardProfile(id, rigPrefix)`) — so one runtime version serves both the preview provider and the authoring app's profile picker.

--- a/apps/vizij-authoring/e2e/standard-profile.workflow.pw.ts
+++ b/apps/vizij-authoring/e2e/standard-profile.workflow.pw.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "@playwright/test";
 import { readFile } from "node:fs/promises";
+import { expect, test } from "@playwright/test";
 import type { Download, Page } from "@playwright/test";
 import {
   bootAuthoring,

--- a/apps/vizij-authoring/e2e/standard-profile.workflow.pw.ts
+++ b/apps/vizij-authoring/e2e/standard-profile.workflow.pw.ts
@@ -1,0 +1,128 @@
+import { expect, test } from "@playwright/test";
+import { readFile } from "node:fs/promises";
+import type { Download, Page } from "@playwright/test";
+import {
+  bootAuthoring,
+  expectDownload,
+  loadMainPreset,
+  openExportDialog,
+  waitForMainFaceReady,
+} from "./helpers";
+
+/** The parsed JSON chunk of a GLB (12-byte header, chunk 0 is JSON). */
+function glbJson(buffer: Buffer): Record<string, unknown> {
+  expect(buffer.readUInt32LE(0)).toBe(0x46546c67); // "glTF"
+  const jsonLength = buffer.readUInt32LE(12);
+  expect(buffer.readUInt32LE(16)).toBe(0x4e4f534a); // "JSON"
+  return JSON.parse(
+    buffer.subarray(20, 20 + jsonLength).toString("utf8"),
+  ) as Record<string, unknown>;
+}
+
+/** The `VIZIJ_bundle.graphs` of a GLB document (root or node extension). */
+function bundleGraphs(
+  gltf: Record<string, unknown>,
+): { id?: string; kind?: string; spec?: { nodes?: unknown[] } }[] {
+  type WithExtensions = { extensions?: { VIZIJ_bundle?: { graphs?: [] } } };
+  const root = gltf as WithExtensions;
+  const nodes = (gltf.nodes ?? []) as WithExtensions[];
+  const bundle =
+    root.extensions?.VIZIJ_bundle ??
+    nodes.map((node) => node.extensions?.VIZIJ_bundle).find(Boolean);
+  expect(bundle, "the exported GLB carries a VIZIJ_bundle").toBeTruthy();
+  return bundle?.graphs ?? [];
+}
+
+async function openStandardProfilesSubmenu(page: Page): Promise<void> {
+  // Park the pointer first: the submenu opens on hover, and a pointer already
+  // resting on the trigger's coordinates produces no enter event.
+  await page.mouse.move(5, 5);
+  await page.getByTestId("app-menu-file").click();
+  await page.getByTestId("app-menu-file-standard-profiles").hover();
+  const item = page.getByTestId("app-menu-file-standard-profile-ros4hri");
+  try {
+    await item.waitFor({ state: "visible", timeout: 2000 });
+  } catch {
+    // Hover-open is timing-sensitive; ArrowRight opens the active submenu
+    // through the menu's keyboard protocol.
+    await page.keyboard.press("ArrowRight");
+    await item.waitFor({ state: "visible", timeout: 5000 });
+  }
+}
+
+async function toggleRos4hriProfile(page: Page): Promise<void> {
+  await openStandardProfilesSubmenu(page);
+  await page.getByTestId("app-menu-file-standard-profile-ros4hri").click();
+  // Checkbox items keep the menu open; Escape closes the submenu, then the
+  // menu, so the next menu click opens instead of toggling it shut.
+  await page.keyboard.press("Escape");
+  await page.keyboard.press("Escape");
+  await expect(
+    page.getByTestId("app-menu-file-standard-profiles"),
+  ).toBeHidden();
+}
+
+async function exportGlb(page: Page): Promise<Download> {
+  await openExportDialog(page);
+  const download = await expectDownload(page, async () => {
+    await page.getByTestId("export-glb-button").click();
+  });
+  return download;
+}
+
+async function downloadedGlbGraphs(download: Download) {
+  const path = await download.path();
+  if (!path) {
+    throw new Error("Expected the exported GLB to resolve to a local file");
+  }
+  return bundleGraphs(glbJson(await readFile(path)));
+}
+
+test("standard profile import round-trips through GLB export @workflow", async ({
+  page,
+}) => {
+  // Surface in-app failures (e.g. the profile fetch erroring) in the test log.
+  page.on("console", (message) => {
+    if (message.type() === "error" || message.type() === "warning") {
+      console.log(`[browser:${message.type()}]`, message.text());
+    }
+  });
+  await bootAuthoring(page);
+  await loadMainPreset(page, "quori:latest");
+
+  // Opt the face into ROS4HRI from File > Standard Profiles.
+  await toggleRos4hriProfile(page);
+
+  // The exported GLB embeds the profile under its stable id.
+  const graphs = await downloadedGlbGraphs(await exportGlb(page));
+  const embedded = graphs.find((graph) => graph.id === "standard::ros4hri");
+  expect(embedded, "standard::ros4hri embedded in the GLB").toBeTruthy();
+  expect(embedded?.kind).toBe("standard-profile");
+  // The real profile graph, not a stub: hundreds of mapping nodes.
+  expect(embedded?.spec?.nodes?.length ?? 0).toBeGreaterThan(100);
+
+  // Re-importing the exported GLB keeps the profile (the carried entry
+  // survives the load → export round trip), shown checked in the menu.
+  const download = await exportGlb(page);
+  const glbPath = await download.path();
+  await page.getByTestId("app-import-file-input").setInputFiles(glbPath!);
+  await waitForMainFaceReady(page);
+  await openStandardProfilesSubmenu(page);
+  await expect(
+    page.getByTestId("app-menu-file-standard-profile-ros4hri"),
+  ).toBeVisible();
+  await page.keyboard.press("Escape");
+  await page.keyboard.press("Escape");
+  const reGraphs = await downloadedGlbGraphs(await exportGlb(page));
+  expect(
+    reGraphs.find((graph) => graph.id === "standard::ros4hri"),
+    "the embedded profile survives re-import and re-export",
+  ).toBeTruthy();
+
+  // Unchecking removes it from the next export.
+  await toggleRos4hriProfile(page);
+  const withoutProfile = await downloadedGlbGraphs(await exportGlb(page));
+  expect(
+    withoutProfile.find((graph) => graph.id === "standard::ros4hri"),
+  ).toBeFalsy();
+});

--- a/apps/vizij-authoring/package.json
+++ b/apps/vizij-authoring/package.json
@@ -33,6 +33,7 @@
     "@vizij/node-graph-react": "workspace:*",
     "@vizij/node-graph": "^0.7.0",
     "@vizij/render": "workspace:*",
+    "@vizij/runtime": "^2.2.0",
     "@vizij/runtime-react": "workspace:*",
     "@vizij/utils": "workspace:*",
     "@vizij/value-json": "^0.2.0",

--- a/apps/vizij-authoring/src/App.tsx
+++ b/apps/vizij-authoring/src/App.tsx
@@ -94,6 +94,8 @@ import {
   buildGlbExportDirtySnapshot,
   useExportDirtyState,
 } from "./hooks/useExportDirtyState";
+import { useStandardProfiles } from "./hooks/useStandardProfiles";
+import { carriedBundleGraphs } from "./hooks/useVizijExport";
 import {
   getMemoryInvestigationFlags,
   updateMemoryDebugState,
@@ -3070,6 +3072,7 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
         crossGroupBlendMode: poseRig.crossGroupBlendMode,
         authoredAnimationClips: authoredAnimationClipsForExport,
         authoredMotionGraphs: authoredProceduralProgramsForExport,
+        carriedGraphs: carriedBundleGraphs(loader.bundle),
       }),
     [
       animatableComponents,
@@ -3077,6 +3080,7 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
       authoredAnimationClipsForExport,
       authoredProceduralProgramsForExport,
       bindings,
+      loader.bundle,
       faceId,
       featureLabelOverrides,
       includeImportedAnimations,
@@ -3942,12 +3946,26 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
     fileInputRef.current?.click();
   }, []);
 
+  const {
+    profiles: availableStandardProfiles,
+    embeddedProfileIds,
+    toggleProfile: toggleStandardProfile,
+  } = useStandardProfiles({
+    bundle: loader.bundle,
+    updateBundle: loader.updateBundle,
+  });
+
   const menuBar = (
     <AppMenuBar
       onNew={handleNewClick}
       onImport={handleImportClick}
       onImportSkipChecks={handleImportSkipChecksClick}
       onImportReferenceFace={handleImportReferenceFaceClick}
+      standardProfiles={availableStandardProfiles}
+      embeddedProfileIds={embeddedProfileIds}
+      onToggleStandardProfile={(profileId, enabled) => {
+        void toggleStandardProfile(profileId, enabled);
+      }}
       onSave={handleSaveExport}
       onExport={() => setShowExportDialog(true)}
       canSave={canExport}
@@ -4625,6 +4643,7 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
         ref={fileInputRef}
         className="hidden"
         accept=".glb,.gltf"
+        data-testid="app-import-file-input"
         onChange={(e) => void handleFileChange(e)}
       />
     </ReferenceFaceProvider>

--- a/apps/vizij-authoring/src/components/app/AppMenuBar.test.tsx
+++ b/apps/vizij-authoring/src/components/app/AppMenuBar.test.tsx
@@ -22,6 +22,9 @@ function renderMenuBar() {
       onImportReferenceFace={vi.fn()}
       onSave={vi.fn()}
       onExport={vi.fn()}
+      standardProfiles={[]}
+      embeddedProfileIds={[]}
+      onToggleStandardProfile={vi.fn()}
       canSave
       saveDirty={false}
       showSelectionGlow={false}

--- a/apps/vizij-authoring/src/components/app/AppMenuBar.tsx
+++ b/apps/vizij-authoring/src/components/app/AppMenuBar.tsx
@@ -32,6 +32,12 @@ interface AppMenuBarProps {
   onImportReferenceFace: () => void;
   onSave: () => void;
   onExport: () => void;
+  /** The shipped standard profiles a face may opt into (empty = none). */
+  standardProfiles: { id: string; title: string }[];
+  /** Profile ids the open GLB embeds (checked state of the toggles). */
+  embeddedProfileIds: string[];
+  /** Import (`enabled`) or remove a standard profile in the open GLB. */
+  onToggleStandardProfile: (profileId: string, enabled: boolean) => void;
   canSave: boolean;
   saveDirty: boolean;
   showSelectionGlow: boolean;
@@ -51,6 +57,9 @@ export function AppMenuBar({
   onImportReferenceFace,
   onSave,
   onExport,
+  standardProfiles,
+  embeddedProfileIds,
+  onToggleStandardProfile,
   canSave,
   saveDirty,
   showSelectionGlow,
@@ -159,6 +168,27 @@ export function AppMenuBar({
         >
           Import Reference Face...
         </MenuItem>
+        <MenuSubmenu
+          label="Standard Profiles"
+          testId="app-menu-file-standard-profiles"
+        >
+          {standardProfiles.length === 0 ? (
+            <MenuLabel>None available</MenuLabel>
+          ) : (
+            standardProfiles.map((profile) => (
+              <MenuCheckboxItem
+                key={profile.id}
+                checked={embeddedProfileIds.includes(profile.id)}
+                onCheckedChange={(checked) =>
+                  onToggleStandardProfile(profile.id, checked)
+                }
+                testId={`app-menu-file-standard-profile-${profile.id}`}
+              >
+                {profile.title}
+              </MenuCheckboxItem>
+            ))
+          )}
+        </MenuSubmenu>
         <MenuItem onSelect={onExport} testId="app-menu-file-export">
           Export...
         </MenuItem>

--- a/apps/vizij-authoring/src/hooks/__tests__/useExportDirtyState.test.tsx
+++ b/apps/vizij-authoring/src/hooks/__tests__/useExportDirtyState.test.tsx
@@ -74,6 +74,7 @@ function createSnapshotOptions(
     crossGroupBlendMode: "additive",
     authoredAnimationClips: [],
     authoredMotionGraphs: [],
+    carriedGraphs: [],
     ...overrides,
   };
 }

--- a/apps/vizij-authoring/src/hooks/useExportDirtyState.ts
+++ b/apps/vizij-authoring/src/hooks/useExportDirtyState.ts
@@ -36,6 +36,12 @@ export interface GlbExportDirtySnapshotOptions {
   crossGroupBlendMode: "average" | "additive";
   authoredAnimationClips: AnimationClipIR[];
   authoredMotionGraphs: AuthoredMotionGraphDirtyEntry[];
+  /**
+   * The loaded bundle's carried (non-authored) graph entries — embedded
+   * standard profiles, foreign kinds. Toggling a profile changes the export,
+   * so it must flip the dirty state.
+   */
+  carriedGraphs: { id?: string; kind: string; spec: unknown }[];
 }
 
 export function buildGlbExportDirtySnapshot(
@@ -73,6 +79,7 @@ export function buildGlbExportDirtySnapshot(
     },
     authoredAnimationClips: options.authoredAnimationClips,
     authoredMotionGraphs: options.authoredMotionGraphs,
+    carriedGraphs: options.carriedGraphs,
   };
 }
 

--- a/apps/vizij-authoring/src/hooks/useStandardProfiles.ts
+++ b/apps/vizij-authoring/src/hooks/useStandardProfiles.ts
@@ -1,0 +1,132 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  standardProfile,
+  standardProfiles,
+  type StandardProfile,
+} from "@vizij/runtime";
+import type {
+  VizijBundleExtension,
+  VizijBundleGraphEntry,
+} from "@vizij/render";
+
+/** The bundle graph kind under which a standard profile embeds in a GLB. */
+export const STANDARD_PROFILE_KIND = "standard-profile";
+
+/**
+ * The bundle graph id under which `profileId` embeds — stable, so re-import
+ * replaces rather than duplicates (mirrors the runtime's `standard::<id>`).
+ */
+export function embeddedProfileGraphId(profileId: string): string {
+  return `standard::${profileId}`;
+}
+
+/** The bare profile id of an embedded entry, `null` for other entries. */
+export function embeddedProfileId(entry: VizijBundleGraphEntry): string | null {
+  if (entry.kind !== STANDARD_PROFILE_KIND) {
+    return null;
+  }
+  const id = entry.id ?? "";
+  return id.startsWith("standard::") ? id.slice("standard::".length) : id;
+}
+
+interface UseStandardProfilesOptions {
+  /** The open document's bundle — `null` while no face is loaded. */
+  bundle: VizijBundleExtension | null;
+  /** The loader's bundle updater (value or functional form). */
+  updateBundle: (
+    updater:
+      | VizijBundleExtension
+      | null
+      | ((prev: VizijBundleExtension | null) => VizijBundleExtension | null),
+  ) => void;
+}
+
+/**
+ * The standard profiles a face may opt into (VIZ-92): the runtime's shipped
+ * registry, and the toggle that imports a profile's graph into the open GLB
+ * (embedded under `standard::<id>`, control paths rig-prefixed) or removes it.
+ * An embedded copy overrides the deployed runtime's built-in mapping of the
+ * same id; the authoring preview does not run it.
+ */
+export function useStandardProfiles({
+  bundle,
+  updateBundle,
+}: UseStandardProfilesOptions) {
+  const [profiles, setProfiles] = useState<StandardProfile[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    standardProfiles()
+      .then((list) => {
+        if (!cancelled) {
+          setProfiles(list);
+        }
+      })
+      .catch((error) => {
+        console.error("standard profiles unavailable", error);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const embeddedProfileIds = useMemo(
+    () =>
+      (bundle?.graphs ?? [])
+        .map(embeddedProfileId)
+        .filter((id): id is string => id !== null),
+    [bundle],
+  );
+
+  const toggleProfile = useCallback(
+    async (profileId: string, enabled: boolean) => {
+      if (!enabled) {
+        updateBundle((prev) => {
+          if (!prev?.graphs) {
+            return prev;
+          }
+          return {
+            ...prev,
+            graphs: prev.graphs.filter(
+              (graph) => embeddedProfileId(graph) !== profileId,
+            ),
+          };
+        });
+        return;
+      }
+      // The profile writes the face's namespaced standard controls, so it
+      // takes the bundle's rig prefix — the same prefixing the deployed
+      // runtime applies when composing the built-in.
+      const faceId = bundle?.metadata?.faceId;
+      const rigPrefix = faceId ? `rig/${faceId}/` : "";
+      const spec = await standardProfile(profileId, rigPrefix);
+      if (!spec) {
+        console.error(`standard profile ${profileId} unavailable`);
+        return;
+      }
+      // Mirrors the runtime bundler's graft: `{kind, id, spec}`, replacing
+      // the entry with the same id if present, appending otherwise.
+      const entry: VizijBundleGraphEntry = {
+        id: embeddedProfileGraphId(profileId),
+        kind: STANDARD_PROFILE_KIND,
+        spec: spec as Record<string, unknown>,
+      };
+      updateBundle((prev) => {
+        if (!prev) {
+          return prev;
+        }
+        const graphs = [...(prev.graphs ?? [])];
+        const existing = graphs.findIndex((graph) => graph.id === entry.id);
+        if (existing >= 0) {
+          graphs[existing] = entry;
+        } else {
+          graphs.push(entry);
+        }
+        return { ...prev, graphs };
+      });
+    },
+    [bundle, updateBundle],
+  );
+
+  return { profiles, embeddedProfileIds, toggleProfile } as const;
+}

--- a/apps/vizij-authoring/src/hooks/useVizijExport.ts
+++ b/apps/vizij-authoring/src/hooks/useVizijExport.ts
@@ -3,6 +3,7 @@ import {
   exportScene,
   type VizijBundleAnimationEntry,
   type VizijBundleExtension,
+  type VizijBundleGraphEntry,
   type VizijPoseRigConfig,
   type VizijSpeechConfig,
   type VizijData,
@@ -1361,6 +1362,23 @@ function clonePoseIrForBundle(
   return cloned;
 }
 
+/** The graph kinds the export builder authors from editor state. */
+const AUTHORED_GRAPH_KINDS = new Set(["rig", "pose-driver", "motiongraph"]);
+
+/**
+ * The loaded bundle's graph entries the export builder does not author —
+ * embedded standard profiles, foreign kinds. Export carries them forward
+ * verbatim (re-exporting a face must not drop what it carried), and the
+ * dirty-state snapshot watches them.
+ */
+export function carriedBundleGraphs(
+  bundle: VizijBundleExtension | null | undefined,
+): VizijBundleGraphEntry[] {
+  return (bundle?.graphs ?? []).filter(
+    (graph) => !AUTHORED_GRAPH_KINDS.has(graph.kind),
+  );
+}
+
 function mergeMotionGraphsIntoBundle(
   bundle: VizijBundleExtension,
   motionGraphs: MotionGraphExportEntry[],
@@ -1554,6 +1572,13 @@ function buildVizijBundle(
       >,
       metadata: { exportedAt: exportTimestamp, faceId: exportFaceId },
     });
+  }
+
+  // Carry forward what this builder does not author (embedded standard
+  // profiles, foreign kinds): re-exporting a face must not drop what it
+  // carried.
+  for (const carried of carriedBundleGraphs(loadedBundle)) {
+    graphs.push(cloneSerializable(carried) as BundleGraphWithIr);
   }
 
   const poseConfigForBundle =

--- a/packages/@vizij/render/src/functions/vizij-bundle.ts
+++ b/packages/@vizij/render/src/functions/vizij-bundle.ts
@@ -128,6 +128,11 @@ export function applyVizijBundle(
       : {};
   const originalExtensions = userData.gltfExtensions;
   let applied = false;
+  // A face loaded from a GLB still carries its load-time bundle in some
+  // descendant's userData; exported as-is it would ride along and shadow the
+  // fresh bundle for every reader (first match wins). Strip those copies for
+  // the export window and restore them on detach.
+  const staleCarriers: { node: Object3D; extensions: unknown }[] = [];
 
   if (bundle) {
     userData.gltfExtensions = {
@@ -135,6 +140,23 @@ export function applyVizijBundle(
       VIZIJ_bundle: bundle,
     };
     (object as any).userData = userData;
+    object.traverse((node) => {
+      if (node === object) {
+        return;
+      }
+      const extensions = (node.userData as Record<string, unknown> | undefined)
+        ?.gltfExtensions as Record<string, unknown> | undefined;
+      if (!extensions || !(BUNDLE_KEYS[0] in extensions)) {
+        return;
+      }
+      staleCarriers.push({ node, extensions });
+      const { [BUNDLE_KEYS[0]]: _stale, ...rest } = extensions;
+      if (Object.keys(rest).length > 0) {
+        node.userData.gltfExtensions = rest;
+      } else {
+        delete node.userData.gltfExtensions;
+      }
+    });
     applied = true;
   }
 
@@ -152,6 +174,10 @@ export function applyVizijBundle(
         delete (object as any).userData;
       }
     }
+    for (const { node, extensions } of staleCarriers) {
+      node.userData.gltfExtensions = extensions;
+    }
+    staleCarriers.length = 0;
     applied = false;
   };
 }

--- a/packages/@vizij/render/tests/vizij-bundle.node-test.mjs
+++ b/packages/@vizij/render/tests/vizij-bundle.node-test.mjs
@@ -74,3 +74,32 @@ test("prefers root-level parser extension over node and scene extensions", () =>
   assert.ok(bundle, "bundle should be found");
   assert.equal(bundle.metadata?.source, "root");
 });
+
+test("applyVizijBundle strips stale descendant bundles for the export window", async () => {
+  const { applyVizijBundle } = await import("../src/functions/vizij-bundle.ts");
+  const root = new Group();
+  const carrier = new Group();
+  root.add(carrier);
+  const staleBundle = { version: 1, graphs: [{ id: "old", kind: "rig" }] };
+  carrier.userData.gltfExtensions = {
+    VIZIJ_bundle: staleBundle,
+    OTHER_ext: { keep: true },
+  };
+  const freshBundle = {
+    version: 1,
+    graphs: [{ id: "standard::ros4hri", kind: "standard-profile" }],
+  };
+
+  const detach = applyVizijBundle(root, freshBundle);
+  // While attached: the root carries the fresh bundle, the descendant's stale
+  // copy is gone (it would shadow the fresh one for first-match readers), and
+  // its unrelated extensions survive.
+  assert.equal(root.userData.gltfExtensions.VIZIJ_bundle, freshBundle);
+  assert.equal(carrier.userData.gltfExtensions.VIZIJ_bundle, undefined);
+  assert.equal(carrier.userData.gltfExtensions.OTHER_ext.keep, true);
+
+  detach();
+  // Detached: the descendant's original extensions are restored intact.
+  assert.equal(carrier.userData.gltfExtensions.VIZIJ_bundle, staleBundle);
+  assert.equal(root.userData?.gltfExtensions, undefined);
+});

--- a/packages/@vizij/runtime-react/package.json
+++ b/packages/@vizij/runtime-react/package.json
@@ -41,7 +41,7 @@
     "@vizij/animation-module": "^0.2.0",
     "@vizij/node-graph-authoring": "workspace:*",
     "@vizij/render": "workspace:*",
-    "@vizij/runtime": "^2.1.0",
+    "@vizij/runtime": "^2.2.0",
     "@vizij/utils": "workspace:*",
     "@vizij/value-json": "^0.2.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -488,6 +488,9 @@ importers:
       '@vizij/render':
         specifier: workspace:*
         version: link:../../packages/@vizij/render
+      '@vizij/runtime':
+        specifier: ^2.2.0
+        version: 2.2.0
       '@vizij/runtime-react':
         specifier: workspace:*
         version: link:../../packages/@vizij/runtime-react
@@ -907,8 +910,8 @@ importers:
         specifier: workspace:*
         version: link:../render
       '@vizij/runtime':
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^2.2.0
+        version: 2.2.0
       '@vizij/utils':
         specifier: workspace:*
         version: link:../utils
@@ -2725,8 +2728,8 @@ packages:
   '@vizij/node-graph@0.7.0':
     resolution: {integrity: sha512-8EtlkEQyLlaEjMeQPJK4XmjB+Y/n4FsZ7U2Z2h7j1/Fob03F00kqVQU+O8ncHjODSwpzeMsJ1D/rulMupiydUA==}
 
-  '@vizij/runtime@2.1.0':
-    resolution: {integrity: sha512-2OjmMdjyOolN9LRQK8xwCAp3E0cQ0j0+OsWcRe49qL/nIbMdarSPiJx5WzoWGFbfQNEX7j7fg+TakOh5iI+rUQ==}
+  '@vizij/runtime@2.2.0':
+    resolution: {integrity: sha512-AuaApP0KuxxxQjl/AqX2rQdhCfbq2Y+Md9Zqg++gcGbgdYa8iGUFG6YCCP+vTcSpPAjgScG3IGIotBAEBvog+w==}
 
   '@vizij/value-json@0.2.0':
     resolution: {integrity: sha512-1wNxYLm4DPBnkcciIY4YClweIfIQinefMPsE8pQeacv1u8/0ls/Y3+GNCb3Rwa1yvdvKodRFhIf69JE2LsUC1Q==}
@@ -7006,7 +7009,7 @@ snapshots:
       '@vizij/value-json': 0.2.0
       '@vizij/wasm-loader': 0.1.5
 
-  '@vizij/runtime@2.1.0':
+  '@vizij/runtime@2.2.0':
     dependencies:
       '@vizij/value-json': 0.2.0
       '@vizij/wasm-loader': 0.1.5


### PR DESCRIPTION
The authoring half of [VIZ-92](https://linear.app/semio-ai/issue/VIZ-92/profile-import-in-glb-when-authoring), on top of the runtime precedence shipped in [vizij-rs#89](https://github.com/vizij-ai/vizij-rs/pull/89) (`@vizij/runtime` 2.2.0).

**Feature** — `File > Standard Profiles` lists the runtime's shipped profiles (`standardProfiles()`) as checkboxes. Checking one imports its graph into the open GLB: embedded under the stable id `standard::<profile>`, control paths rig-prefixed (`rig/<faceId>/`), re-import replacing in place — mirroring `vizij-bundle add-standard` byte-for-byte in entry shape. Unchecking removes it. Opt-in by design: the imported copy is part of the **asset**, not the preview — the authoring runtime composes no profile, and at deploy the embedded copy **overrides** the built-in mapping of the same id.

**Two real bugs fixed along the way**
1. **`@vizij/render`: re-exports carried two bundles.** A face loaded from a GLB keeps its load-time `VIZIJ_bundle` in the scene graph's `userData`; export attached the fresh bundle while the stale copy rode along on a descendant node. First-match readers — including this app on re-import and the native runtime's `Bundle::from_gltf_json` — saw the **stale** bundle, shadowing any edit made since load. `applyVizijBundle` now strips descendant copies for the export window and restores them on detach. (Unit-tested; this shadowing affected *all* re-exported edits, not just profiles.)
2. **Export dropped non-authored graph kinds.** `buildVizijBundle` rebuilt `graphs` from rig/pose-driver/motiongraph only — a GLB embedded via `vizij-bundle add-standard` then opened+saved here silently lost its profile. The builder now carries forward everything it does not author, and the dirty-state snapshot watches those carried entries (toggling a profile marks the document unsaved).

**Verification**
- New `@workflow` e2e: import ROS4HRI → exported GLB embeds the 674-node `standard::ros4hri` graph → re-import shows it checked, re-export keeps it → uncheck removes it. **Passing locally (54.7s)**, exercising the real wasm registry end-to-end.
- Units: vizij-authoring 729 ✓, @vizij/render 14 ✓ (incl. the new stale-strip test); tsc clean on the app and runtime-react.
- `reference-face.smoke` fails on this machine **identically on clean main** (pre-existing pose-copy dialog timeout, unrelated).

**Deps** — `@vizij/runtime` ^2.2.0 for the app (new direct dep) and runtime-react, so one wasm version serves the preview provider and the picker. Changesets: `@vizij/render` patch, `@vizij/runtime-react` patch.

Profile *edition* and canonical JSON re-export are deliberately out of scope — that's [VIZ-93](https://linear.app/semio-ai/issue/VIZ-93/profile-edition), next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)