### PR TITLE
test(e2e): reference-face smoke asserts the current pose-copy contract + runs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,24 @@ jobs:
         with:
           name: playwright-report
           path: e2e/test-results/
+
+  authoring-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build:packages
+      - run: pnpm --filter vizij-authoring exec playwright install --with-deps chromium
+      - run: pnpm --filter vizij-authoring test:e2e:smoke
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: authoring-smoke-report
+          path: apps/vizij-authoring/test-results/

--- a/apps/vizij-authoring/e2e/reference-face.smoke.pw.ts
+++ b/apps/vizij-authoring/e2e/reference-face.smoke.pw.ts
@@ -1,7 +1,13 @@
 import { expect, test } from "@playwright/test";
-import { bootAuthoring, loadMainPreset, loadReferencePreset } from "./helpers";
+import {
+  bootAuthoring,
+  loadMainPreset,
+  loadReferencePreset,
+  sanitizePresetId,
+  waitForReferenceFaceReady,
+} from "./helpers";
 
-test("reference face compare, copy, and reset @smoke", async ({ page }) => {
+test("reference face compare and pose copy @smoke", async ({ page }) => {
   await bootAuthoring(page);
   await loadMainPreset(page, "quori:latest");
   await loadReferencePreset(page, "quori:basic");
@@ -9,6 +15,9 @@ test("reference face compare, copy, and reset @smoke", async ({ page }) => {
   const posesTab = page.getByTestId("control-authoring-tab-poses");
   await posesTab.click();
 
+  // Same-character reference: quori:basic's poses map fully onto
+  // quori:latest (every path resolves by exact normalized match) and the
+  // pose names collide, so the dialog offers an in-place overwrite.
   const copyButton = page.getByTestId("variables-poses-copy-reference");
   await expect(copyButton).toBeVisible();
   await expect(copyButton).not.toHaveText(/Copy Ref Pose \(0\)/);
@@ -16,11 +25,27 @@ test("reference face compare, copy, and reset @smoke", async ({ page }) => {
   await expect(
     page.getByRole("heading", { name: "Pose Copy Mapping" }),
   ).toBeVisible();
-  await page.getByRole("button", { name: "Confirm Copy" }).click();
-  await expect(page.getByRole("alert")).toContainText(
-    "Blocking unresolved mapping",
-  );
-  await page.getByRole("button", { name: "Cancel" }).click();
+  await expect(page.getByText("unresolved rows: 0")).toBeVisible();
+  const confirmButton = page.getByRole("button", { name: "Overwrite Pose" });
+  await expect(confirmButton).toBeEnabled();
+  await confirmButton.click();
+  // A fully resolved mapping copies without complaint: the dialog closes
+  // and no blocking alert appears.
+  await expect(
+    page.getByRole("heading", { name: "Pose Copy Mapping" }),
+  ).toBeHidden();
+  await expect(page.getByRole("alert")).toBeHidden();
+
+  // Cross-character reference: no pose maps onto the other rig, so the
+  // copy flow never opens. (The blocking-unresolved path is unit-tested in
+  // referenceFace/mapping.test.ts; no shipped preset pairing reaches it.)
+  await page.getByTestId("reference-face-unload").click();
+  await page
+    .getByTestId(`reference-face-preset-${sanitizePresetId("toasty:basic")}`)
+    .click();
+  await waitForReferenceFaceReady(page);
+  await expect(copyButton).toHaveText(/Copy Ref Pose \(0\)/);
+  await expect(copyButton).toBeDisabled();
 
   await page.getByTestId("main-runtime-reset-inputs").click();
   await expect(page.getByTestId("main-runtime-ready-flag")).toBeVisible();


### PR DESCRIPTION
Follow-up to the investigation on the locally-failing `reference-face.smoke`.

**Why it failed everywhere but CI stayed green:** the spec still asserted the world before `e90b6345` "Update default face presets" (2026-03-06) — quori:basic → quori:latest pose copy blocked on unresolved mappings behind a "Confirm Copy" button. Since that refresh, every mapping resolves by exact normalized path match ("unresolved rows: 0") and the pose names collide, so the dialog offers **"Overwrite Pose"** — the old assertions could never pass. Nothing noticed because **no CI job runs the authoring smoke suite** (the `e2e` job covers the root `vizij-e2e` demo suite only).

**Spec rewrite** — asserts what the app actually does today:
- Same-character reference (quori:basic): dialog reports `unresolved rows: 0`, "Overwrite Pose" is enabled, confirming closes the dialog with no blocking alert.
- Cross-character reference (toasty:basic, after unloading): "Copy Ref Pose (0)", disabled — the copy flow never opens.
- The blocking-unresolved path stays covered at unit level ([`referenceFace/mapping.test.ts`](apps/vizij-authoring/src/referenceFace/mapping.test.ts)); no shipped preset pairing can reach it through the UI.

**CI** — new `authoring-smoke` job (~2 min, mirrors the `e2e` job's setup: install → build:packages → playwright chromium → `test:e2e:smoke`, report artifact on failure) so the authoring smoke suite can no longer rot invisibly.

Verified locally: the rewritten spec passes in 27.1s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)