### PR TITLE
docs(node-graph): specs for multi-output ports and user-defined many-to-many blocks

### DIFF
--- a/packages/@vizij/node-graph-authoring/README.md
+++ b/packages/@vizij/node-graph-authoring/README.md
@@ -8,6 +8,10 @@ Authoring-time helpers for constructing Vizij graph specifications. The package 
 - The expression parser understands comparison and boolean operators (`>`, `<`, `==`, `!=`, `&&`, `||`, `!`) and maps them through shared metadata to the appropriate logic nodes.
 - Graph summaries surface the slot `valueType`, making it easier to audit vector wiring in generated specs.
 
+## Design Docs
+
+`docs/` holds the design documents for the compile contract, including the two plans for multi-output ports and user-definable many-in / many-out blocks. Start at `docs/README.md`.
+
 ## IR Inspection
 
 Use the bundled `vizij-ir-report` CLI whenever you need to peek at or diff the metadata-annotated IR graph for a set of bindings—no GraphSpec export required. The tool rebuilds the IR via `buildRigGraphSpec`, emits a normalized machine-readable dump (including registry annotations under `irGraph.nodes[].annotations.registry`), and can compare dumps for CI/regression guards.

--- a/packages/@vizij/node-graph-authoring/docs/README.md
+++ b/packages/@vizij/node-graph-authoring/docs/README.md
@@ -8,6 +8,7 @@ Design documents for the authoring-time graph compiler. Cross-repo architecture 
    - Lets authored expressions read more than one output port from a node. Confined to vizij-web. Independent and ready to schedule.
 2. `subgraph-function-node-design-2026-07-30.md`
    - Lets authors define reusable many-in / many-out blocks via a `call` node and a graph-local function table. Lands mostly in `vizij-rs`.
+   - Its section 4.8 specifies how the two plans compose — the end state is `polar_to_cart(radius, angle).x`, where doc 1 delivers the `.x` and doc 2 delivers the function. There is deliberately no third integration document; the joins live with the dependent plan.
 
 ## Background: the graph is already many-to-many
 

--- a/packages/@vizij/node-graph-authoring/docs/README.md
+++ b/packages/@vizij/node-graph-authoring/docs/README.md
@@ -1,0 +1,16 @@
+# @vizij/node-graph-authoring Docs
+
+Design documents for the authoring-time graph compiler. Cross-repo architecture lives in `vizij-docs`; authoring-app execution tracking lives in `apps/vizij-authoring/docs`. This folder owns the compile contract between authored bindings and `GraphSpec`.
+
+## Design Documents
+
+1. `multi-output-ports-authoring-plan-2026-07-30.md`
+   - Lets authored expressions read more than one output port from a node. Confined to vizij-web. Independent and ready to schedule.
+2. `subgraph-function-node-design-2026-07-30.md`
+   - Lets authors define reusable many-in / many-out blocks via a `call` node and a graph-local function table. Lands mostly in `vizij-rs`.
+
+## Background: the graph is already many-to-many
+
+A recurring assumption is that a graph node computes one value from many inputs. It does not. `eval_node` produces a map of named output ports per node, edges are port-addressed via `output_key` (defaulting to `out`), and node signatures declare `outputs: Vec<PortSpec>` plus optional `variadic_outputs`. `MultiSlider` and `Split` already use this.
+
+The single-output behavior everyone observes comes from the authoring layer in this package, which resolves every node to its default port and truncates function signatures at `outputs[0]`. Both documents above start from that distinction; see section 3 of each for the file-level evidence.

--- a/packages/@vizij/node-graph-authoring/docs/multi-output-ports-authoring-plan-2026-07-30.md
+++ b/packages/@vizij/node-graph-authoring/docs/multi-output-ports-authoring-plan-2026-07-30.md
@@ -1,0 +1,229 @@
+# Multi-Output Ports in the Authoring Compiler
+
+Last updated: 2026-07-30
+Owner: Vizij Graph / Authoring
+Status: draft design document (current-state + target-state)
+Scope: `@vizij/node-graph-authoring`, `apps/demo-graph-studio`, `apps/vizij-authoring`
+Companion doc: `subgraph-function-node-design-2026-07-30.md`
+
+## 1) Goal
+
+Let authored graphs read more than one output port from a node.
+
+The graph substrate already evaluates every node as a many-in / many-out function. The authoring compiler in this package does not: it treats a node as a single value and always reads the implicit `out` port. This document specifies the change that closes that gap, entirely inside vizij-web.
+
+Non-goal: letting users define new node types. That is the companion doc.
+
+## 2) Verification Basis
+
+Findings below were read from:
+
+- `packages/@vizij/node-graph-authoring/src/**` at commit `693b039a` (this repo, authoritative).
+- `apps/demo-graph-studio/src/**` at the same commit.
+- `vizij-rs` core sources from a local checkout that is **behind** the published `@vizij/node-graph@0.7.0` this repo builds against (it lacks the `case` node that 0.7.0 metadata exposes). Rust line references are therefore indicative. Every core invariant this plan depends on is independently confirmed from the TypeScript side, which is pinned to 0.7.0 — see the cross-checks in section 3.2.
+
+## 3) Current State
+
+### 3.1 The core is already many-out
+
+| Capability                         | Where                                                                     |
+| ---------------------------------- | ------------------------------------------------------------------------- |
+| Per-node map of named output ports | `GraphRuntime.outputs: HashMap<NodeId, HashMap<String, PortValue>>`       |
+| Port-addressed edges               | `InputConnection { node_id, output_key }`, `output_key` defaults to `out` |
+| Declared multi-output signatures   | `NodeSignature.outputs: Vec<PortSpec>` plus `variadic_outputs`            |
+| Per-port shape enforcement         | `NodeSpec.output_shapes: HashMap<String, Shape>`                          |
+| Nodes already using it             | `MultiSlider` (`x`/`y`/`z`), `Split` (variadic `part1..partN`)            |
+
+Node evaluation is atomic: `eval_node` computes the whole port map in one call and inserts it once. `topo_order` is node-granular. For many-to-many that is the correct granularity — a node with five consumers reading three different ports is still evaluated exactly once.
+
+### 3.2 Cross-checks from the TypeScript side (pinned to 0.7.0)
+
+- `packages/@vizij/node-graph-authoring/src/ir/compiler.ts:89` already compiles `edge.from.portId` into `from.output` on the wire spec.
+- `packages/@vizij/node-graph-authoring/src/ir/types.ts:12` — `IrPortRef` already carries an optional `portId`.
+- `apps/demo-graph-studio/src/store/useEditorStore.ts:618` and `:952` already read and write `output_key` / `sourceHandle`, defaulting to `out`.
+- `apps/demo-graph-studio/src/components/EditorCanvas.tsx:364` already renders one React Flow `Handle` per `schema.outputs` entry, including variadic groups.
+- `@vizij/node-graph-react` already exports `useNodeOutput(nodeId, outputKey)` and `useNodeOutputs`.
+
+So the wire format, the IR, the node-canvas editor, and the React read hooks are all port-aware today.
+
+### 3.3 Where the single-output assumption actually lives
+
+Three places, all in this package.
+
+**(a) The expression compiler's currency is a node id, not a port ref.**
+
+`materializeExpression` (`src/graphBuilder.ts:1245`) returns `string`, and so does every helper it calls: `getConstantNodeId` (`:671`), `getVectorConstantNodeId` (`:693`), `createBinaryOperationNode` (`:720`), `createVariadicOperationNode` (`:747`), `createNamedOperationNode` (`:773`), `ensureReservedVariableNode` (`:801`), `ensureGraphTimeNode` (`:817`), `emitScalarFunctionNode` (`:835`), `emitCaseFunctionNode` (`:982`).
+
+Consequently all 28 `from: { nodeId }` edge emissions in `graphBuilder.ts` omit `portId`, and the compiler emits `out` everywhere by construction.
+
+**(b) The function registry discards every port but the first.**
+
+`src/expressionFunctions.ts:574`:
+
+```ts
+resultValueType: inferExpressionValueType(
+  (signature.outputs as SignatureOutput[])?.[0]?.ty ?? null,
+),
+```
+
+A `ScalarFunctionDefinition` has exactly one `resultValueType`. There is no representation for "this function has ports `position` and `rotation`."
+
+**(c) The expression grammar has no way to name a port.**
+
+`ControlExpressionNode` (`src/expression.ts:1`) is `Literal | VectorLiteral | Reference | Unary | Binary | Function`. `IDENT_PART` is `/[A-Za-z0-9_]/` — `.` is not an identifier character and there is no member-access production. `ExpressionVariableTable.resolveNodeId(name): string | null` (`src/expressionVariables.ts:51`) resolves a name to a node id with no port component.
+
+Supporting facts: the per-expression type map `ExpressionBuildContext.nodeValueTypes` (`src/graphBuilder.ts:612`) is keyed by node id, so it cannot describe two ports of differing type on one node. And the binding model itself is one expression per `(animatable, component)` slot — vector animatables are reassembled by fanning N independent scalar subtrees into a `join` and then a single `output` sink (`src/graphBuilder.ts:2459-2501`).
+
+### 3.4 Consequences today
+
+1. `MultiSlider` is unusable from expressions; only its `x` port is reachable.
+2. `Split`'s variadic outputs are unreachable from expressions.
+3. Any future multi-result node (IK returning position and rotation, a solver returning value and error) is expressible in the core but not authorable.
+4. Two bindings that need two results of the same computation each build their own copy of the subtree, because each binding slot compiles in its own `ExpressionBuildContext`. Constant dedup is per-context (`context.constants`), so there is no cross-slot common-subexpression elimination at all.
+
+## 4) Target State
+
+1. A node reference in an expression may name a port: `solver.position`.
+2. A reference with no port resolves to the node's sole non-optional output, or errors with a listing of available ports if the node has more than one.
+3. The compiler threads `{ nodeId, portId }` end to end, so `IrEdge.from.portId` is populated whenever the source is not the default port.
+4. Nodes with multiple outputs are instantiated once per distinct call site, not once per consumed port.
+5. Value-type checking is per port.
+6. Specs that contain no port references compile byte-identically to today.
+
+## 5) Design
+
+### 5.1 Change the compiler's currency from `NodeId` to `PortRef`
+
+The single highest-leverage change. Introduce an internal alias in `graphBuilder.ts`:
+
+```ts
+type PortRef = { nodeId: string; portId?: string };
+```
+
+`portId` stays optional and `undefined` means "default port", so the emitted IR — and therefore the compiled `GraphSpec` — is unchanged for every existing expression. `convertIrEdgeToGraphEdge` already passes `undefined` through as an absent `output`.
+
+Mechanical steps:
+
+1. Change the return type of the nine helpers in section 3.3(a) from `string` to `PortRef`. Node-creating helpers return `{ nodeId }`; only new port-selecting code returns a populated `portId`.
+2. Change `materializeExpression`'s return type to `PortRef`.
+3. Change the 28 `from: { nodeId: x }` sites to `from: x`.
+4. Change `ExpressionBuildContext.nodeValueTypes` from `Map<string, ExpressionValueType>` to a map keyed by a `portKey(ref)` helper (`` `${nodeId}` `` when `portId` is undefined, `` `${nodeId}#${portId}` `` otherwise). Update `setNodeValueType`, `getNodeValueType`, `ensureOperandValueType` (`:617`, `:625`, `:645`) to take a `PortRef`.
+
+This step is a pure refactor with no behavior change and should land as its own commit, verified by the existing IR parity fixtures (`src/__tests__/irParity.test.ts`) staying green **without regeneration**. That is the acceptance gate for step 1: if the frozen fixtures move, the refactor was not behavior-preserving.
+
+### 5.2 Grammar: member access
+
+Add one AST node to `ControlExpressionNode`:
+
+```ts
+| { type: "Member"; object: ControlExpressionNode; port: string }
+```
+
+Parsing: add a postfix loop in the primary-expression parser that consumes `.` followed by an identifier, binding tighter than any unary or binary operator. Grammar is `postfix := primary ("." IDENT)*`.
+
+Constraints worth fixing now rather than discovering later:
+
+- The object of a `Member` must be a `Reference` or a `Function` call. `(a + b).x` is rejected at parse time with "Port access requires a control or function call." Allowing it on arbitrary expressions would imply structural field access on values, which is a different feature.
+- Chained access (`a.b.c`) is rejected in v1. Ports are flat.
+- `.` must not be consumed inside numeric literals. The literal scanner runs before the postfix loop, so `1.5` is unaffected, but add a regression test for `1.5.x` producing a clean parse error rather than a silent `1.5` followed by junk.
+
+`collectExpressionReferences` (`src/expression.ts:597`) must descend into `Member.object` so reference collection and the "unknown control" diagnostics keep working. `mapExpression` (`:624`) needs a `Member` arm.
+
+### 5.3 Variable and function resolution
+
+`ExpressionVariableTable` gains a port-aware resolve alongside the existing one:
+
+```ts
+resolvePort(name: string, port?: string): { ref: PortRef; valueType } | null;
+```
+
+`resolveNodeId` stays for callers that only need the node. Slot variables always expose exactly one port, so `resolvePort(name, "anything")` on a slot variable is an error: "Control `expr` has no port `x`."
+
+Port resolution rules when materializing `Member`:
+
+1. Look up the source signature (registry signature for a function call, variable metadata for a reference).
+2. If `port` names a declared `PortSpec` in `signature.outputs`, use it.
+3. Else if `variadic_outputs` is declared and `port` matches its `{id}_{n}` pattern, accept it and record the required arity.
+4. Else push the issue "Node type `split` has no output `foo`. Available: `part1`, `part2`." — listing the actual ports is the whole point; a bare "unknown port" is not actionable.
+
+Bare references keep working via a defaulting rule: no `portId` means the sole non-optional output. If a signature declares more than one non-optional output and the expression does not name a port, emit "Node type `multislider` produces multiple outputs; name one (`x`, `y`, `z`)." This is the only place where previously-valid input can become an error — see section 6.
+
+### 5.4 Function definitions carry all ports
+
+Replace `ScalarFunctionDefinition.resultValueType: ExpressionValueType` with:
+
+```ts
+outputs: { id: string; valueType: ExpressionValueType; optional: boolean }[];
+variadicOutputs?: { id: string; min: number; max: number | null; valueType: ExpressionValueType };
+defaultOutput?: string;  // resolved sole non-optional output, when unambiguous
+```
+
+Keep `resultValueType` as a deprecated getter returning `outputs[defaultOutputIndex].valueType` so the `if`/`case` special-casing at `expressionFunctions.ts:578-598` does not have to change in the same commit.
+
+Build these from the registry signature instead of truncating at `[0]`. `FUNCTION_OVERRIDES` gains an optional `replaceOutputs` for the same reason `replaceInputs` exists.
+
+### 5.5 Call-site sharing
+
+Once a call can produce several consumed ports, `solver(a, b).position + solver(a, b).rotation` must not instantiate the solver twice.
+
+Add a memo to `ExpressionBuildContext` keyed by a structural hash of `(functionName, materialized argument PortRefs, literal params)`. On hit, reuse the existing node id and vary only `portId`. This is scoped, cheap, and sufficient for the in-expression case.
+
+Cross-slot sharing (two different bindings calling the same solver) is explicitly **out of scope** here: each slot compiles in its own context, and unifying them means hoisting shared subtrees to graph scope with stable ids, which changes node identity across the whole spec and invalidates every IR fixture. Track it separately; it is a bigger change than this document.
+
+### 5.6 UI
+
+`apps/demo-graph-studio` needs no work for the canvas — `EditorCanvas.tsx:364` already renders per-output handles and `useEditorStore` already persists `sourceHandle`. Worth adding: label the handle with the port id when a node has more than one output, since today they are visually undifferentiated.
+
+`apps/vizij-authoring` is the real UI work, because its authoring surface is the expression text field, not a node canvas:
+
+1. Expression autocomplete must offer `.port` after a reference or call that has multiple outputs.
+2. `src/utils/bindingExpressions.ts` and the inspector's pipeline-stage display need to render port-qualified references without mangling them.
+3. Slot diagnostics (`src/components/binding/SlotDiagnosticsContext.tsx`) should surface the new "multiple outputs, name one" issue as a fixable hint rather than a generic parse error.
+
+### 5.7 The sink is still 1:1
+
+`Output` takes one `in` and writes one `TypedPath`. Reading two ports of a node into two animatables therefore still means two `output` nodes. That is correct and needs no change — but it is worth stating plainly, because "many-to-many" can be misheard as "one node writes several bindings," which this plan does not deliver and does not need to.
+
+## 6) Compatibility
+
+- Wire format: unchanged. `output_key` already defaults to `out`.
+- Existing expressions: unchanged, with one exception. A bare reference to a node type that declares multiple non-optional outputs currently silently resolves to the first port; under section 5.3 it becomes an error. In practice the only reachable such type today is `multislider`, which the expression vocabulary does not expose as a callable function, so the expected real-world impact is zero. Confirm with a repo-wide fixture sweep before landing, and if any authored graph is affected, ship the defaulting rule as a warning for one release before promoting it to an error.
+- IR fixtures: must not change in steps 1-2. They will change in step 3 only for expressions that use the new syntax.
+
+## 7) Work Breakdown
+
+| #   | Commit                                                 | Risk | Gate                                                   |
+| --- | ------------------------------------------------------ | ---- | ------------------------------------------------------ |
+| 1   | `PortRef` currency refactor in `graphBuilder.ts` (5.1) | low  | IR parity fixtures green **unregenerated**             |
+| 2   | Multi-output `ScalarFunctionDefinition` (5.4)          | low  | Function registry snapshot unchanged for existing fns  |
+| 3   | `Member` AST + parser + `collectExpressionReferences`  | med  | New parser tests incl. `1.5.x` and `(a+b).x` rejection |
+| 4   | Port resolution + diagnostics (5.3)                    | med  | Issue-text tests; unknown-port lists available ports   |
+| 5   | Call-site memoization (5.5)                            | med  | Double-port call emits one node, two edges             |
+| 6   | demo-graph-studio handle labels (5.6)                  | low  | Visual check                                           |
+| 7   | vizij-authoring autocomplete + diagnostics (5.6)       | med  | E2E: author `split(v).part2`, verify runtime write     |
+
+Steps 1 and 2 are independent and can land in either order. 3-5 are sequential. 6 and 7 depend on 4.
+
+## 8) Test Plan
+
+- **Parser**: member access precedence against unary/binary; rejection cases; numeric-literal interaction.
+- **Compiler**: `split(v).part2` emits `from.output === "part2"`; bare reference to single-output node still emits no `output` key; multi-output bare reference produces the expected issue string.
+- **Parity**: existing `irParity.test.ts` fixtures unchanged through step 5 except where the fixture itself uses new syntax.
+- **Sharing**: `f(x).a + f(x).b` emits exactly one `f` node.
+- **Runtime**: extend `packages/@vizij/node-graph-react/src/__tests__/urdf-fk-ik.test.tsx`, which already exercises `output_key: "position"`, with an authored-expression counterpart so the authoring path is covered by the same contract the hand-written spec already proves.
+- **E2E**: one authoring flow that binds two animatables to two ports of one node.
+
+## 9) Risks
+
+1. **Refactor blast radius.** Step 1 touches ~40 call sites in a 2858-line file. Mitigated by the unregenerated-fixture gate — it is a genuine behavioral no-op or it fails.
+2. **Silent default-port drift.** If a node type gains a second output in a future core release, previously-valid bare references start erroring. That is the correct behavior but it is a cross-repo coupling: adding an output port to an existing node type becomes a breaking authoring change. Note it in the core's release checklist.
+3. **Diagnostic quality.** Port errors surface in a text field with no canvas to point at. Budget real effort for the message text; a bad message here is worse than the missing feature.
+4. **Registry staleness.** `expressionFunctions.ts` derives everything from `requireNodeSignature`, a static global. That is fine for this plan and is the exact assumption the companion doc breaks — sequence accordingly.
+
+## 10) Out of Scope
+
+- User-defined node types (companion doc).
+- Cross-slot common-subexpression elimination.
+- Multi-path sinks.
+- Port-level topological scheduling (see companion doc section 4.7).
+- Structural field access on values (`transform.translation` as a value operation rather than a port).

--- a/packages/@vizij/node-graph-authoring/docs/multi-output-ports-authoring-plan-2026-07-30.md
+++ b/packages/@vizij/node-graph-authoring/docs/multi-output-ports-authoring-plan-2026-07-30.md
@@ -222,7 +222,7 @@ Steps 1 and 2 are independent and can land in either order. 3-5 are sequential. 
 
 ## 10) Out of Scope
 
-- User-defined node types (companion doc).
+- User-defined node types (companion doc; its section 4.8 specifies how the two compose, including the one rule — default-port resolution — that both plans implement and must keep in agreement).
 - Cross-slot common-subexpression elimination.
 - Multi-path sinks.
 - Port-level topological scheduling (see companion doc section 4.7).

--- a/packages/@vizij/node-graph-authoring/docs/subgraph-function-node-design-2026-07-30.md
+++ b/packages/@vizij/node-graph-authoring/docs/subgraph-function-node-design-2026-07-30.md
@@ -1,0 +1,241 @@
+# Subgraph / Function Nodes: User-Definable Many-to-Many Blocks
+
+Last updated: 2026-07-30
+Owner: Vizij Graph / Authoring
+Status: draft design document (current-state + target-state)
+Scope: `vizij-rs/crates/node-graph/*` primarily; `@vizij/node-graph-authoring`, `@vizij/node-graph-react`, `apps/demo-graph-studio` secondarily
+Companion doc: `multi-output-ports-authoring-plan-2026-07-30.md`
+
+## 1) Goal
+
+Let a graph author define a reusable block that takes several inputs and produces several named outputs, without adding a Rust variant for each one.
+
+This is the feature people usually mean by "make the low-level building block many-to-many." The arity is not the blocker — the core is already many-in / many-out (see companion doc section 3.1). The blocker is that the vocabulary is closed.
+
+## 2) Verification Basis
+
+Same caveat as the companion doc: the `vizij-rs` checkout consulted is behind the published `@vizij/node-graph@0.7.0` that this repo builds against, so Rust line references are indicative. The structural facts this design turns on — closed `NodeType` enum, receiverless schema export, flat node-id addressing, node-keyed runtime state — are all visible in the wasm surface that 0.7.0 exposes and are cross-checked against the TypeScript shim in `packages/@vizij/node-graph-authoring/src/metadata-shim.d.ts`.
+
+**This document specifies work that lands mostly in `vizij-rs`.** It lives here because the authoring compiler is the primary consumer and because the metadata contract it breaks is consumed from this package.
+
+## 3) Current State: What Blocks It
+
+### 3.1 The node vocabulary is a closed Rust enum
+
+`NodeType` in `vizij-graph-core/src/types.rs` is a fixed enum with ~50 variants, matched exhaustively in `eval_node`. Adding a node means editing Rust, rebuilding wasm, and republishing `@vizij/node-graph`. There is no mechanism — none — for defining a node from TypeScript, from a spec file, or at runtime.
+
+### 3.2 The schema registry is a receiverless global
+
+```rust
+#[wasm_bindgen]
+pub fn get_node_schemas_json() -> String {
+    let reg = vizij_graph_core::registry();
+    ...
+}
+```
+
+No graph handle, no instance. The TypeScript shim mirrors this: `getNodeRegistry()`, `requireNodeSignature(typeId)`, `listNodeTypeIds()` — all global lookups by type id. `expressionFunctions.ts` builds its entire function table from this at module scope.
+
+Any design where node signatures depend on the loaded graph breaks this contract. That is the single largest ripple in this document, and it is worth stating up front rather than discovering during implementation.
+
+### 3.3 Node identity is flat and global
+
+- `set_param(node_id, key, json)` addresses nodes by bare id.
+- `GraphRuntime.outputs: HashMap<NodeId, HashMap<String, PortValue>>` is a flat map.
+- `GraphRuntime.node_states: HashMap<NodeId, NodeRuntimeState>` holds spring/damp/slew accumulators, keyed by node id and retained across evaluations via `node_states.retain(...)` in `evaluate_all`.
+
+Two instances of the same reusable block therefore cannot share inner node ids without sharing — and corrupting — each other's transition state.
+
+### 3.4 There is no grouping or macro concept anywhere
+
+Confirmed by search across `vizij-rs/crates` and `vizij-web`: no subgraph, macro, group, or graph-reference node type exists in any form.
+
+### 3.5 Two more facts that shape the design
+
+`evaluate_all` looks up each node with `spec.nodes.iter().find(|n| n.id == id)` inside the topo loop — O(n²) in node count, every frame.
+
+`eval_all` serializes **every** node's **every** port to JSON on **every** frame, and passes the whole payload across the wasm boundary. Node count is not free at either end.
+
+Both matter because the leading implementation option multiplies node count.
+
+## 4) Design
+
+### 4.1 Spec surface: a function table
+
+Extend `GraphSpec` with a named function table. This is the contract; the evaluator behind it is swappable.
+
+```jsonc
+{
+  "functions": {
+    "polar_to_cart": {
+      "inputs": [
+        { "id": "r", "ty": "Float" },
+        { "id": "theta", "ty": "Float" },
+      ],
+      "outputs": [
+        { "id": "x", "ty": "Float" },
+        { "id": "y", "ty": "Float" },
+      ],
+      "body": {
+        "nodes": [
+          {
+            "id": "cos",
+            "type": "cos",
+            "inputs": { "in": { "node_id": "$in.theta" } },
+          },
+          {
+            "id": "x",
+            "type": "multiply",
+            "inputs": {
+              "operand_1": { "node_id": "$in.r" },
+              "operand_2": { "node_id": "cos" },
+            },
+          },
+          // ...
+        ],
+        "returns": { "x": { "node_id": "x" }, "y": { "node_id": "y" } },
+      },
+    },
+  },
+  "nodes": [
+    {
+      "id": "p1",
+      "type": "call",
+      "params": { "function": "polar_to_cart" },
+      "inputs": {
+        "r": { "node_id": "radius" },
+        "theta": { "node_id": "angle" },
+      },
+    },
+  ],
+}
+```
+
+Design commitments:
+
+- **One new `NodeType` variant: `Call`.** The enum stays closed; it gains exactly one variant, and that variant is the extension point. This is the whole trick.
+- Inner references to `$in.<port>` bind to the call site's inputs. `returns` maps declared output ports to inner nodes (optionally inner ports, once the companion doc lands).
+- `functions` is a sibling of `nodes`, not nested inside a node, so a definition can be reused by many call sites and serialized once.
+- Function definitions may reference other functions. Recursion is rejected at load (section 4.5).
+
+### 4.2 Evaluation: inline at load, not nested at runtime
+
+Two options were considered.
+
+**Option A — inline expansion at load.** `load_graph` expands every `call` node into a copy of the function body with namespaced ids (`p1/cos`, `p1/x`), rewriting `$in.*` references to the call site's actual sources and rewriting consumers of `p1.<port>` to the mapped inner node. The runtime, `topo_order`, `eval_node`, and the wasm surface are untouched.
+
+**Option B — nested runtime.** `Call` evaluates a child `GraphRuntime` recursively.
+
+**Recommendation: Option A for v1.**
+
+|                        | Option A (inline)                        | Option B (nested)                                        |
+| ---------------------- | ---------------------------------------- | -------------------------------------------------------- |
+| Core evaluator changes | none                                     | recursive eval, child state ownership, error propagation |
+| `topo_order` changes   | none                                     | must handle nesting                                      |
+| Transition state       | works via id namespacing                 | needs per-instance child state trees                     |
+| Debuggability          | inner nodes visible in `eval_all` output | inner nodes invisible without new API                    |
+| Node count             | multiplied per instance                  | flat                                                     |
+| Per-frame JSON payload | multiplied per instance                  | flat                                                     |
+| Dynamic recursion      | impossible                               | possible                                                 |
+
+Option A's costs are real and land exactly on the two hot spots in section 3.5: the O(n²) topo lookup and the per-frame full-outputs serialization. Both should be addressed as prerequisites, not deferred — fix the lookup with a `HashMap<NodeId, &NodeSpec>` index built once per `evaluate_all`, and add an opt-in filter to `eval_all` so tooling can request only the ports it renders. Those are worthwhile independent of this feature.
+
+Option A's benefit is that it makes the feature almost entirely a _load-time_ concern in one function, which is a far smaller correctness surface than a recursive evaluator. Keep the spec surface in 4.1 identical either way so the evaluator can be swapped later without a format migration.
+
+### 4.3 Instancing and stable identity
+
+Namespaced ids must be **stable across recompiles**, because `node_states.retain` uses them to preserve spring/damp/slew accumulators. If ids churn, every transition node inside a function silently resets on every graph rebuild — a bug that will present as intermittent visual popping and will be miserable to trace back here.
+
+Rule: inner id = `{callNodeId}/{innerNodeId}`. Call node ids are already stable in authored specs. Reject `/` in author-supplied node ids at load so the namespace is unambiguous.
+
+`set_param` then addresses inner nodes as `p1/cos`. Whether per-instance param overrides are exposed in the UI is a separate product question; the addressing works either way.
+
+### 4.4 Metadata: static registry to instance-level signatures
+
+This is the ripple flagged in 3.2, and the part most likely to be underestimated.
+
+`getNodeRegistry()` / `requireNodeSignature(typeId)` cannot describe a `call` node, because its ports depend on which function it targets in which graph.
+
+Proposed contract change:
+
+1. Keep the global registry for built-in types. Unchanged, no breakage.
+2. Add `getGraphSignatures(spec)` returning per-node resolved signatures for a given spec, where `call` nodes resolve against `spec.functions`.
+3. In `expressionFunctions.ts`, the module-scope `SCALAR_FUNCTIONS` table stays as the built-in vocabulary; graph-local functions become a second, spec-scoped lookup consulted after it. Do not merge them into one global table — that reintroduces the same coupling and makes the vocabulary depend on load order.
+4. `apps/demo-graph-studio`'s `NodePalette` and `EditorCanvas` read port lists from the resolved signatures rather than `schema.outputs` directly. `EditorCanvas.tsx:148` (`outputs: schema.outputs ?? []`) is the seam.
+
+### 4.5 Load-time validation
+
+`load_graph` must reject, with actionable messages:
+
+1. `call` referencing an unknown function name.
+2. Recursive or mutually recursive function references (cycle-detect over the function reference graph before expansion — otherwise inlining does not terminate).
+3. `$in.<port>` referencing an undeclared input port.
+4. `returns` omitting a declared output port, or naming an unknown inner node.
+5. Author-supplied node ids containing `/`.
+6. Expansion exceeding a configured node-count ceiling — a nested function used ten times inside another used ten times is 100 instances, and the failure mode without a ceiling is a hang, not an error.
+
+### 4.6 Authoring surface
+
+Deliberately deferred. This document specifies the substrate. How a user _creates_ a function — select-nodes-and-collapse in demo-graph-studio, a named expression in vizij-authoring, or a file-level library — is a product decision that should be made after the substrate exists and can be prototyped against. Shipping the substrate with a JSON-only authoring path is a legitimate first milestone.
+
+### 4.7 The port-level topology question
+
+Node-granular scheduling means a node's ports all become available at once. So you cannot have output `A` of a call feed a chain that eventually feeds input `2` of that same call — it is a cycle at node granularity, even though it may be acyclic at port granularity.
+
+This constrains genuine many-to-many solvers with partial feedback, which is a plausible motivation for wanting this feature in the first place.
+
+**Decision for v1: keep node-granular scheduling and reject those graphs with a clear cycle error.** Port-level topology is a substantially larger change (edge-granular dependency graph, partial node evaluation, revised `eval_node` contract) and it should not ride along with this one. If a concrete use case demands it, it gets its own document.
+
+Flag it early to users, because "why can't I wire this back in" is otherwise an opaque failure.
+
+## 5) Alternatives Considered
+
+**Expression-only macros in the authoring layer.** Textual substitution in `@vizij/node-graph-authoring`, no core change. Cheap, and genuinely worth considering if the only motivation is reuse. Rejected as the primary design: it cannot produce multiple outputs from one evaluation, it duplicates work per use site, and it is invisible to demo-graph-studio and to any non-vizij-web consumer of the core.
+
+**A scripting node (WASM/Rhai/Lua body).** Maximum expressiveness, but it introduces a sandboxing and determinism problem, a second language surface to document and version, and a much harder story for the metadata registry. Not warranted by the current motivation.
+
+**One Rust variant per new function.** The status quo. Fine for genuinely primitive operations; it is precisely what does not scale to user-defined blocks.
+
+## 6) Work Breakdown
+
+Roughly ordered; items 1-2 are prerequisites that stand on their own merit.
+
+| #   | Change                                                     | Repo      | Risk |
+| --- | ---------------------------------------------------------- | --------- | ---- |
+| 1   | `HashMap` node index in `evaluate_all` (drop O(n²) lookup) | vizij-rs  | low  |
+| 2   | Opt-in port filter for `eval_all`'s per-frame JSON payload | vizij-rs  | low  |
+| 3   | `functions` table in `GraphSpec` + serde + normalization   | vizij-rs  | med  |
+| 4   | `NodeType::Call` variant                                   | vizij-rs  | low  |
+| 5   | Load-time inline expansion with id namespacing             | vizij-rs  | high |
+| 6   | Load-time validation and cycle detection (4.5)             | vizij-rs  | med  |
+| 7   | `getGraphSignatures(spec)` + wasm export                   | vizij-rs  | med  |
+| 8   | Spec-scoped function lookup in `expressionFunctions.ts`    | vizij-web | med  |
+| 9   | demo-graph-studio palette/canvas read resolved signatures  | vizij-web | med  |
+| 10  | Authoring UX for defining a function                       | vizij-web | TBD  |
+
+Items 1-2 can land immediately and independently. 10 is deliberately unspecified per 4.6.
+
+## 7) Test Plan
+
+- **Expansion**: a two-instance function produces disjoint namespaced ids and identical topology per instance.
+- **State isolation**: two instances of a function containing a `spring` converge independently from different initial conditions.
+- **State persistence**: recompiling an unchanged graph preserves spring state (guards the 4.3 stability rule — this is the regression that would otherwise ship silently).
+- **Validation**: each of the six rejections in 4.5 has a test asserting the message, not just the failure.
+- **Cycle**: a feedback wiring that is port-acyclic but node-cyclic is rejected with the 4.7 error, not a hang or a wrong result.
+- **Metadata**: `getGraphSignatures` resolves `call` ports; the global registry is unchanged for built-ins.
+- **Parity**: a graph authored as a function and the same graph authored inline produce identical writes over 600 frames.
+
+## 8) Risks and Open Questions
+
+1. **Node-count blowup.** Nested reuse multiplies instances, and both the topo loop and the per-frame JSON payload scale with node count. Items 1-2 are prerequisites, not nice-to-haves. Enforce the ceiling from 4.5(6).
+2. **Transition-state identity.** Highest-severity correctness risk. See 4.3 and its dedicated test.
+3. **Metadata contract change.** Touches every consumer of `@vizij/node-graph/metadata`. Additive if `getGraphSignatures` is a new export and the global registry keeps working for built-ins — hold that line.
+4. **Cross-repo sequencing.** Items 3-7 must ship in a published `@vizij/node-graph` before 8-9 can land. Coordinate with the release flow in `scripts/` and the `wasm:link` local-dev path.
+5. **Open: are functions graph-local or a shared library?** This document assumes graph-local (`spec.functions`), which is self-contained and serializes cleanly. A cross-graph library needs a resolution and versioning story and should not be designed speculatively.
+6. **Open: per-instance param overrides.** Addressing works (4.3); whether it is exposed, and how it serializes, is unresolved.
+
+## 9) Relationship to the Companion Doc
+
+The multi-output authoring plan is independent and strictly smaller. It can and should land first: it is confined to vizij-web, it delivers immediate value against existing multi-output node types, and it establishes the port-ref plumbing in the compiler that a `call` node's multiple outputs will need anyway.
+
+This document depends on that plumbing existing. It does not depend on it landing first in wall-clock terms, but implementing this one first would mean building the same `PortRef` refactor under more pressure.

--- a/packages/@vizij/node-graph-authoring/docs/subgraph-function-node-design-2026-07-30.md
+++ b/packages/@vizij/node-graph-authoring/docs/subgraph-function-node-design-2026-07-30.md
@@ -93,7 +93,11 @@ Extend `GraphSpec` with a named function table. This is the contract; the evalua
           },
           // ...
         ],
-        "returns": { "x": { "node_id": "x" }, "y": { "node_id": "y" } },
+        // `output` is optional and defaults to the inner node's default port.
+        "returns": {
+          "x": { "node_id": "x" },
+          "y": { "node_id": "y", "output": "out" },
+        },
       },
     },
   },
@@ -114,7 +118,7 @@ Extend `GraphSpec` with a named function table. This is the contract; the evalua
 Design commitments:
 
 - **One new `NodeType` variant: `Call`.** The enum stays closed; it gains exactly one variant, and that variant is the extension point. This is the whole trick.
-- Inner references to `$in.<port>` bind to the call site's inputs. `returns` maps declared output ports to inner nodes (optionally inner ports, once the companion doc lands).
+- Inner references to `$in.<port>` bind to the call site's inputs. `returns` maps each declared output port to an inner **port ref** — `{ node_id, output? }`, where an absent `output` means the inner node's default port. This does **not** depend on the companion doc: `output_key` already exists in the wire format today, and without it a function wrapping a `split` could not expose `part2`, which is exactly the many-to-many case this feature is for.
 - `functions` is a sibling of `nodes`, not nested inside a node, so a definition can be reused by many call sites and serialized once.
 - Function definitions may reference other functions. Recursion is rejected at load (section 4.5).
 
@@ -122,7 +126,7 @@ Design commitments:
 
 Two options were considered.
 
-**Option A — inline expansion at load.** `load_graph` expands every `call` node into a copy of the function body with namespaced ids (`p1/cos`, `p1/x`), rewriting `$in.*` references to the call site's actual sources and rewriting consumers of `p1.<port>` to the mapped inner node. The runtime, `topo_order`, `eval_node`, and the wasm surface are untouched.
+**Option A — inline expansion at load.** `load_graph` expands every `call` node into a copy of the function body with namespaced ids (`p1/cos`, `p1/x`), rewriting `$in.*` references to the call site's actual sources and rewriting each consumer of `p1` to the port ref that `returns` designates. Note that the rewrite target is a `(node_id, output_key)` **pair**, not a node: a consumer reading `{ node_id: "p1", output_key: "y" }` where `returns.y` is `{ node_id: "s", output: "part2" }` becomes `{ node_id: "p1/s", output_key: "part2" }`. Consumers that name no `output_key` resolve against the function's sole non-optional declared output, mirroring the defaulting rule in companion doc section 5.3. The runtime, `topo_order`, `eval_node`, and the wasm surface are untouched.
 
 **Option B — nested runtime.** `Call` evaluates a child `GraphRuntime` recursively.
 
@@ -170,9 +174,10 @@ Proposed contract change:
 1. `call` referencing an unknown function name.
 2. Recursive or mutually recursive function references (cycle-detect over the function reference graph before expansion — otherwise inlining does not terminate).
 3. `$in.<port>` referencing an undeclared input port.
-4. `returns` omitting a declared output port, or naming an unknown inner node.
-5. Author-supplied node ids containing `/`.
-6. Expansion exceeding a configured node-count ceiling — a nested function used ten times inside another used ten times is 100 instances, and the failure mode without a ceiling is a hang, not an error.
+4. `returns` omitting a declared output port, naming an unknown inner node, or naming an `output` that the inner node's signature does not declare.
+5. A `returns` port ref whose resolved inner port type contradicts the declared output `ty`.
+6. Author-supplied node ids containing `/`.
+7. Expansion exceeding a configured node-count ceiling — a nested function used ten times inside another used ten times is 100 instances, and the failure mode without a ceiling is a hang, not an error.
 
 ### 4.6 Authoring surface
 
@@ -187,6 +192,26 @@ This constrains genuine many-to-many solvers with partial feedback, which is a p
 **Decision for v1: keep node-granular scheduling and reject those graphs with a clear cycle error.** Port-level topology is a substantially larger change (edge-granular dependency graph, partial node evaluation, revised `eval_node` contract) and it should not ride along with this one. If a concrete use case demands it, it gets its own document.
 
 Flag it early to users, because "why can't I wire this back in" is otherwise an opaque failure.
+
+### 4.8 Integration with the multi-output ports plan
+
+The end state both documents serve is one sentence: an author defines a many-in / many-out block and calls it from an expression, naming the port they want.
+
+```text
+polar_to_cart(radius, angle).x
+```
+
+The companion doc delivers the `.x`. This doc delivers the `polar_to_cart`. Four joins belong to neither document alone and are specified here because this is the dependent one.
+
+**Join 1 — materializing a `call` from an expression.** `emitScalarFunctionNode` maps positional arguments to declared input ports in signature order. A `call` needs the same treatment against `spec.functions[name].inputs`. Two rules to fix now: arity mismatch is an error (user-defined functions have no optional-input concept in v1), and user-defined functions have **no params**, only inputs — so the literal-param machinery in `buildParamAssignments` must not be wired in speculatively. Adding params later is additive; unwinding a speculative implementation is not.
+
+**Join 2 — two dedup layers, and they compose in one order only.** The companion doc memoizes call sites within an expression context (§5.5, TypeScript, compile time). This doc expands each surviving `call` inline (Rust, load time). A memoized `f(x).a + f(x).b` yields one `call` node, which yields one inlined body — correct, but only because the memo runs first. Do not add a second dedup pass at load. Two independent dedup mechanisms over the same identity are a source of id churn, and id churn is precisely what section 4.3 forbids.
+
+**Join 3 — the default-port rule is implemented twice, in two languages.** Companion doc §5.3 resolves a bare reference to the sole non-optional output. Section 4.2 above applies the same rule when rewriting a consumer that names no `output_key`. If the two implementations disagree, a graph authored through expressions and the same graph authored as raw JSON diverge — silently, and only for nodes with multiple outputs. Write the rule once in prose, cite it from both call sites, and cover it with the authored-vs-inline parity test in section 7.
+
+**Join 4 — diagnostics cross a boundary the author never sees.** A type error inside an inlined body reports against `p1/cos`, an id that appears in no document the author wrote. Load-time errors must render provenance: `function "polar_to_cart", node "cos" (called from "p1")`. This is the most likely place for the feature to feel bad in practice, and it is cheap if expansion carries provenance from the start. Retrofitting it means threading it back through every validation path in section 4.5.
+
+Sequencing note: none of these require the companion doc to have landed first. They require the two to agree on join 3.
 
 ## 5) Alternatives Considered
 
@@ -220,14 +245,14 @@ Items 1-2 can land immediately and independently. 10 is deliberately unspecified
 - **Expansion**: a two-instance function produces disjoint namespaced ids and identical topology per instance.
 - **State isolation**: two instances of a function containing a `spring` converge independently from different initial conditions.
 - **State persistence**: recompiling an unchanged graph preserves spring state (guards the 4.3 stability rule — this is the regression that would otherwise ship silently).
-- **Validation**: each of the six rejections in 4.5 has a test asserting the message, not just the failure.
+- **Validation**: each of the seven rejections in 4.5 has a test asserting the message, not just the failure.
 - **Cycle**: a feedback wiring that is port-acyclic but node-cyclic is rejected with the 4.7 error, not a hang or a wrong result.
 - **Metadata**: `getGraphSignatures` resolves `call` ports; the global registry is unchanged for built-ins.
 - **Parity**: a graph authored as a function and the same graph authored inline produce identical writes over 600 frames.
 
 ## 8) Risks and Open Questions
 
-1. **Node-count blowup.** Nested reuse multiplies instances, and both the topo loop and the per-frame JSON payload scale with node count. Items 1-2 are prerequisites, not nice-to-haves. Enforce the ceiling from 4.5(6).
+1. **Node-count blowup.** Nested reuse multiplies instances, and both the topo loop and the per-frame JSON payload scale with node count. Items 1-2 are prerequisites, not nice-to-haves. Enforce the ceiling from 4.5(7).
 2. **Transition-state identity.** Highest-severity correctness risk. See 4.3 and its dedicated test.
 3. **Metadata contract change.** Touches every consumer of `@vizij/node-graph/metadata`. Additive if `getGraphSignatures` is a new export and the global registry keeps working for built-ins — hold that line.
 4. **Cross-repo sequencing.** Items 3-7 must ship in a published `@vizij/node-graph` before 8-9 can land. Coordinate with the release flow in `scripts/` and the `wasm:link` local-dev path.


### PR DESCRIPTION
## Why

The recurring assumption is that a graph node is a many-inputs → **one** value function. It isn't. `eval_node` produces a per-node map of named output ports, edges are port-addressed via `output_key` (defaulting to `out`), `NodeSignature` declares `outputs: Vec<PortSpec>` plus `variadic_outputs`, and `MultiSlider` / `Split` already use it. The IR (`IrPortRef.portId`), the demo-graph-studio canvas (one `Handle` per output), and `useNodeOutput(nodeId, outputKey)` are all port-aware today.

The single-output behavior everyone observes lives in the authoring compiler in `@vizij/node-graph-authoring`:

- `materializeExpression` and its nine helpers return a bare node id, so all 28 `from: { nodeId }` edge emissions omit `portId`.
- `expressionFunctions.ts:574` truncates every signature at `outputs[0]`.
- The expression grammar has no member-access production, and `resolveNodeId` has no port component.

Two docs split the follow-on work into the two genuinely different pieces it is.

## What's here

Docs only — no code changes.

- `docs/multi-output-ports-authoring-plan-2026-07-30.md` — thread a `PortRef` through the expression compiler, add `.port` member access to the grammar, resolve ports against registry signatures, memoize call sites so a two-port call emits one node. Confined to vizij-web. Sequenced as seven commit-sized steps, with the refactor step gated on the existing IR parity fixtures staying green **without regeneration**.
- `docs/subgraph-function-node-design-2026-07-30.md` — a graph-local `functions` table plus exactly one new `NodeType::Call`, expanded inline at load with namespaced ids. Lands mostly in `vizij-rs`. Covers the two things most likely to be underestimated: transition-state identity (`node_states` is keyed by node id and retained across evals, so namespaced ids must be stable across recompiles or springs silently reset), and the static-registry break in `@vizij/node-graph/metadata`.
- `docs/README.md` — index, plus the background note above so the next person doesn't re-derive it.
- Pointer to `docs/` from the package README.

## How the two compose

Rather than a third document, subgraph §4.8 pins the joins. The end state is one line — `polar_to_cart(radius, angle).x`, where the first doc delivers the `.x` and the second delivers the function. Four things belong to neither plan alone:

1. Materializing a `call` from an expression (positional args → declared input ports; user functions have inputs but **no** params in v1, so `buildParamAssignments` must not be wired in speculatively).
2. Dedup ordering — the TS call-site memo must run before Rust load-time inlining, and there must not be a second dedup pass at load, because id churn breaks transition-state identity.
3. **Default-port resolution is implemented twice, in two languages.** If the TS and Rust rules disagree, a graph authored via expressions and the same graph authored as raw JSON diverge silently, and only for multi-output nodes. Covered by an authored-vs-inline parity test.
4. Error provenance for inlined inner nodes — a failure at `p1/cos` must render as `function "polar_to_cart", node "cos" (called from "p1")`.

Writing that section surfaced two real bugs in the original subgraph draft, now fixed: `returns` mapped to bare node ids (so a function wrapping a `split` couldn't expose `part2` — the exact case the feature exists for), and the inline rewrite target was described as a node rather than a `(node_id, output_key)` pair.

## Recommendation

Land the multi-output plan first. It's smaller, it's vizij-web-only, it delivers value against node types that already exist, and it builds the `PortRef` plumbing the `call` node would need anyway.

## Notes / caveats

- The `vizij-rs` checkout consulted is **behind** the published `@vizij/node-graph@0.7.0` this repo builds against (it lacks `case`), so Rust line references are indicative. Every core invariant either doc depends on is cross-checked from the TypeScript side, which is pinned to 0.7.0 — see section 2 and 3.2 of each doc.
- One decision worth reviewer attention: subgraph §4.7 keeps node-granular scheduling for v1, which means a call whose output feeds back into its own input is rejected as a cycle even when it's port-acyclic. That constrains solvers with partial feedback. Port-level topology is deliberately deferred to its own document.
- Subgraph §4.6 deliberately does **not** specify how a user creates a function. That's a product decision better made against a working substrate.

Verified: `markdownlint` and `prettier` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
