### PR TITLE
feat(authoring): profile JSON round-trip — export canonical, replace, deploy-verified (VIZ-93)

### DIFF
--- a/.changeset/runtime-react-runtime-22.md
+++ b/.changeset/runtime-react-runtime-22.md
@@ -2,4 +2,4 @@
 "@vizij/runtime-react": patch
 ---
 
-Require `@vizij/runtime` ^2.2.0 — the release that ships the standard-profile registry (`standardProfiles()` / `standardProfile(id, rigPrefix)`) — so one runtime version serves both the preview provider and the authoring app's profile picker.
+Require `@vizij/runtime` ^2.3.0 — the releases that ship the standard-profile registry (`standardProfiles()` / `standardProfile(id, rigPrefix)`) and `composeFace()` — so one runtime version serves the preview provider, the authoring app's profile picker, and the deploy-and-verify test loop.

--- a/apps/vizij-authoring/e2e/profile-edition.workflow.pw.ts
+++ b/apps/vizij-authoring/e2e/profile-edition.workflow.pw.ts
@@ -1,0 +1,128 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { composeFace, startRuntime } from "@vizij/runtime";
+import { bootAuthoring, expectDownload, loadMainPreset } from "./helpers";
+import {
+  closeMenus,
+  exportGlb,
+  glbJson,
+  openStandardProfilesSubmenu,
+  toggleRos4hriProfile,
+} from "./profile-helpers";
+
+// The full VIZ-93 loop, autonomously: import the profile, export it as
+// canonical JSON, edit that JSON (as a human contributor would), replace the
+// embedded copy from it, export the GLB — and deploy that GLB on the wasm
+// runtime to verify the edited mapping actually drives the face.
+test("profile JSON round-trip: export, edit, replace, deploy @workflow", async ({
+  page,
+}) => {
+  page.on("console", (message) => {
+    if (message.type() === "error") {
+      console.log(`[browser:error]`, message.text());
+    }
+  });
+  await bootAuthoring(page);
+  await loadMainPreset(page, "quori:latest");
+  await toggleRos4hriProfile(page);
+
+  // Export as JSON: the canonical, face-independent form — the full built-in
+  // graph with the rig prefix stripped back out of the written paths.
+  await openStandardProfilesSubmenu(page);
+  const jsonDownload = await expectDownload(page, async () => {
+    await page
+      .getByTestId("app-menu-file-standard-profile-export-ros4hri")
+      .click();
+  });
+  await closeMenus(page);
+  const canonical = JSON.parse(
+    await readFile((await jsonDownload.path())!, "utf8"),
+  ) as { nodes: { type?: string; params?: { path?: string } }[]; edges: [] };
+  expect(canonical.nodes.length).toBeGreaterThan(100);
+  expect(canonical.edges.length).toBeGreaterThan(100);
+  const outputs = canonical.nodes.filter((node) => node.type === "output");
+  expect(outputs.length).toBeGreaterThan(0);
+  for (const node of outputs) {
+    expect(
+      node.params?.path?.startsWith("rig/"),
+      `unprefixed output path, got ${node.params?.path}`,
+    ).toBeFalsy();
+  }
+
+  // "Edit" the JSON as a contributor would — here down to a minimal mapping
+  // the built-in never produces: valence rides verbatim onto happy.
+  const edited = {
+    nodes: [
+      {
+        id: "v",
+        type: "input",
+        params: { path: "standard/ros4hri/expression/valence", value: 0.0 },
+      },
+      {
+        id: "o",
+        type: "output",
+        params: { path: "standard/vizij/expression/happy" },
+      },
+    ],
+    edges: [{ from: { node_id: "v" }, to: { node_id: "o", input: "in" } }],
+  };
+  const editedDir = await mkdtemp(path.join(tmpdir(), "vizij-profile-"));
+  const editedPath = path.join(editedDir, "ros4hri.json");
+  await writeFile(editedPath, JSON.stringify(edited));
+
+  // Replace the embedded copy from the edited JSON via the real picker flow.
+  await openStandardProfilesSubmenu(page);
+  const chooserPromise = page.waitForEvent("filechooser");
+  await page
+    .getByTestId("app-menu-file-standard-profile-replace-ros4hri")
+    .click();
+  const chooser = await chooserPromise;
+  await chooser.setFiles(editedPath);
+  await closeMenus(page);
+
+  // The exported GLB carries the edited copy, rig-prefixed on the way in.
+  const glbDownload = await exportGlb(page);
+  const gltf = glbJson(await readFile((await glbDownload.path())!));
+  type WithExtensions = {
+    extensions?: {
+      VIZIJ_bundle?: {
+        graphs?: { id?: string; spec?: typeof edited }[];
+        metadata?: { faceId?: string };
+      };
+    };
+  };
+  const bundle = ((gltf.nodes ?? []) as WithExtensions[])
+    .map((node) => node.extensions?.VIZIJ_bundle)
+    .find(Boolean);
+  const faceId = bundle?.metadata?.faceId;
+  expect(faceId, "the exported bundle names its face").toBeTruthy();
+  const embedded = bundle?.graphs?.find(
+    (graph) => graph.id === "standard::ros4hri",
+  );
+  expect(embedded?.spec?.nodes.length).toBe(2);
+  expect(embedded?.spec?.nodes[1]?.params?.path).toBe(
+    `rig/${faceId}/standard/vizij/expression/happy`,
+  );
+
+  // Deploy the authored GLB on the wasm runtime: composeFace applies the
+  // embedded-overrides-built-in precedence, and the edited mapping drives
+  // the face — the built-in would have one-hotted "sad" (happy ≈ 0).
+  const spec = (await composeFace(gltf, { program: "none" })) as object;
+  const runtime = await startRuntime();
+  await runtime.loadGraph(spec);
+  runtime.setValue("standard/ros4hri/expression/name", { text: "sad" });
+  runtime.setValue("standard/ros4hri/expression/valence", { f32: 0.8 });
+  for (let i = 0; i < 5; i += 1) {
+    runtime.step(16);
+  }
+  const happyPath = `rig/${faceId}/standard/vizij/expression/happy`;
+  const happy = runtime.readValues([happyPath])[happyPath] as {
+    f32?: number;
+  } | null;
+  expect(
+    happy && Math.abs((happy.f32 ?? 0) - 0.8) < 1e-6,
+    `edited mapping deployed, got ${JSON.stringify(happy)}`,
+  ).toBeTruthy();
+});

--- a/apps/vizij-authoring/e2e/profile-helpers.ts
+++ b/apps/vizij-authoring/e2e/profile-helpers.ts
@@ -1,0 +1,89 @@
+import { readFile } from "node:fs/promises";
+import { expect } from "@playwright/test";
+import type { Download, Page } from "@playwright/test";
+import { expectDownload, openExportDialog } from "./helpers";
+
+/** The parsed JSON chunk of a GLB (12-byte header, chunk 0 is JSON). */
+export function glbJson(buffer: Buffer): Record<string, unknown> {
+  expect(buffer.readUInt32LE(0)).toBe(0x46546c67); // "glTF"
+  const jsonLength = buffer.readUInt32LE(12);
+  expect(buffer.readUInt32LE(16)).toBe(0x4e4f534a); // "JSON"
+  return JSON.parse(
+    buffer.subarray(20, 20 + jsonLength).toString("utf8"),
+  ) as Record<string, unknown>;
+}
+
+export interface BundleGraphEntry {
+  id?: string;
+  kind?: string;
+  spec?: { nodes?: { type?: string; params?: { path?: string } }[] };
+}
+
+/** The `VIZIJ_bundle.graphs` of a GLB document (root or node extension). */
+export function bundleGraphs(
+  gltf: Record<string, unknown>,
+): BundleGraphEntry[] {
+  type WithExtensions = { extensions?: { VIZIJ_bundle?: { graphs?: [] } } };
+  const root = gltf as WithExtensions;
+  const nodes = (gltf.nodes ?? []) as WithExtensions[];
+  const bundle =
+    root.extensions?.VIZIJ_bundle ??
+    nodes.map((node) => node.extensions?.VIZIJ_bundle).find(Boolean);
+  expect(bundle, "the exported GLB carries a VIZIJ_bundle").toBeTruthy();
+  return bundle?.graphs ?? [];
+}
+
+/** Open File > Standard Profiles so its per-profile items are visible. */
+export async function openStandardProfilesSubmenu(page: Page): Promise<void> {
+  // Park the pointer first: the submenu opens on hover, and a pointer already
+  // resting on the trigger's coordinates produces no enter event.
+  await page.mouse.move(5, 5);
+  await page.getByTestId("app-menu-file").click();
+  await page.getByTestId("app-menu-file-standard-profiles").hover();
+  const item = page.getByTestId("app-menu-file-standard-profile-ros4hri");
+  try {
+    await item.waitFor({ state: "visible", timeout: 2000 });
+  } catch {
+    // Hover-open is timing-sensitive; ArrowRight opens the active submenu
+    // through the menu's keyboard protocol.
+    await page.keyboard.press("ArrowRight");
+    await item.waitFor({ state: "visible", timeout: 5000 });
+  }
+}
+
+/** Close whatever menu levels are open so the next menu click opens. */
+export async function closeMenus(page: Page): Promise<void> {
+  await page.keyboard.press("Escape");
+  await page.keyboard.press("Escape");
+  await expect(
+    page.getByTestId("app-menu-file-standard-profiles"),
+  ).toBeHidden();
+}
+
+/** Toggle the ROS4HRI profile checkbox (import when unchecked, remove when
+ * checked) and close the menu. */
+export async function toggleRos4hriProfile(page: Page): Promise<void> {
+  await openStandardProfilesSubmenu(page);
+  await page.getByTestId("app-menu-file-standard-profile-ros4hri").click();
+  await closeMenus(page);
+}
+
+/** Export the open face as GLB through the export dialog. */
+export async function exportGlb(page: Page): Promise<Download> {
+  await openExportDialog(page);
+  const download = await expectDownload(page, async () => {
+    await page.getByTestId("export-glb-button").click();
+  });
+  return download;
+}
+
+/** The exported GLB's bundle graphs. */
+export async function downloadedGlbGraphs(
+  download: Download,
+): Promise<BundleGraphEntry[]> {
+  const path = await download.path();
+  if (!path) {
+    throw new Error("Expected the exported GLB to resolve to a local file");
+  }
+  return bundleGraphs(glbJson(await readFile(path)));
+}

--- a/apps/vizij-authoring/e2e/standard-profile.workflow.pw.ts
+++ b/apps/vizij-authoring/e2e/standard-profile.workflow.pw.ts
@@ -1,82 +1,12 @@
-import { readFile } from "node:fs/promises";
 import { expect, test } from "@playwright/test";
-import type { Download, Page } from "@playwright/test";
+import { bootAuthoring, loadMainPreset, waitForMainFaceReady } from "./helpers";
 import {
-  bootAuthoring,
-  expectDownload,
-  loadMainPreset,
-  openExportDialog,
-  waitForMainFaceReady,
-} from "./helpers";
-
-/** The parsed JSON chunk of a GLB (12-byte header, chunk 0 is JSON). */
-function glbJson(buffer: Buffer): Record<string, unknown> {
-  expect(buffer.readUInt32LE(0)).toBe(0x46546c67); // "glTF"
-  const jsonLength = buffer.readUInt32LE(12);
-  expect(buffer.readUInt32LE(16)).toBe(0x4e4f534a); // "JSON"
-  return JSON.parse(
-    buffer.subarray(20, 20 + jsonLength).toString("utf8"),
-  ) as Record<string, unknown>;
-}
-
-/** The `VIZIJ_bundle.graphs` of a GLB document (root or node extension). */
-function bundleGraphs(
-  gltf: Record<string, unknown>,
-): { id?: string; kind?: string; spec?: { nodes?: unknown[] } }[] {
-  type WithExtensions = { extensions?: { VIZIJ_bundle?: { graphs?: [] } } };
-  const root = gltf as WithExtensions;
-  const nodes = (gltf.nodes ?? []) as WithExtensions[];
-  const bundle =
-    root.extensions?.VIZIJ_bundle ??
-    nodes.map((node) => node.extensions?.VIZIJ_bundle).find(Boolean);
-  expect(bundle, "the exported GLB carries a VIZIJ_bundle").toBeTruthy();
-  return bundle?.graphs ?? [];
-}
-
-async function openStandardProfilesSubmenu(page: Page): Promise<void> {
-  // Park the pointer first: the submenu opens on hover, and a pointer already
-  // resting on the trigger's coordinates produces no enter event.
-  await page.mouse.move(5, 5);
-  await page.getByTestId("app-menu-file").click();
-  await page.getByTestId("app-menu-file-standard-profiles").hover();
-  const item = page.getByTestId("app-menu-file-standard-profile-ros4hri");
-  try {
-    await item.waitFor({ state: "visible", timeout: 2000 });
-  } catch {
-    // Hover-open is timing-sensitive; ArrowRight opens the active submenu
-    // through the menu's keyboard protocol.
-    await page.keyboard.press("ArrowRight");
-    await item.waitFor({ state: "visible", timeout: 5000 });
-  }
-}
-
-async function toggleRos4hriProfile(page: Page): Promise<void> {
-  await openStandardProfilesSubmenu(page);
-  await page.getByTestId("app-menu-file-standard-profile-ros4hri").click();
-  // Checkbox items keep the menu open; Escape closes the submenu, then the
-  // menu, so the next menu click opens instead of toggling it shut.
-  await page.keyboard.press("Escape");
-  await page.keyboard.press("Escape");
-  await expect(
-    page.getByTestId("app-menu-file-standard-profiles"),
-  ).toBeHidden();
-}
-
-async function exportGlb(page: Page): Promise<Download> {
-  await openExportDialog(page);
-  const download = await expectDownload(page, async () => {
-    await page.getByTestId("export-glb-button").click();
-  });
-  return download;
-}
-
-async function downloadedGlbGraphs(download: Download) {
-  const path = await download.path();
-  if (!path) {
-    throw new Error("Expected the exported GLB to resolve to a local file");
-  }
-  return bundleGraphs(glbJson(await readFile(path)));
-}
+  closeMenus,
+  downloadedGlbGraphs,
+  exportGlb,
+  openStandardProfilesSubmenu,
+  toggleRos4hriProfile,
+} from "./profile-helpers";
 
 test("standard profile import round-trips through GLB export @workflow", async ({
   page,
@@ -111,8 +41,7 @@ test("standard profile import round-trips through GLB export @workflow", async (
   await expect(
     page.getByTestId("app-menu-file-standard-profile-ros4hri"),
   ).toBeVisible();
-  await page.keyboard.press("Escape");
-  await page.keyboard.press("Escape");
+  await closeMenus(page);
   const reGraphs = await downloadedGlbGraphs(await exportGlb(page));
   expect(
     reGraphs.find((graph) => graph.id === "standard::ros4hri"),

--- a/apps/vizij-authoring/package.json
+++ b/apps/vizij-authoring/package.json
@@ -33,7 +33,7 @@
     "@vizij/node-graph-react": "workspace:*",
     "@vizij/node-graph": "^0.7.0",
     "@vizij/render": "workspace:*",
-    "@vizij/runtime": "^2.2.0",
+    "@vizij/runtime": "^2.3.0",
     "@vizij/runtime-react": "workspace:*",
     "@vizij/utils": "workspace:*",
     "@vizij/value-json": "^0.2.0",

--- a/apps/vizij-authoring/src/App.tsx
+++ b/apps/vizij-authoring/src/App.tsx
@@ -3950,10 +3950,32 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
     profiles: availableStandardProfiles,
     embeddedProfileIds,
     toggleProfile: toggleStandardProfile,
+    exportProfileJson: exportStandardProfileJson,
+    importProfileJson: importStandardProfileJson,
   } = useStandardProfiles({
     bundle: loader.bundle,
     updateBundle: loader.updateBundle,
   });
+  // The profile whose "Replace from JSON..." picker is open — consumed when
+  // the hidden input below delivers the chosen file.
+  const replaceProfileIdRef = useRef<string | null>(null);
+  const profileJsonInputRef = useRef<HTMLInputElement>(null);
+  const handleReplaceStandardProfileJson = useCallback((profileId: string) => {
+    replaceProfileIdRef.current = profileId;
+    profileJsonInputRef.current?.click();
+  }, []);
+  const handleProfileJsonFileChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      const profileId = replaceProfileIdRef.current;
+      replaceProfileIdRef.current = null;
+      event.target.value = "";
+      if (file && profileId) {
+        void importStandardProfileJson(profileId, file);
+      }
+    },
+    [importStandardProfileJson],
+  );
 
   const menuBar = (
     <AppMenuBar
@@ -3966,6 +3988,8 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
       onToggleStandardProfile={(profileId, enabled) => {
         void toggleStandardProfile(profileId, enabled);
       }}
+      onExportStandardProfileJson={exportStandardProfileJson}
+      onReplaceStandardProfileJson={handleReplaceStandardProfileJson}
       onSave={handleSaveExport}
       onExport={() => setShowExportDialog(true)}
       canSave={canExport}
@@ -4645,6 +4669,15 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
         accept=".glb,.gltf"
         data-testid="app-import-file-input"
         onChange={(e) => void handleFileChange(e)}
+      />
+      {/* Hidden file input for "Replace <profile> from JSON..." */}
+      <input
+        type="file"
+        ref={profileJsonInputRef}
+        className="hidden"
+        accept=".json"
+        data-testid="app-profile-json-input"
+        onChange={handleProfileJsonFileChange}
       />
     </ReferenceFaceProvider>
   );

--- a/apps/vizij-authoring/src/components/app/AppMenuBar.test.tsx
+++ b/apps/vizij-authoring/src/components/app/AppMenuBar.test.tsx
@@ -25,6 +25,8 @@ function renderMenuBar() {
       standardProfiles={[]}
       embeddedProfileIds={[]}
       onToggleStandardProfile={vi.fn()}
+      onExportStandardProfileJson={vi.fn()}
+      onReplaceStandardProfileJson={vi.fn()}
       canSave
       saveDirty={false}
       showSelectionGlow={false}

--- a/apps/vizij-authoring/src/components/app/AppMenuBar.tsx
+++ b/apps/vizij-authoring/src/components/app/AppMenuBar.tsx
@@ -38,6 +38,10 @@ interface AppMenuBarProps {
   embeddedProfileIds: string[];
   /** Import (`enabled`) or remove a standard profile in the open GLB. */
   onToggleStandardProfile: (profileId: string, enabled: boolean) => void;
+  /** Download an embedded profile as canonical (unprefixed) JSON. */
+  onExportStandardProfileJson: (profileId: string) => void;
+  /** Replace an embedded profile from a canonical JSON file. */
+  onReplaceStandardProfileJson: (profileId: string) => void;
   canSave: boolean;
   saveDirty: boolean;
   showSelectionGlow: boolean;
@@ -60,6 +64,8 @@ export function AppMenuBar({
   standardProfiles,
   embeddedProfileIds,
   onToggleStandardProfile,
+  onExportStandardProfileJson,
+  onReplaceStandardProfileJson,
   canSave,
   saveDirty,
   showSelectionGlow,
@@ -188,6 +194,25 @@ export function AppMenuBar({
               </MenuCheckboxItem>
             ))
           )}
+          {standardProfiles
+            .filter((profile) => embeddedProfileIds.includes(profile.id))
+            .map((profile) => (
+              <React.Fragment key={profile.id}>
+                <MenuSeparator />
+                <MenuItem
+                  onSelect={() => onExportStandardProfileJson(profile.id)}
+                  testId={`app-menu-file-standard-profile-export-${profile.id}`}
+                >
+                  Export {profile.title} as JSON...
+                </MenuItem>
+                <MenuItem
+                  onSelect={() => onReplaceStandardProfileJson(profile.id)}
+                  testId={`app-menu-file-standard-profile-replace-${profile.id}`}
+                >
+                  Replace {profile.title} from JSON...
+                </MenuItem>
+              </React.Fragment>
+            ))}
         </MenuSubmenu>
         <MenuItem onSelect={onExport} testId="app-menu-file-export">
           Export...

--- a/apps/vizij-authoring/src/hooks/useStandardProfiles.test.ts
+++ b/apps/vizij-authoring/src/hooks/useStandardProfiles.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyRigPrefix,
+  embeddedProfileGraphId,
+  embeddedProfileId,
+  stripRigPrefix,
+} from "./useStandardProfiles";
+
+const PREFIX = "rig/quori_latest/";
+
+// A miniature profile shape: only output nodes' written paths take the rig
+// prefix; inputs (the standard's keys) and other node kinds stay untouched.
+const canonical = {
+  nodes: [
+    {
+      id: "v",
+      type: "input",
+      params: { path: "standard/ros4hri/expression/valence", value: 0 },
+    },
+    { id: "c", type: "constant", params: { value: 0.5 } },
+    {
+      id: "o",
+      type: "output",
+      params: { path: "standard/vizij/expression/happy" },
+    },
+  ],
+  edges: [{ from: { node_id: "v" }, to: { node_id: "o", input: "in" } }],
+};
+
+describe("rig prefix transforms", () => {
+  it("prefixes only output paths, and stripping restores the canonical form", () => {
+    const prefixed = applyRigPrefix(canonical, PREFIX);
+    expect(prefixed.nodes[0].params.path).toBe(
+      "standard/ros4hri/expression/valence",
+    );
+    expect(prefixed.nodes[2].params.path).toBe(
+      `${PREFIX}standard/vizij/expression/happy`,
+    );
+    // The round trip is exact — a re-exported, unedited profile diffs clean.
+    expect(stripRigPrefix(prefixed, PREFIX)).toStrictEqual(canonical);
+  });
+
+  it("is the identity for an empty prefix (face without a faceId)", () => {
+    expect(applyRigPrefix(canonical, "")).toStrictEqual(canonical);
+    expect(stripRigPrefix(canonical, "")).toStrictEqual(canonical);
+  });
+
+  it("leaves foreign-prefix paths alone when stripping", () => {
+    const other = applyRigPrefix(canonical, "rig/other_face/");
+    const stripped = stripRigPrefix(other, PREFIX);
+    expect(stripped.nodes[2].params.path).toBe(
+      "rig/other_face/standard/vizij/expression/happy",
+    );
+  });
+});
+
+describe("embedded profile ids", () => {
+  it("round-trips through the stable graph id", () => {
+    expect(embeddedProfileGraphId("ros4hri")).toBe("standard::ros4hri");
+    expect(
+      embeddedProfileId({
+        id: "standard::ros4hri",
+        kind: "standard-profile",
+        spec: {},
+      }),
+    ).toBe("ros4hri");
+    expect(
+      embeddedProfileId({ id: "the_rig", kind: "rig", spec: {} }),
+    ).toBeNull();
+  });
+});

--- a/apps/vizij-authoring/src/hooks/useStandardProfiles.ts
+++ b/apps/vizij-authoring/src/hooks/useStandardProfiles.ts
@@ -8,6 +8,7 @@ import type {
   VizijBundleExtension,
   VizijBundleGraphEntry,
 } from "@vizij/render";
+import { downloadJsonFile } from "../utils/fileIO";
 
 /** The bundle graph kind under which a standard profile embeds in a GLB. */
 export const STANDARD_PROFILE_KIND = "standard-profile";
@@ -27,6 +28,59 @@ export function embeddedProfileId(entry: VizijBundleGraphEntry): string | null {
   }
   const id = entry.id ?? "";
   return id.startsWith("standard::") ? id.slice("standard::".length) : id;
+}
+
+/** A graph spec's nodes, loosely typed for the prefix transforms. */
+interface SpecNode {
+  type?: string;
+  params?: { path?: string };
+}
+
+/**
+ * The rig prefix applied to a profile spec's written control paths — the same
+ * transform the runtime applies when composing or embedding (it prefixes only
+ * `output` nodes' `params.path`). Returns a transformed copy.
+ */
+export function applyRigPrefix<T extends { nodes?: unknown[] }>(
+  spec: T,
+  rigPrefix: string,
+): T {
+  if (!rigPrefix) {
+    return spec;
+  }
+  const clone = structuredClone(spec);
+  for (const node of (clone.nodes ?? []) as SpecNode[]) {
+    if (node.type === "output" && typeof node.params?.path === "string") {
+      node.params.path = `${rigPrefix}${node.params.path}`;
+    }
+  }
+  return clone;
+}
+
+/**
+ * The inverse of {@link applyRigPrefix}: strips `rigPrefix` from `output`
+ * nodes' written paths, restoring the canonical, face-independent profile
+ * JSON — the form the built-ins ship in and a re-exported profile must be
+ * contributed back in. Returns a transformed copy.
+ */
+export function stripRigPrefix<T extends { nodes?: unknown[] }>(
+  spec: T,
+  rigPrefix: string,
+): T {
+  if (!rigPrefix) {
+    return spec;
+  }
+  const clone = structuredClone(spec);
+  for (const node of (clone.nodes ?? []) as SpecNode[]) {
+    if (
+      node.type === "output" &&
+      typeof node.params?.path === "string" &&
+      node.params.path.startsWith(rigPrefix)
+    ) {
+      node.params.path = node.params.path.slice(rigPrefix.length);
+    }
+  }
+  return clone;
 }
 
 interface UseStandardProfilesOptions {
@@ -78,6 +132,40 @@ export function useStandardProfiles({
     [bundle],
   );
 
+  // The profile writes the face's namespaced standard controls, so its
+  // embedded copy takes the bundle's rig prefix — the same prefixing the
+  // deployed runtime applies when composing the built-in.
+  const rigPrefix = useMemo(() => {
+    const faceId = bundle?.metadata?.faceId;
+    return faceId ? `rig/${faceId}/` : "";
+  }, [bundle]);
+
+  // Graft `spec` in as `standard::<profileId>` — the runtime bundler's
+  // replace-or-append, so re-import updates in place.
+  const embedSpec = useCallback(
+    (profileId: string, spec: Record<string, unknown>) => {
+      const entry: VizijBundleGraphEntry = {
+        id: embeddedProfileGraphId(profileId),
+        kind: STANDARD_PROFILE_KIND,
+        spec,
+      };
+      updateBundle((prev) => {
+        if (!prev) {
+          return prev;
+        }
+        const graphs = [...(prev.graphs ?? [])];
+        const existing = graphs.findIndex((graph) => graph.id === entry.id);
+        if (existing >= 0) {
+          graphs[existing] = entry;
+        } else {
+          graphs.push(entry);
+        }
+        return { ...prev, graphs };
+      });
+    },
+    [updateBundle],
+  );
+
   const toggleProfile = useCallback(
     async (profileId: string, enabled: boolean) => {
       if (!enabled) {
@@ -94,39 +182,69 @@ export function useStandardProfiles({
         });
         return;
       }
-      // The profile writes the face's namespaced standard controls, so it
-      // takes the bundle's rig prefix — the same prefixing the deployed
-      // runtime applies when composing the built-in.
-      const faceId = bundle?.metadata?.faceId;
-      const rigPrefix = faceId ? `rig/${faceId}/` : "";
       const spec = await standardProfile(profileId, rigPrefix);
       if (!spec) {
         console.error(`standard profile ${profileId} unavailable`);
         return;
       }
-      // Mirrors the runtime bundler's graft: `{kind, id, spec}`, replacing
-      // the entry with the same id if present, appending otherwise.
-      const entry: VizijBundleGraphEntry = {
-        id: embeddedProfileGraphId(profileId),
-        kind: STANDARD_PROFILE_KIND,
-        spec: spec as Record<string, unknown>,
-      };
-      updateBundle((prev) => {
-        if (!prev) {
-          return prev;
-        }
-        const graphs = [...(prev.graphs ?? [])];
-        const existing = graphs.findIndex((graph) => graph.id === entry.id);
-        if (existing >= 0) {
-          graphs[existing] = entry;
-        } else {
-          graphs.push(entry);
-        }
-        return { ...prev, graphs };
-      });
+      embedSpec(profileId, spec as Record<string, unknown>);
     },
-    [bundle, updateBundle],
+    [embedSpec, rigPrefix, updateBundle],
   );
 
-  return { profiles, embeddedProfileIds, toggleProfile } as const;
+  /**
+   * Download the embedded profile as canonical JSON: the rig prefix applied
+   * at import is stripped back out, so the file is face-independent —
+   * diffable against, and contributable to, the shipped built-ins.
+   */
+  const exportProfileJson = useCallback(
+    (profileId: string) => {
+      const entry = (bundle?.graphs ?? []).find(
+        (graph) => embeddedProfileId(graph) === profileId,
+      );
+      if (!entry?.spec) {
+        console.error(`no embedded profile ${profileId} to export`);
+        return;
+      }
+      const canonical = stripRigPrefix(
+        entry.spec as { nodes?: unknown[] },
+        rigPrefix,
+      );
+      downloadJsonFile(canonical, `${profileId}.json`);
+    },
+    [bundle, rigPrefix],
+  );
+
+  /**
+   * Replace the embedded profile from a canonical (unprefixed) JSON file:
+   * the rig prefix is applied on the way in, mirroring import-from-registry.
+   */
+  const importProfileJson = useCallback(
+    async (profileId: string, file: File) => {
+      let spec: { nodes?: unknown[]; edges?: unknown[] };
+      try {
+        spec = JSON.parse(await file.text());
+      } catch (error) {
+        console.error(`profile JSON ${file.name} does not parse`, error);
+        return;
+      }
+      if (!Array.isArray(spec.nodes) || !Array.isArray(spec.edges)) {
+        console.error(`profile JSON ${file.name} is not a graph spec`);
+        return;
+      }
+      embedSpec(
+        profileId,
+        applyRigPrefix(spec, rigPrefix) as Record<string, unknown>,
+      );
+    },
+    [embedSpec, rigPrefix],
+  );
+
+  return {
+    profiles,
+    embeddedProfileIds,
+    toggleProfile,
+    exportProfileJson,
+    importProfileJson,
+  } as const;
 }

--- a/packages/@vizij/runtime-react/package.json
+++ b/packages/@vizij/runtime-react/package.json
@@ -41,7 +41,7 @@
     "@vizij/animation-module": "^0.2.0",
     "@vizij/node-graph-authoring": "workspace:*",
     "@vizij/render": "workspace:*",
-    "@vizij/runtime": "^2.2.0",
+    "@vizij/runtime": "^2.3.0",
     "@vizij/utils": "workspace:*",
     "@vizij/value-json": "^0.2.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -489,8 +489,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/@vizij/render
       '@vizij/runtime':
-        specifier: ^2.2.0
-        version: 2.2.0
+        specifier: ^2.3.0
+        version: 2.3.0
       '@vizij/runtime-react':
         specifier: workspace:*
         version: link:../../packages/@vizij/runtime-react
@@ -910,8 +910,8 @@ importers:
         specifier: workspace:*
         version: link:../render
       '@vizij/runtime':
-        specifier: ^2.2.0
-        version: 2.2.0
+        specifier: ^2.3.0
+        version: 2.3.0
       '@vizij/utils':
         specifier: workspace:*
         version: link:../utils
@@ -2728,8 +2728,8 @@ packages:
   '@vizij/node-graph@0.7.0':
     resolution: {integrity: sha512-8EtlkEQyLlaEjMeQPJK4XmjB+Y/n4FsZ7U2Z2h7j1/Fob03F00kqVQU+O8ncHjODSwpzeMsJ1D/rulMupiydUA==}
 
-  '@vizij/runtime@2.2.0':
-    resolution: {integrity: sha512-AuaApP0KuxxxQjl/AqX2rQdhCfbq2Y+Md9Zqg++gcGbgdYa8iGUFG6YCCP+vTcSpPAjgScG3IGIotBAEBvog+w==}
+  '@vizij/runtime@2.3.0':
+    resolution: {integrity: sha512-WBZ+M4Rp7MY175nDIK5bbfeikX0RINycpmDbPkgsFnYy7IwN7iff9fDeklUH8XX8Pvx+pCs37LdymSPJOk+RMg==}
 
   '@vizij/value-json@0.2.0':
     resolution: {integrity: sha512-1wNxYLm4DPBnkcciIY4YClweIfIQinefMPsE8pQeacv1u8/0ls/Y3+GNCb3Rwa1yvdvKodRFhIf69JE2LsUC1Q==}
@@ -7009,7 +7009,7 @@ snapshots:
       '@vizij/value-json': 0.2.0
       '@vizij/wasm-loader': 0.1.5
 
-  '@vizij/runtime@2.2.0':
+  '@vizij/runtime@2.3.0':
     dependencies:
       '@vizij/value-json': 0.2.0
       '@vizij/wasm-loader': 0.1.5


### PR DESCRIPTION
The first half of [VIZ-93](https://linear.app/semio-ai/issue/VIZ-93/profile-edition): the **human-editable JSON loop** with autonomous deploy-verification. (In-editor graph edition of the embedded profile is the follow-up PR — it rides on this harness.)

**Menu** — `File > Standard Profiles` gains per-embedded-profile actions:
- **Export as JSON…** — the embedded copy in canonical, face-independent form: `stripRigPrefix` (the exact inverse of the runtime's prefixing, which touches only `output` nodes' `params.path`) removes the `rig/<faceId>/` prefix, so the file diffs clean against the shipped built-ins and an improved mapping can be contributed straight back to [`vizij-arora-host/profiles/`](https://github.com/vizij-ai/vizij-rs/tree/main/crates/interop/vizij-arora-host/profiles).
- **Replace from JSON…** — embeds a canonical JSON file in place (real file-chooser flow), prefixing on the way in.

**The autonomous loop, closed** — the new `@workflow` e2e does the whole VIZ-93 ride without a human: import ROS4HRI → export its JSON (674 nodes, all output paths verified unprefixed) → *edit* it down to a mapping the built-in never produces (valence → happy verbatim) → replace via the picker → export the GLB → **deploy that GLB in-test** through [`composeFace`](https://github.com/vizij-ai/vizij-rs/pull/90) (`@vizij/runtime` 2.3.0) on the wasm runtime → stage `name="sad", valence=0.8` → observe `happy == 0.8` on the rig-prefixed control. Both workflow specs green locally in 58.6s.

**Also**: shared GLB/profile e2e helpers extracted to `e2e/profile-helpers.ts`; prefix transforms round-trip unit-tested (4 new vitest cases, 733 total green); runtime pins → `^2.3.0` (one wasm version for the preview provider, the picker, and the test loop); tsc + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)