### PR TITLE
feat(authoring): edit an embedded standard profile in the graph editor (VIZ-93)

### DIFF
--- a/apps/vizij-authoring/e2e/profile-editor.workflow.pw.ts
+++ b/apps/vizij-authoring/e2e/profile-editor.workflow.pw.ts
@@ -76,9 +76,7 @@ test("embedded profile edits in the graph editor apply to the bundle @workflow",
   // false), so the deterministic edit is severing a mapping edge — the one
   // into the "sad" output.
   await expect(page.locator(".react-flow__edge")).toHaveCount(2);
-  await page
-    .getByTestId("rf__edge-e-v-o2-out-input")
-    .click({ force: true });
+  await page.getByTestId("rf__edge-e-v-o2-out-input").click({ force: true });
   await page.keyboard.press("Backspace");
   await expect(page.locator(".react-flow__edge")).toHaveCount(1);
 

--- a/apps/vizij-authoring/e2e/profile-editor.workflow.pw.ts
+++ b/apps/vizij-authoring/e2e/profile-editor.workflow.pw.ts
@@ -1,0 +1,103 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { bootAuthoring, loadMainPreset } from "./helpers";
+import {
+  closeMenus,
+  downloadedGlbGraphs,
+  exportGlb,
+  openStandardProfilesSubmenu,
+  toggleRos4hriProfile,
+} from "./profile-helpers";
+
+// VIZ-93's in-editor edition: the embedded profile opens in the graph
+// editor, a UI edit applies back to the embedded copy (never to a program),
+// and the exported GLB carries the edited graph.
+test("embedded profile edits in the graph editor apply to the bundle @workflow", async ({
+  page,
+}) => {
+  page.on("console", (message) => {
+    if (message.type() === "error") {
+      console.log(`[browser:error]`, message.text());
+    }
+  });
+  await bootAuthoring(page);
+  await loadMainPreset(page, "quori:latest");
+  await toggleRos4hriProfile(page);
+
+  // Shrink the embedded copy to a two-node mapping first (the JSON loop from
+  // the previous slice), so the editor session is deterministic to drive.
+  // Two mappings off one input, so severing one leaves a live graph (the
+  // export builder prunes fully unwired endpoints).
+  const tiny = {
+    nodes: [
+      {
+        id: "v",
+        type: "input",
+        params: { path: "standard/ros4hri/expression/valence", value: 0.0 },
+      },
+      {
+        id: "o",
+        type: "output",
+        params: { path: "standard/vizij/expression/happy" },
+      },
+      {
+        id: "o2",
+        type: "output",
+        params: { path: "standard/vizij/expression/sad" },
+      },
+    ],
+    edges: [
+      { from: { node_id: "v" }, to: { node_id: "o", input: "in" } },
+      { from: { node_id: "v" }, to: { node_id: "o2", input: "in" } },
+    ],
+  };
+  const dir = await mkdtemp(path.join(tmpdir(), "vizij-profile-editor-"));
+  const tinyPath = path.join(dir, "ros4hri.json");
+  await writeFile(tinyPath, JSON.stringify(tiny));
+  await openStandardProfilesSubmenu(page);
+  const chooserPromise = page.waitForEvent("filechooser");
+  await page
+    .getByTestId("app-menu-file-standard-profile-replace-ros4hri")
+    .click();
+  await (await chooserPromise).setFiles(tinyPath);
+  await closeMenus(page);
+
+  // Open the embedded copy in the graph editor: the session banner shows and
+  // the canvas holds exactly the profile's two nodes.
+  await openStandardProfilesSubmenu(page);
+  await page.getByTestId("app-menu-file-standard-profile-edit-ros4hri").click();
+  await closeMenus(page);
+  await expect(page.getByTestId("profile-editor-banner")).toBeVisible();
+  await expect(page.locator(".react-flow__node")).toHaveCount(3);
+
+  // A UI edit: the profile's input/output endpoints are fixed (deletable:
+  // false), so the deterministic edit is severing a mapping edge — the one
+  // into the "sad" output.
+  await expect(page.locator(".react-flow__edge")).toHaveCount(2);
+  await page
+    .getByTestId("rf__edge-e-v-o2-out-input")
+    .click({ force: true });
+  await page.keyboard.press("Backspace");
+  await expect(page.locator(".react-flow__edge")).toHaveCount(1);
+
+  // Apply: the session ends and the bundle carries the edited copy.
+  await page.getByTestId("profile-editor-apply").click();
+  await expect(page.getByTestId("profile-editor-banner")).toBeHidden();
+  const graphs = await downloadedGlbGraphs(await exportGlb(page));
+  const embedded = graphs.find((graph) => graph.id === "standard::ros4hri");
+  expect(embedded, "the embedded profile survives the edit").toBeTruthy();
+  const editedSpec = embedded?.spec as {
+    nodes?: { type?: string; params?: { path?: string } }[];
+    edges?: unknown[];
+  };
+  // One mapping survives, and it is the happy one.
+  expect(editedSpec?.edges?.length).toBe(1);
+  const outputPaths = (editedSpec?.nodes ?? [])
+    .filter((node) => node.type === "output")
+    .map((node) => node.params?.path);
+  expect(outputPaths).toContain(
+    `rig/${"quori_latest"}/standard/vizij/expression/happy`,
+  );
+});

--- a/apps/vizij-authoring/src/App.tsx
+++ b/apps/vizij-authoring/src/App.tsx
@@ -94,7 +94,10 @@ import {
   buildGlbExportDirtySnapshot,
   useExportDirtyState,
 } from "./hooks/useExportDirtyState";
-import { useStandardProfiles } from "./hooks/useStandardProfiles";
+import {
+  embeddedProfileId,
+  useStandardProfiles,
+} from "./hooks/useStandardProfiles";
 import { carriedBundleGraphs } from "./hooks/useVizijExport";
 import {
   getMemoryInvestigationFlags,
@@ -813,6 +816,14 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
     bundleProceduralSnapshotOverrides,
     setBundleProceduralSnapshotOverrides,
   ] = useState<Record<string, ProceduralProgramSnapshot>>({});
+  // The standard profile whose graph currently owns the motiongraph editor
+  // (VIZ-93 edit session), `null` outside a session. While set, the
+  // procedural target machinery must neither hydrate over the profile's
+  // content nor snapshot it into a program — see the guards in
+  // `saveProceduralTarget` and `loadSelectedProceduralTarget`.
+  const [editingProfileId, setEditingProfileId] = useState<string | null>(null);
+  const editingProfileIdRef = useRef<string | null>(null);
+  editingProfileIdRef.current = editingProfileId;
   const [hiddenBundleAnimationTargetIds, setHiddenBundleAnimationTargetIds] =
     useState<Record<string, true>>({});
   const [hiddenBundleProceduralTargetIds, setHiddenBundleProceduralTargetIds] =
@@ -1442,6 +1453,11 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
   );
   const saveProceduralTarget = useCallback(
     (targetId: string) => {
+      // A profile edit session owns the editor: its content must never be
+      // snapshotted into a program target.
+      if (editingProfileIdRef.current) {
+        return;
+      }
       const programId = parseAuthoredProceduralTargetValue(targetId);
       if (!programId && !targetId.startsWith(BUNDLE_PROCEDURAL_TARGET_PREFIX)) {
         return;
@@ -2028,6 +2044,11 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
   );
   const loadSelectedProceduralTarget = useCallback(
     (targetId: string | null) => {
+      // A profile edit session owns the editor: target changes neither
+      // hydrate over its content nor clear it (apply/discard does).
+      if (editingProfileIdRef.current) {
+        return;
+      }
       if (!targetId) {
         const editorStore = useEditorStore.getState();
         editorStore.clear();
@@ -3952,10 +3973,64 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
     toggleProfile: toggleStandardProfile,
     exportProfileJson: exportStandardProfileJson,
     importProfileJson: importStandardProfileJson,
+    replaceProfileSpec: replaceStandardProfileSpec,
   } = useStandardProfiles({
     bundle: loader.bundle,
     updateBundle: loader.updateBundle,
   });
+  const handleEditStandardProfileGraph = useCallback(
+    (profileId: string) => {
+      const entry = (loader.bundle?.graphs ?? []).find(
+        (graph) => embeddedProfileId(graph) === profileId,
+      );
+      if (!entry?.spec) {
+        console.error(`no embedded profile ${profileId} to edit`);
+        return;
+      }
+      // Park the current program's edits exactly like a target switch, then
+      // let the profile session own the editor.
+      if (selectedProceduralTargetId) {
+        saveProceduralTarget(selectedProceduralTargetId);
+      }
+      setSelectedProceduralTargetId(null);
+      const parsed = specToEditorState(entry.spec as Record<string, unknown>);
+      hydrateProceduralEditorState({
+        nodes: parsed.nodes,
+        edges: parsed.edges,
+        enabledOutputs: Array.from(parsed.enabledOutputs),
+        enabledInputs: Array.from(parsed.enabledInputs),
+        customInputPaths: [...parsed.customInputPaths],
+      });
+      setEditingProfileId(profileId);
+      setWorkspacePanelVisibility("motiongraph", true);
+    },
+    [
+      loader.bundle,
+      saveProceduralTarget,
+      selectedProceduralTargetId,
+      setWorkspacePanelVisibility,
+    ],
+  );
+  const applyStandardProfileEdits = useCallback(() => {
+    if (!editingProfileId) {
+      return;
+    }
+    const spec = buildProceduralExportSpec(snapshotProceduralEditorState());
+    replaceStandardProfileSpec(
+      editingProfileId,
+      spec as Record<string, unknown>,
+    );
+    setEditingProfileId(null);
+    const editorStore = useEditorStore.getState();
+    editorStore.clear();
+    editorStore.setSelected(null);
+  }, [editingProfileId, replaceStandardProfileSpec]);
+  const discardStandardProfileEdits = useCallback(() => {
+    setEditingProfileId(null);
+    const editorStore = useEditorStore.getState();
+    editorStore.clear();
+    editorStore.setSelected(null);
+  }, []);
   // The profile whose "Replace from JSON..." picker is open — consumed when
   // the hidden input below delivers the chosen file.
   const replaceProfileIdRef = useRef<string | null>(null);
@@ -3990,6 +4065,7 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
       }}
       onExportStandardProfileJson={exportStandardProfileJson}
       onReplaceStandardProfileJson={handleReplaceStandardProfileJson}
+      onEditStandardProfileGraph={handleEditStandardProfileGraph}
       onSave={handleSaveExport}
       onExport={() => setShowExportDialog(true)}
       canSave={canExport}
@@ -4401,33 +4477,70 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
             }
           />
           <ResizablePanel defaultSize={42} minSize={20}>
-            <MotionGraphPanel
-              onSelectNode={handleSelectMotionGraphNodeWithInspectorSync}
-              playbackState={selectedProgramPanelPlaybackState}
-              onPlayTransport={
-                resolvedSelectedProceduralTargetId
-                  ? handlePlayProgramRuntime
-                  : undefined
-              }
-              onPauseTransport={
-                selectedProgramCanPauseOrStop
-                  ? handlePauseProgramRuntime
-                  : undefined
-              }
-              onStopTransport={
-                selectedProgramCanPauseOrStop
-                  ? handleStopProgramRuntime
-                  : undefined
-              }
-              playbackAvailable={Boolean(
-                resolvedSelectedProceduralTargetId &&
-                  selectedProgramRuntimeSnapshot,
-              )}
-              statusMessage={programPanelStatusMessage}
-              splitVertical={motionGraphSplitVertical}
-              onToggleSplit={() => setMotionGraphSplitVertical((prev) => !prev)}
-              onClosePanel={handleHideMotionGraphPanel}
-            />
+            <div className="flex h-full flex-col">
+              {editingProfileId ? (
+                <div
+                  className="flex items-center gap-2 border-b border-border-default bg-bg-secondary px-3 py-1.5 text-xs text-text-secondary"
+                  data-testid="profile-editor-banner"
+                >
+                  <span className="flex-1">
+                    Editing the{" "}
+                    <span className="font-semibold text-text-primary">
+                      {editingProfileId}
+                    </span>{" "}
+                    standard profile — applied to the embedded copy, not a
+                    program.
+                  </span>
+                  <button
+                    type="button"
+                    className="rounded bg-accent-primary px-2 py-1 text-xs font-medium text-white hover:opacity-90"
+                    data-testid="profile-editor-apply"
+                    onClick={applyStandardProfileEdits}
+                  >
+                    Apply to Profile
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded border border-border-default px-2 py-1 text-xs hover:bg-bg-hover"
+                    data-testid="profile-editor-discard"
+                    onClick={discardStandardProfileEdits}
+                  >
+                    Discard
+                  </button>
+                </div>
+              ) : null}
+              <div className="min-h-0 flex-1">
+                <MotionGraphPanel
+                  onSelectNode={handleSelectMotionGraphNodeWithInspectorSync}
+                  playbackState={selectedProgramPanelPlaybackState}
+                  onPlayTransport={
+                    resolvedSelectedProceduralTargetId
+                      ? handlePlayProgramRuntime
+                      : undefined
+                  }
+                  onPauseTransport={
+                    selectedProgramCanPauseOrStop
+                      ? handlePauseProgramRuntime
+                      : undefined
+                  }
+                  onStopTransport={
+                    selectedProgramCanPauseOrStop
+                      ? handleStopProgramRuntime
+                      : undefined
+                  }
+                  playbackAvailable={Boolean(
+                    resolvedSelectedProceduralTargetId &&
+                      selectedProgramRuntimeSnapshot,
+                  )}
+                  statusMessage={programPanelStatusMessage}
+                  splitVertical={motionGraphSplitVertical}
+                  onToggleSplit={() =>
+                    setMotionGraphSplitVertical((prev) => !prev)
+                  }
+                  onClosePanel={handleHideMotionGraphPanel}
+                />
+              </div>
+            </div>
           </ResizablePanel>
         </>
       ) : null}
@@ -4518,7 +4631,7 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
               animationActive={effectiveAnimationPanelVisible}
               centerAuthoringMode={centerAuthoringMode}
               runtimeFaceId={faceId}
-              enableMotionGraphPruning
+              enableMotionGraphPruning={!editingProfileId}
               onSelectMotionGraphNode={
                 handleSelectMotionGraphNodeWithInspectorSync
               }

--- a/apps/vizij-authoring/src/components/app/AppMenuBar.test.tsx
+++ b/apps/vizij-authoring/src/components/app/AppMenuBar.test.tsx
@@ -27,6 +27,7 @@ function renderMenuBar() {
       onToggleStandardProfile={vi.fn()}
       onExportStandardProfileJson={vi.fn()}
       onReplaceStandardProfileJson={vi.fn()}
+      onEditStandardProfileGraph={vi.fn()}
       canSave
       saveDirty={false}
       showSelectionGlow={false}

--- a/apps/vizij-authoring/src/components/app/AppMenuBar.tsx
+++ b/apps/vizij-authoring/src/components/app/AppMenuBar.tsx
@@ -42,6 +42,8 @@ interface AppMenuBarProps {
   onExportStandardProfileJson: (profileId: string) => void;
   /** Replace an embedded profile from a canonical JSON file. */
   onReplaceStandardProfileJson: (profileId: string) => void;
+  /** Open an embedded profile's graph in the editor (apply-back session). */
+  onEditStandardProfileGraph: (profileId: string) => void;
   canSave: boolean;
   saveDirty: boolean;
   showSelectionGlow: boolean;
@@ -66,6 +68,7 @@ export function AppMenuBar({
   onToggleStandardProfile,
   onExportStandardProfileJson,
   onReplaceStandardProfileJson,
+  onEditStandardProfileGraph,
   canSave,
   saveDirty,
   showSelectionGlow,
@@ -210,6 +213,12 @@ export function AppMenuBar({
                   testId={`app-menu-file-standard-profile-replace-${profile.id}`}
                 >
                   Replace {profile.title} from JSON...
+                </MenuItem>
+                <MenuItem
+                  onSelect={() => onEditStandardProfileGraph(profile.id)}
+                  testId={`app-menu-file-standard-profile-edit-${profile.id}`}
+                >
+                  Edit {profile.title} in Graph Editor...
                 </MenuItem>
               </React.Fragment>
             ))}

--- a/apps/vizij-authoring/src/hooks/useStandardProfiles.ts
+++ b/apps/vizij-authoring/src/hooks/useStandardProfiles.ts
@@ -246,5 +246,9 @@ export function useStandardProfiles({
     toggleProfile,
     exportProfileJson,
     importProfileJson,
+    /** Replace an embedded profile's spec in place (e.g. from the graph
+     * editor's apply-back). The spec is stored as given — already
+     * rig-prefixed, like the embedded copy it replaces. */
+    replaceProfileSpec: embedSpec,
   } as const;
 }


### PR DESCRIPTION
The second half of [VIZ-93](https://linear.app/semio-ai/issue/VIZ-93/profile-edition): **in-editor edition**, on top of [#104](https://github.com/vizij-ai/vizij-web/pull/104)'s JSON loop and deploy-verified harness.

**Feature** — `File > Standard Profiles > Edit <profile> in Graph Editor…` hydrates the embedded copy into the motiongraph editor as an **exclusive session**: a banner marks it (`Apply to Profile` / `Discard`), and applying writes the edited graph back into the bundle's `standard::<id>` entry — never into a program.

**Why a session, not a program target** — profiles must not inherit program semantics (play/delete affordances, face-variable scoping). Three guard rails make the borrow safe, each found by driving the real app:
1. Opening **parks** the selected program's edits exactly like a target switch, then deselects — the lifecycle's auto-reselect can't hydrate over the session (guarded), and `saveProceduralTarget` can't snapshot profile content into a program (guarded).
2. The editor's `loadSelectedProceduralTarget(null)` **clear** path is also guarded — deselection during session-open no longer wipes the hydrated profile.
3. The VariablesPanel's **motion-graph pruning** — which trims the editor's enabled IO to the face's own variables — is suspended for the session (`enableMotionGraphPruning={!editingProfileId}` on the pruning layout). A profile's entire purpose is mapping *foreign* standard keys onto standard controls; without this the canvas reconcilers silently culled the profile's endpoint nodes (diagnosed by tracing the store: hydrate 2 → enabled sets pruned to 0 → culled to 0).

**E2E** (`profile-editor.workflow.pw.ts`, green in 36s; all three profile workflow specs green together in 1.5m): import ROS4HRI → shrink to a two-mapping copy via the JSON loop → open the editor session (banner + 3 canvas nodes) → **sever the sad mapping edge on the canvas** → Apply → export: the GLB's embedded copy carries one edge, and the happy mapping survives. 733 unit tests, tsc + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)