### PR TITLE
docs(standalone): arora-native TTS (the polly module) section (VIZ-94)

### DIFF
--- a/apps/vizij-standalone/README.md
+++ b/apps/vizij-standalone/README.md
@@ -330,13 +330,13 @@ Practical interpretation:
 
 If speech looks half-configured, check both the Tauri CLI flags and the browser-side env/localStorage state before debugging the runtime layer itself.
 
-### Arora-native TTS (the `polly` module)
+### Arora-native TTS (the Vizij `tts` module)
 
-The speech pipeline above runs in JavaScript (`@vizij/speech-react`): it fetches audio + visemes in the webview and writes face pose weights directly. [`polly`](https://github.com/semio-ai/arora-sdk/tree/main/modules/polly) is the **arora-native** counterpart — the same text-to-speech, exposed as a behavior the runtime can call (`say(text, voice)`), so speech is part of the graph instead of a side system.
+The speech pipeline above runs in JavaScript (`@vizij/speech-react`): it fetches audio + visemes in the webview and writes face pose weights directly. The [`tts` module in vizij-rs](https://github.com/vizij-ai/vizij-rs/blob/main/crates/vizij/src/tts.rs) is the **arora-native** counterpart — the same text-to-speech, exposed as a `say(text, voice)` action the device describes, so speech is part of the behavior instead of a side system. The native `vizij` app registers it on its device.
 
 It uses the **same provider** as the JS path — the Vizij TTS cloud function (`{API_URL}/tts/get-audio` + `/tts/get-visemes`, AWS Polly behind it) — and reads the same `API_URL` (default the demo cloud function) plus a `voice` (default `Ruth`), so it needs no extra configuration and no credentials. Each tick it emits the current viseme (the AWS Polly viseme code at the audio playhead) as an output.
 
-**Status — not yet wired into the standalone.** `polly` is a host-side (native) module: it runs in a native Arora engine, not the wasm engine the webview hosts today. Turning it on here means running a native Arora in the Tauri backend and hosting the module there (the chosen path); that plumbing is the remaining step, tracked in [VIZ-94](https://linear.app/semio-ai/issue/VIZ-94) / [arora-sdk#215](https://github.com/semio-ai/arora-sdk/pull/215).
+**Status — not yet wired into the standalone.** The module runs in a native Arora engine (the `vizij` binary), not the wasm engine the webview hosts today. Turning it on here means running a native Arora in the Tauri backend and hosting the module there (the chosen path); that plumbing is the remaining step, tracked in [VIZ-94](https://linear.app/semio-ai/issue/VIZ-94).
 
 Two pieces are deliberately outside the module:
 

--- a/apps/vizij-standalone/README.md
+++ b/apps/vizij-standalone/README.md
@@ -330,6 +330,19 @@ Practical interpretation:
 
 If speech looks half-configured, check both the Tauri CLI flags and the browser-side env/localStorage state before debugging the runtime layer itself.
 
+### Arora-native TTS (the `polly` module)
+
+The speech pipeline above runs in JavaScript (`@vizij/speech-react`): it fetches audio + visemes in the webview and writes face pose weights directly. [`polly`](https://github.com/semio-ai/arora-sdk/tree/main/modules/polly) is the **arora-native** counterpart — the same text-to-speech, exposed as a behavior the runtime can call (`say(text, voice)`), so speech is part of the graph instead of a side system.
+
+It uses the **same provider** as the JS path — the Vizij TTS cloud function (`{API_URL}/tts/get-audio` + `/tts/get-visemes`, AWS Polly behind it) — and reads the same `API_URL` (default the demo cloud function) plus a `voice` (default `Ruth`), so it needs no extra configuration and no credentials. Each tick it emits the current viseme (the AWS Polly viseme code at the audio playhead) as an output.
+
+**Status — not yet wired into the standalone.** `polly` is a host-side (native) module: it runs in a native Arora engine, not the wasm engine the webview hosts today. Turning it on here means running a native Arora in the Tauri backend and hosting the module there (the chosen path); that plumbing is the remaining step, tracked in [VIZ-94](https://linear.app/semio-ai/issue/VIZ-94) / [arora-sdk#215](https://github.com/semio-ai/arora-sdk/pull/215).
+
+Two pieces are deliberately outside the module:
+
+- **Viseme → face.** The module only *produces* the current viseme code. Mapping it to the face's poses — the vocabulary, the destination key, and the crossfade dynamics — is the action/graph layer's job. _Placeholder: the binding and the standard viseme profile land with the actions work._
+- **Face requirements (GLB) and authoring.** What a face bundle must carry for visemes, and how to author or adapt it, belongs with the face standard rather than the module. _Placeholder: links to the ROS4HRI face docs to be added once the action-level dispatch is settled._
+
 ## Development
 
 ### Windows prerequisites

--- a/apps/vizij-standalone/README.md
+++ b/apps/vizij-standalone/README.md
@@ -340,7 +340,7 @@ It uses the **same provider** as the JS path — the Vizij TTS cloud function (`
 
 Two pieces are deliberately outside the module:
 
-- **Viseme → face.** The module only *produces* the current viseme code. Mapping it to the face's poses — the vocabulary, the destination key, and the crossfade dynamics — is the action/graph layer's job. _Placeholder: the binding and the standard viseme profile land with the actions work._
+- **Viseme → face.** The module only _produces_ the current viseme code. Mapping it to the face's poses — the vocabulary, the destination key, and the crossfade dynamics — is the action/graph layer's job. _Placeholder: the binding and the standard viseme profile land with the actions work._
 - **Face requirements (GLB) and authoring.** What a face bundle must carry for visemes, and how to author or adapt it, belongs with the face standard rather than the module. _Placeholder: links to the ROS4HRI face docs to be added once the action-level dispatch is settled._
 
 ## Development


### PR DESCRIPTION
Adds an **Arora-native TTS** subsection to the standalone's Speech Support docs, for the [`polly`](https://github.com/semio-ai/arora-sdk/tree/main/modules/polly) TTS module ([arora-sdk#215](https://github.com/semio-ai/arora-sdk/pull/215), [VIZ-94](https://linear.app/semio-ai/issue/VIZ-94)).

- Documents it as the arora-native counterpart of the JS `@vizij/speech-react` pipeline: `say(text, voice)` as a behavior, **same provider** (the Vizij TTS cloud function), **same config** (`API_URL`, `voice`), emitting the current viseme each tick.
- **Honest about status**: `polly` is a host-side native module, so it doesn't run in the webview's wasm engine — enabling it in the standalone means running a native Arora in the Tauri backend (the chosen path), still to be wired.
- Leaves the **viseme→face mapping** (action/graph layer) and the **GLB/ROS4HRI adaptation** (face standard) as explicit placeholders, per the current module-level focus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)