### PR TITLE
feat(skills): skills join the profile surface (VIZ-96)

### DIFF
--- a/apps/vizij-authoring/e2e/skills.workflow.pw.ts
+++ b/apps/vizij-authoring/e2e/skills.workflow.pw.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { bootAuthoring, loadMainPreset, waitForMainFaceReady } from "./helpers";
+import { closeMenus, downloadedGlbGraphs, exportGlb } from "./profile-helpers";
+
+/** Open File > Skills so its per-skill items are visible. */
+async function openSkillsSubmenu(page: Page): Promise<void> {
+  // Park the pointer first: the submenu opens on hover, and a pointer already
+  // resting on the trigger's coordinates produces no enter event.
+  await page.mouse.move(5, 5);
+  await page.getByTestId("app-menu-file").click();
+  await page.getByTestId("app-menu-file-skills").hover();
+  const item = page.getByTestId("app-menu-file-skill-look_at");
+  try {
+    await item.waitFor({ state: "visible", timeout: 2000 });
+  } catch {
+    // Hover-open is timing-sensitive; ArrowRight opens the active submenu
+    // through the menu's keyboard protocol.
+    await page.keyboard.press("ArrowRight");
+    await item.waitFor({ state: "visible", timeout: 5000 });
+  }
+}
+
+/** Toggle the look_at skill checkbox (embed when unchecked, remove when
+ * checked) and close the menu. */
+async function toggleLookAtSkill(page: Page): Promise<void> {
+  await openSkillsSubmenu(page);
+  await page.getByTestId("app-menu-file-skill-look_at").click();
+  await closeMenus(page);
+}
+
+test("skill embed and edition round-trip through GLB export @workflow", async ({
+  page,
+}) => {
+  // Surface in-app failures (e.g. the skills fetch erroring) in the test log.
+  page.on("console", (message) => {
+    if (message.type() === "error" || message.type() === "warning") {
+      console.log(`[browser:${message.type()}]`, message.text());
+    }
+  });
+  await bootAuthoring(page);
+  await loadMainPreset(page, "quori:latest");
+
+  // Pin the look_at skill from File > Skills: the exported GLB embeds its
+  // fragment under the stable id, as the face's override of the shipped
+  // behavior.
+  await toggleLookAtSkill(page);
+  const graphs = await downloadedGlbGraphs(await exportGlb(page));
+  const embedded = graphs.find((graph) => graph.id === "skill::look_at");
+  expect(embedded, "skill::look_at embedded in the GLB").toBeTruthy();
+  expect(embedded?.kind).toBe("skill");
+  // The real fragment, not a stub: the policy/gaze/lifecycle nodes.
+  expect(embedded?.spec?.nodes?.length ?? 0).toBeGreaterThan(10);
+  // Fragments are face-independent: the placeholder task inputs embed as-is.
+  const paths = (embedded?.spec?.nodes ?? [])
+    .map((node) => node.params?.path)
+    .filter(Boolean);
+  expect(paths).toContain("task/policy");
+
+  // The skill-editor session borrows the graph editor and applies back into
+  // the embedded copy.
+  await openSkillsSubmenu(page);
+  await page.getByTestId("app-menu-file-skill-edit-look_at").click();
+  await closeMenus(page);
+  await expect(page.getByTestId("skill-editor-banner")).toBeVisible();
+  await page.getByTestId("skill-editor-apply").click();
+  await expect(page.getByTestId("skill-editor-banner")).toBeHidden();
+
+  // Re-importing the exported GLB keeps the skill (the carried entry
+  // survives the load → export round trip), shown checked in the menu.
+  const download = await exportGlb(page);
+  const glbPath = await download.path();
+  await page.getByTestId("app-import-file-input").setInputFiles(glbPath!);
+  await waitForMainFaceReady(page);
+  const reGraphs = await downloadedGlbGraphs(await exportGlb(page));
+  expect(
+    reGraphs.find((graph) => graph.id === "skill::look_at"),
+    "the embedded skill survives re-import and re-export",
+  ).toBeTruthy();
+
+  // Unchecking removes it from the next export.
+  await toggleLookAtSkill(page);
+  const withoutSkill = await downloadedGlbGraphs(await exportGlb(page));
+  expect(
+    withoutSkill.find((graph) => graph.id === "skill::look_at"),
+  ).toBeFalsy();
+});

--- a/apps/vizij-authoring/package.json
+++ b/apps/vizij-authoring/package.json
@@ -33,7 +33,7 @@
     "@vizij/node-graph-react": "workspace:*",
     "@vizij/node-graph": "^0.7.0",
     "@vizij/render": "workspace:*",
-    "@vizij/runtime": "^2.3.0",
+    "@vizij/runtime": "^2.4.0",
     "@vizij/runtime-react": "workspace:*",
     "@vizij/utils": "workspace:*",
     "@vizij/value-json": "^0.2.0",

--- a/apps/vizij-authoring/src/App.tsx
+++ b/apps/vizij-authoring/src/App.tsx
@@ -98,6 +98,7 @@ import {
   embeddedProfileId,
   useStandardProfiles,
 } from "./hooks/useStandardProfiles";
+import { embeddedSkillId, useSkills } from "./hooks/useSkills";
 import { carriedBundleGraphs } from "./hooks/useVizijExport";
 import {
   getMemoryInvestigationFlags,
@@ -824,6 +825,9 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
   const [editingProfileId, setEditingProfileId] = useState<string | null>(null);
   const editingProfileIdRef = useRef<string | null>(null);
   editingProfileIdRef.current = editingProfileId;
+  const [editingSkillId, setEditingSkillId] = useState<string | null>(null);
+  const editingSkillIdRef = useRef<string | null>(null);
+  editingSkillIdRef.current = editingSkillId;
   const [hiddenBundleAnimationTargetIds, setHiddenBundleAnimationTargetIds] =
     useState<Record<string, true>>({});
   const [hiddenBundleProceduralTargetIds, setHiddenBundleProceduralTargetIds] =
@@ -1453,9 +1457,9 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
   );
   const saveProceduralTarget = useCallback(
     (targetId: string) => {
-      // A profile edit session owns the editor: its content must never be
-      // snapshotted into a program target.
-      if (editingProfileIdRef.current) {
+      // A profile or skill edit session owns the editor: its content must
+      // never be snapshotted into a program target.
+      if (editingProfileIdRef.current || editingSkillIdRef.current) {
         return;
       }
       const programId = parseAuthoredProceduralTargetValue(targetId);
@@ -2044,9 +2048,9 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
   );
   const loadSelectedProceduralTarget = useCallback(
     (targetId: string | null) => {
-      // A profile edit session owns the editor: target changes neither
-      // hydrate over its content nor clear it (apply/discard does).
-      if (editingProfileIdRef.current) {
+      // A profile or skill edit session owns the editor: target changes
+      // neither hydrate over its content nor clear it (apply/discard does).
+      if (editingProfileIdRef.current || editingSkillIdRef.current) {
         return;
       }
       if (!targetId) {
@@ -4052,6 +4056,88 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
     [importStandardProfileJson],
   );
 
+  const {
+    skills: availableSkills,
+    embeddedSkillIds,
+    toggleSkill,
+    exportSkillJson,
+    importSkillJson,
+    replaceSkillSpec,
+  } = useSkills({
+    bundle: loader.bundle,
+    updateBundle: loader.updateBundle,
+  });
+  const handleEditSkillGraph = useCallback(
+    (skillId: string) => {
+      const entry = (loader.bundle?.graphs ?? []).find(
+        (graph) => embeddedSkillId(graph) === skillId,
+      );
+      if (!entry?.spec) {
+        console.error(`no embedded skill ${skillId} to edit`);
+        return;
+      }
+      // Park the current program's edits exactly like a target switch, then
+      // let the skill session own the editor.
+      if (selectedProceduralTargetId) {
+        saveProceduralTarget(selectedProceduralTargetId);
+      }
+      setSelectedProceduralTargetId(null);
+      const parsed = specToEditorState(entry.spec as Record<string, unknown>);
+      hydrateProceduralEditorState({
+        nodes: parsed.nodes,
+        edges: parsed.edges,
+        enabledOutputs: Array.from(parsed.enabledOutputs),
+        enabledInputs: Array.from(parsed.enabledInputs),
+        customInputPaths: [...parsed.customInputPaths],
+      });
+      setEditingSkillId(skillId);
+      setWorkspacePanelVisibility("motiongraph", true);
+    },
+    [
+      loader.bundle,
+      saveProceduralTarget,
+      selectedProceduralTargetId,
+      setWorkspacePanelVisibility,
+    ],
+  );
+  const applySkillEdits = useCallback(() => {
+    if (!editingSkillId) {
+      return;
+    }
+    const spec = buildProceduralExportSpec(snapshotProceduralEditorState());
+    replaceSkillSpec(editingSkillId, spec as Record<string, unknown>);
+    setEditingSkillId(null);
+    const editorStore = useEditorStore.getState();
+    editorStore.clear();
+    editorStore.setSelected(null);
+  }, [editingSkillId, replaceSkillSpec]);
+  const discardSkillEdits = useCallback(() => {
+    setEditingSkillId(null);
+    const editorStore = useEditorStore.getState();
+    editorStore.clear();
+    editorStore.setSelected(null);
+  }, []);
+  // The skill whose "Replace from JSON..." picker is open — consumed when
+  // the hidden input below delivers the chosen file.
+  const replaceSkillIdRef = useRef<string | null>(null);
+  const skillJsonInputRef = useRef<HTMLInputElement>(null);
+  const handleReplaceSkillJson = useCallback((skillId: string) => {
+    replaceSkillIdRef.current = skillId;
+    skillJsonInputRef.current?.click();
+  }, []);
+  const handleSkillJsonFileChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      const skillId = replaceSkillIdRef.current;
+      replaceSkillIdRef.current = null;
+      event.target.value = "";
+      if (file && skillId) {
+        void importSkillJson(skillId, file);
+      }
+    },
+    [importSkillJson],
+  );
+
   const menuBar = (
     <AppMenuBar
       onNew={handleNewClick}
@@ -4066,6 +4152,14 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
       onExportStandardProfileJson={exportStandardProfileJson}
       onReplaceStandardProfileJson={handleReplaceStandardProfileJson}
       onEditStandardProfileGraph={handleEditStandardProfileGraph}
+      skills={availableSkills}
+      embeddedSkillIds={embeddedSkillIds}
+      onToggleSkill={(skillId, enabled) => {
+        void toggleSkill(skillId, enabled);
+      }}
+      onExportSkillJson={exportSkillJson}
+      onReplaceSkillJson={handleReplaceSkillJson}
+      onEditSkillGraph={handleEditSkillGraph}
       onSave={handleSaveExport}
       onExport={() => setShowExportDialog(true)}
       canSave={canExport}
@@ -4509,6 +4603,37 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
                   </button>
                 </div>
               ) : null}
+              {editingSkillId ? (
+                <div
+                  className="flex items-center gap-2 border-b border-border-default bg-bg-secondary px-3 py-1.5 text-xs text-text-secondary"
+                  data-testid="skill-editor-banner"
+                >
+                  <span className="flex-1">
+                    Editing the{" "}
+                    <span className="font-semibold text-text-primary">
+                      {editingSkillId}
+                    </span>{" "}
+                    skill fragment — applied to the embedded copy, not a
+                    program.
+                  </span>
+                  <button
+                    type="button"
+                    className="rounded bg-accent-primary px-2 py-1 text-xs font-medium text-white hover:opacity-90"
+                    data-testid="skill-editor-apply"
+                    onClick={applySkillEdits}
+                  >
+                    Apply to Skill
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded border border-border-default px-2 py-1 text-xs hover:bg-bg-hover"
+                    data-testid="skill-editor-discard"
+                    onClick={discardSkillEdits}
+                  >
+                    Discard
+                  </button>
+                </div>
+              ) : null}
               <div className="min-h-0 flex-1">
                 <MotionGraphPanel
                   onSelectNode={handleSelectMotionGraphNodeWithInspectorSync}
@@ -4631,7 +4756,7 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
               animationActive={effectiveAnimationPanelVisible}
               centerAuthoringMode={centerAuthoringMode}
               runtimeFaceId={faceId}
-              enableMotionGraphPruning={!editingProfileId}
+              enableMotionGraphPruning={!editingProfileId && !editingSkillId}
               onSelectMotionGraphNode={
                 handleSelectMotionGraphNodeWithInspectorSync
               }
@@ -4791,6 +4916,15 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
         accept=".json"
         data-testid="app-profile-json-input"
         onChange={handleProfileJsonFileChange}
+      />
+      {/* Hidden file input for "Replace <skill> from JSON..." */}
+      <input
+        type="file"
+        ref={skillJsonInputRef}
+        className="hidden"
+        accept=".json"
+        data-testid="app-skill-json-input"
+        onChange={handleSkillJsonFileChange}
       />
     </ReferenceFaceProvider>
   );

--- a/apps/vizij-authoring/src/components/app/AppMenuBar.test.tsx
+++ b/apps/vizij-authoring/src/components/app/AppMenuBar.test.tsx
@@ -28,6 +28,12 @@ function renderMenuBar() {
       onExportStandardProfileJson={vi.fn()}
       onReplaceStandardProfileJson={vi.fn()}
       onEditStandardProfileGraph={vi.fn()}
+      skills={[]}
+      embeddedSkillIds={[]}
+      onToggleSkill={vi.fn()}
+      onExportSkillJson={vi.fn()}
+      onReplaceSkillJson={vi.fn()}
+      onEditSkillGraph={vi.fn()}
       canSave
       saveDirty={false}
       showSelectionGlow={false}

--- a/apps/vizij-authoring/src/components/app/AppMenuBar.tsx
+++ b/apps/vizij-authoring/src/components/app/AppMenuBar.tsx
@@ -44,6 +44,18 @@ interface AppMenuBarProps {
   onReplaceStandardProfileJson: (profileId: string) => void;
   /** Open an embedded profile's graph in the editor (apply-back session). */
   onEditStandardProfileGraph: (profileId: string) => void;
+  /** The shipped skills a face may pin an override of (empty = none). */
+  skills: { id: string; title: string }[];
+  /** Skill ids the open GLB embeds (checked state of the toggles). */
+  embeddedSkillIds: string[];
+  /** Embed (`enabled`) or remove a skill fragment in the open GLB. */
+  onToggleSkill: (skillId: string, enabled: boolean) => void;
+  /** Download an embedded skill fragment as canonical JSON. */
+  onExportSkillJson: (skillId: string) => void;
+  /** Replace an embedded skill fragment from a canonical JSON file. */
+  onReplaceSkillJson: (skillId: string) => void;
+  /** Open an embedded skill's fragment in the editor (apply-back session). */
+  onEditSkillGraph: (skillId: string) => void;
   canSave: boolean;
   saveDirty: boolean;
   showSelectionGlow: boolean;
@@ -69,6 +81,12 @@ export function AppMenuBar({
   onExportStandardProfileJson,
   onReplaceStandardProfileJson,
   onEditStandardProfileGraph,
+  skills,
+  embeddedSkillIds,
+  onToggleSkill,
+  onExportSkillJson,
+  onReplaceSkillJson,
+  onEditSkillGraph,
   canSave,
   saveDirty,
   showSelectionGlow,
@@ -219,6 +237,47 @@ export function AppMenuBar({
                   testId={`app-menu-file-standard-profile-edit-${profile.id}`}
                 >
                   Edit {profile.title} in Graph Editor...
+                </MenuItem>
+              </React.Fragment>
+            ))}
+        </MenuSubmenu>
+        <MenuSubmenu label="Skills" testId="app-menu-file-skills">
+          {skills.length === 0 ? (
+            <MenuLabel>None available</MenuLabel>
+          ) : (
+            skills.map((skill) => (
+              <MenuCheckboxItem
+                key={skill.id}
+                checked={embeddedSkillIds.includes(skill.id)}
+                onCheckedChange={(checked) => onToggleSkill(skill.id, checked)}
+                testId={`app-menu-file-skill-${skill.id}`}
+              >
+                {skill.title}
+              </MenuCheckboxItem>
+            ))
+          )}
+          {skills
+            .filter((skill) => embeddedSkillIds.includes(skill.id))
+            .map((skill) => (
+              <React.Fragment key={skill.id}>
+                <MenuSeparator />
+                <MenuItem
+                  onSelect={() => onExportSkillJson(skill.id)}
+                  testId={`app-menu-file-skill-export-${skill.id}`}
+                >
+                  Export {skill.title} as JSON...
+                </MenuItem>
+                <MenuItem
+                  onSelect={() => onReplaceSkillJson(skill.id)}
+                  testId={`app-menu-file-skill-replace-${skill.id}`}
+                >
+                  Replace {skill.title} from JSON...
+                </MenuItem>
+                <MenuItem
+                  onSelect={() => onEditSkillGraph(skill.id)}
+                  testId={`app-menu-file-skill-edit-${skill.id}`}
+                >
+                  Edit {skill.title} in Graph Editor...
                 </MenuItem>
               </React.Fragment>
             ))}

--- a/apps/vizij-authoring/src/hooks/useSkills.ts
+++ b/apps/vizij-authoring/src/hooks/useSkills.ts
@@ -1,0 +1,184 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  skills as runtimeSkills,
+  skillSource,
+  type Skill,
+} from "@vizij/runtime";
+import type {
+  VizijBundleExtension,
+  VizijBundleGraphEntry,
+} from "@vizij/render";
+import { downloadJsonFile } from "../utils/fileIO";
+
+/** The bundle graph kind under which a skill fragment embeds in a GLB. */
+export const SKILL_KIND = "skill";
+
+/**
+ * The bundle graph id under which `skillId` embeds — stable, so re-import
+ * replaces rather than duplicates (mirrors the runtime's `skill::<id>`).
+ */
+export function embeddedSkillGraphId(skillId: string): string {
+  return `skill::${skillId}`;
+}
+
+/** The bare skill id of an embedded entry, `null` for other entries. */
+export function embeddedSkillId(entry: VizijBundleGraphEntry): string | null {
+  if (entry.kind !== SKILL_KIND) {
+    return null;
+  }
+  const id = entry.id ?? "";
+  return id.startsWith("skill::") ? id.slice("skill::".length) : id;
+}
+
+interface UseSkillsOptions {
+  /** The open document's bundle — `null` while no face is loaded. */
+  bundle: VizijBundleExtension | null;
+  /** The loader's bundle updater (value or functional form). */
+  updateBundle: (
+    updater:
+      | VizijBundleExtension
+      | null
+      | ((prev: VizijBundleExtension | null) => VizijBundleExtension | null),
+  ) => void;
+}
+
+/**
+ * The skills a face may pin (VIZ-96): the runtime's shipped registry — the
+ * spawnable task-run behaviors behind the device's actions (e.g. the look_at
+ * gaze skill on `/skill/look_at`) — and the toggle that embeds a skill's
+ * fragment into the open GLB (under `skill::<id>`) or removes it. An embedded
+ * copy is the face's pinned override of the deployed runtime's built-in
+ * behavior. Unlike standard profiles, skill fragments are face-independent by
+ * construction (their placeholder `task/*` paths are rewritten per run), so
+ * there is no rig prefix to apply or strip and the embedded spec *is* the
+ * canonical form.
+ */
+export function useSkills({ bundle, updateBundle }: UseSkillsOptions) {
+  const [skills, setSkills] = useState<Skill[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    runtimeSkills()
+      .then((list) => {
+        if (!cancelled) {
+          setSkills(list);
+        }
+      })
+      .catch((error) => {
+        console.error("skills unavailable", error);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const embeddedSkillIds = useMemo(
+    () =>
+      (bundle?.graphs ?? [])
+        .map(embeddedSkillId)
+        .filter((id): id is string => id !== null),
+    [bundle],
+  );
+
+  // Graft `spec` in as `skill::<skillId>` — replace-or-append, so re-import
+  // updates in place.
+  const embedSpec = useCallback(
+    (skillId: string, spec: Record<string, unknown>) => {
+      const entry: VizijBundleGraphEntry = {
+        id: embeddedSkillGraphId(skillId),
+        kind: SKILL_KIND,
+        spec,
+      };
+      updateBundle((prev) => {
+        if (!prev) {
+          return prev;
+        }
+        const graphs = [...(prev.graphs ?? [])];
+        const existing = graphs.findIndex((graph) => graph.id === entry.id);
+        if (existing >= 0) {
+          graphs[existing] = entry;
+        } else {
+          graphs.push(entry);
+        }
+        return { ...prev, graphs };
+      });
+    },
+    [updateBundle],
+  );
+
+  const toggleSkill = useCallback(
+    async (skillId: string, enabled: boolean) => {
+      if (!enabled) {
+        updateBundle((prev) => {
+          if (!prev?.graphs) {
+            return prev;
+          }
+          return {
+            ...prev,
+            graphs: prev.graphs.filter(
+              (graph) => embeddedSkillId(graph) !== skillId,
+            ),
+          };
+        });
+        return;
+      }
+      const spec = await skillSource(skillId);
+      if (!spec) {
+        console.error(`skill ${skillId} unavailable`);
+        return;
+      }
+      embedSpec(skillId, spec as Record<string, unknown>);
+    },
+    [embedSpec, updateBundle],
+  );
+
+  /**
+   * Download the embedded skill fragment as canonical JSON — the embedded
+   * spec verbatim (fragments carry face-independent placeholder paths), so
+   * the file is diffable against, and contributable to, the shipped
+   * built-ins.
+   */
+  const exportSkillJson = useCallback(
+    (skillId: string) => {
+      const entry = (bundle?.graphs ?? []).find(
+        (graph) => embeddedSkillId(graph) === skillId,
+      );
+      if (!entry?.spec) {
+        console.error(`no embedded skill ${skillId} to export`);
+        return;
+      }
+      downloadJsonFile(entry.spec, `${skillId}.json`);
+    },
+    [bundle],
+  );
+
+  /** Replace the embedded skill fragment from a canonical JSON file. */
+  const importSkillJson = useCallback(
+    async (skillId: string, file: File) => {
+      let spec: { nodes?: unknown[]; edges?: unknown[] };
+      try {
+        spec = JSON.parse(await file.text());
+      } catch (error) {
+        console.error(`skill JSON ${file.name} does not parse`, error);
+        return;
+      }
+      if (!Array.isArray(spec.nodes) || !Array.isArray(spec.edges)) {
+        console.error(`skill JSON ${file.name} is not a graph spec`);
+        return;
+      }
+      embedSpec(skillId, spec as Record<string, unknown>);
+    },
+    [embedSpec],
+  );
+
+  return {
+    skills,
+    embeddedSkillIds,
+    toggleSkill,
+    exportSkillJson,
+    importSkillJson,
+    /** Replace an embedded skill's spec in place (the graph editor's
+     * apply-back). */
+    replaceSkillSpec: embedSpec,
+  } as const;
+}

--- a/apps/vizij-standalone/package.json
+++ b/apps/vizij-standalone/package.json
@@ -21,6 +21,7 @@
     "@vizij/node-graph-react": "workspace:*",
     "@vizij/node-graph": "^0.7.0",
     "@vizij/render": "workspace:*",
+    "@vizij/runtime": "^2.4.0",
     "@vizij/runtime-react": "workspace:*",
     "@vizij/speech-react": "workspace:*",
     "@vizij/utils": "workspace:*",

--- a/apps/vizij-standalone/src/components/EndpointsPanel.tsx
+++ b/apps/vizij-standalone/src/components/EndpointsPanel.tsx
@@ -2,13 +2,16 @@
 // (and browser control panel), the optional ROS 2 data-topic bridge, and the
 // optional Semio Studio bridge. It reads the snapshot from the Rust side
 // (`get_endpoints`) and re-polls periodically so the WS running state and the
-// Studio owners (which the owner prompt can change live) stay current.
+// Studio owners (which the owner prompt can change live) stay current. Below
+// the endpoints it lists the runtime's skills — the spawnable behaviors the
+// face ships, from the same registry the authoring app's Skills menu offers.
 //
 // `ros2`/`studio` are present only when the app was built with those features;
 // when absent, their sections simply don't render.
 
 import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { skills as runtimeSkills, type Skill } from "@vizij/runtime";
 
 interface WsEndpoint {
   url: string;
@@ -37,6 +40,21 @@ interface EndpointsInfo {
 
 export function EndpointsPanel({ className }: { className?: string }) {
   const [info, setInfo] = useState<EndpointsInfo | null>(null);
+  const [skills, setSkills] = useState<Skill[]>([]);
+
+  useEffect(() => {
+    let mounted = true;
+    runtimeSkills()
+      .then((list) => {
+        if (mounted) setSkills(list);
+      })
+      .catch(() => {
+        // Registry unavailable (wasm not loaded) — leave the section empty.
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
 
   useEffect(() => {
     let mounted = true;
@@ -114,6 +132,27 @@ export function EndpointsPanel({ className }: { className?: string }) {
               </span>
             )}
           </p>
+        </div>
+      )}
+
+      {skills.length > 0 && (
+        <div className="mt-2" data-testid="endpoints-skills">
+          <span className="font-medium text-neutral-300">Skills</span>
+          {skills.map((skill) => (
+            <div key={skill.id} className="mt-1">
+              <div className="text-neutral-200">
+                {skill.title}{" "}
+                <code className="text-neutral-400">
+                  ({skill.parameters.join(", ")})
+                </code>
+              </div>
+              <div className="text-neutral-500">{skill.description}</div>
+              <div className="text-neutral-500">
+                served as the <code>/skill/{skill.id}</code> action where the
+                device&apos;s bridge exposes the skill plane
+              </div>
+            </div>
+          ))}
         </div>
       )}
     </div>

--- a/packages/@vizij/runtime-react/package.json
+++ b/packages/@vizij/runtime-react/package.json
@@ -41,7 +41,7 @@
     "@vizij/animation-module": "^0.2.0",
     "@vizij/node-graph-authoring": "workspace:*",
     "@vizij/render": "workspace:*",
-    "@vizij/runtime": "^2.3.0",
+    "@vizij/runtime": "^2.4.0",
     "@vizij/utils": "workspace:*",
     "@vizij/value-json": "^0.2.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -489,8 +489,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/@vizij/render
       '@vizij/runtime':
-        specifier: ^2.3.0
-        version: 2.3.0
+        specifier: ^2.4.0
+        version: 2.4.0
       '@vizij/runtime-react':
         specifier: workspace:*
         version: link:../../packages/@vizij/runtime-react
@@ -640,6 +640,9 @@ importers:
       '@vizij/render':
         specifier: workspace:*
         version: link:../../packages/@vizij/render
+      '@vizij/runtime':
+        specifier: ^2.4.0
+        version: 2.4.0
       '@vizij/runtime-react':
         specifier: workspace:*
         version: link:../../packages/@vizij/runtime-react
@@ -910,8 +913,8 @@ importers:
         specifier: workspace:*
         version: link:../render
       '@vizij/runtime':
-        specifier: ^2.3.0
-        version: 2.3.0
+        specifier: ^2.4.0
+        version: 2.4.0
       '@vizij/utils':
         specifier: workspace:*
         version: link:../utils
@@ -2728,8 +2731,8 @@ packages:
   '@vizij/node-graph@0.7.0':
     resolution: {integrity: sha512-8EtlkEQyLlaEjMeQPJK4XmjB+Y/n4FsZ7U2Z2h7j1/Fob03F00kqVQU+O8ncHjODSwpzeMsJ1D/rulMupiydUA==}
 
-  '@vizij/runtime@2.3.0':
-    resolution: {integrity: sha512-WBZ+M4Rp7MY175nDIK5bbfeikX0RINycpmDbPkgsFnYy7IwN7iff9fDeklUH8XX8Pvx+pCs37LdymSPJOk+RMg==}
+  '@vizij/runtime@2.4.0':
+    resolution: {integrity: sha512-+BA6bxpvjOvHueZyRgHo6Z8f+9fbK2xuVgPiwXaE+fZQVE02Qf8gKkpWWQpUrWXphVK5JlwRtbdOLigVz8RClw==}
 
   '@vizij/value-json@0.2.0':
     resolution: {integrity: sha512-1wNxYLm4DPBnkcciIY4YClweIfIQinefMPsE8pQeacv1u8/0ls/Y3+GNCb3Rwa1yvdvKodRFhIf69JE2LsUC1Q==}
@@ -7009,7 +7012,7 @@ snapshots:
       '@vizij/value-json': 0.2.0
       '@vizij/wasm-loader': 0.1.5
 
-  '@vizij/runtime@2.3.0':
+  '@vizij/runtime@2.4.0':
     dependencies:
       '@vizij/value-json': 0.2.0
       '@vizij/wasm-loader': 0.1.5


### PR DESCRIPTION
The vizij-web half of [VIZ-96](https://linear.app/semio-ai/issue/VIZ-96/skills-join-the-profile-surface-standalone-authoring-access-and), on [vizij-rs #93](https://github.com/vizij-ai/vizij-rs/pull/93)'s `@vizij/runtime` 2.4.0 skills API: the authoring app and the standalone get access to and display of the runtime's **skills** — the spawnable behaviors behind the device's actions (the look_at gaze skill on `/skill/look_at`).

## Authoring — File → Skills, mirroring Standard Profiles

- `useSkills` hook + a **File → Skills** submenu: the checkbox embeds a skill's fragment into the open GLB under `skill::<id>` — the face's pinned override of the shipped behavior, which the native device registers in place of the built-in ([vizij-rs #93](https://github.com/vizij-ai/vizij-rs/pull/93)); unchecking removes it.
- **Export as JSON / Replace from JSON** round-trip the canonical fragment. Simpler than profiles by construction: skill fragments are face-independent (placeholder `task/*` paths, rewritten per run at graft time), so there is no rig prefix to apply or strip — the embedded spec *is* the canonical form.
- **Edit in Graph Editor**: an `editingSkillId` session with the same guard rails as profile sessions (program edits parked, target hydration guarded, motion-graph pruning disabled, banner with Apply-to-Skill/Discard).
- `carriedBundleGraphs` already round-trips the `skill` kind through load → export unchanged, so re-imported faces keep their pinned skills.
- **E2e** (`skills.workflow.pw.ts`, passes locally in 49s): embed → the exported GLB carries the real fragment (`skill::look_at`, `task/policy` placeholder intact) → editor session applies back → re-import survives → uncheck removes.

## Standalone — the actions view

The endpoints panel gains a **Skills** section listing the runtime's registry: title, parameters, description, and the `/skill/<id>` action each is served as where the device's bridge exposes the skill plane. (A live served-actions introspection over the shell needs a device-methods command that doesn't exist yet — tracked in VIZ-96.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)