### PR TITLE
fix(authoring): discard saved rig state from another schema generation

### DIFF
--- a/apps/vizij-authoring/e2e/rig-state-gate.workflow.pw.ts
+++ b/apps/vizij-authoring/e2e/rig-state-gate.workflow.pw.ts
@@ -65,7 +65,5 @@ test("a saved rig state from another schema generation is discarded, not applied
     warnings.some((w) => w.includes("discarding the saved authoring state")),
     "the discard is reported on the console",
   ).toBeTruthy();
-  await expect
-    .poll(outputsOf, { timeout: 30_000 })
-    .toBe(baselineOutputs);
+  await expect.poll(outputsOf, { timeout: 30_000 }).toBe(baselineOutputs);
 });

--- a/apps/vizij-authoring/e2e/rig-state-gate.workflow.pw.ts
+++ b/apps/vizij-authoring/e2e/rig-state-gate.workflow.pw.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "@playwright/test";
+import { bootAuthoring, loadMainPreset } from "./helpers";
+
+const STORAGE_KEY = "vizij:rig-authoring:v2";
+
+/** The persisted rig-state map, read from the app's localStorage. */
+async function readSavedStates(
+  page: import("@playwright/test").Page,
+): Promise<Record<string, { schemaVersion?: number }>> {
+  return page.evaluate((key) => {
+    const raw = window.localStorage.getItem(key);
+    return raw ? JSON.parse(raw) : {};
+  }, STORAGE_KEY);
+}
+
+test("a saved rig state from another schema generation is discarded, not applied @workflow", async ({
+  page,
+}) => {
+  const warnings: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "warning") warnings.push(message.text());
+  });
+
+  // A passive load never persists; one real edit does — capture the current
+  // values as a driver, as an authoring session would.
+  await bootAuthoring(page);
+  await loadMainPreset(page, "quori:latest");
+  await page.getByRole("button", { name: "Capture Current" }).click();
+  await expect
+    .poll(async () => Object.keys(await readSavedStates(page)).length, {
+      timeout: 30_000,
+    })
+    .toBeGreaterThan(0);
+  const baseline = await readSavedStates(page);
+  const faceId = Object.keys(baseline)[0]!;
+  const outputsOf = async () =>
+    /outputs: \d+/.exec(
+      (await page.getByTestId("main-runtime-status").textContent()) ?? "",
+    )?.[0];
+  const baselineOutputs = await outputsOf();
+  expect(baselineOutputs, "the baseline run reports its outputs").toBeTruthy();
+
+  // Downgrade the save to a previous generation, as a browser that last
+  // authored before a bundle/schema migration would hold.
+  await page.evaluate(
+    ([key, id]) => {
+      const map = JSON.parse(window.localStorage.getItem(key)!);
+      map[id].schemaVersion = 4;
+      window.localStorage.setItem(key, JSON.stringify(map));
+    },
+    [STORAGE_KEY, faceId] as const,
+  );
+
+  // The reload must refuse the stale save: discard it (visibly), derive the
+  // face fresh from the asset, and re-persist a current-generation state.
+  await page.reload();
+  await bootAuthoring(page);
+  await loadMainPreset(page, "quori:latest");
+  await expect
+    .poll(async () => (await readSavedStates(page))[faceId]?.schemaVersion, {
+      timeout: 30_000,
+    })
+    .not.toBe(4);
+  expect(
+    warnings.some((w) => w.includes("discarding the saved authoring state")),
+    "the discard is reported on the console",
+  ).toBeTruthy();
+  await expect
+    .poll(outputsOf, { timeout: 30_000 })
+    .toBe(baselineOutputs);
+});

--- a/apps/vizij-authoring/src/hooks/useRigPersistence.ts
+++ b/apps/vizij-authoring/src/hooks/useRigPersistence.ts
@@ -32,7 +32,12 @@ import {
   type FeatureFlagState,
 } from "./useFeatureLabels";
 
-const RIG_STATE_SCHEMA_VERSION = 4;
+// The compatibility generation of a saved rig state. A restore is refused
+// across generations (see the load gate below), so bump this whenever the
+// persisted shape OR the meaning of what it stores changes — including
+// bundle-side migrations that re-encode the values a save would re-apply
+// (v5: the assets' embedded values moved to arora serde).
+const RIG_STATE_SCHEMA_VERSION = 5;
 
 interface UseRigPersistenceOptions {
   faceId: string | null;
@@ -308,7 +313,19 @@ export function useRigPersistence({
       return;
     }
 
-    const persisted = loadRigState(faceId);
+    let persisted = loadRigState(faceId);
+    if (persisted && persisted.schemaVersion !== RIG_STATE_SCHEMA_VERSION) {
+      // A save from another generation re-applies bindings and value
+      // encodings the current bundle no longer speaks, corrupting the face
+      // on every load. Start from the asset and forget the stale save.
+      // eslint-disable-next-line no-console -- the drop must be visible
+      console.warn(
+        `[vizij-authoring] discarding the saved authoring state for ${faceId}: ` +
+          `schema v${persisted.schemaVersion ?? 0} (current v${RIG_STATE_SCHEMA_VERSION})`,
+      );
+      deleteRigState(faceId);
+      persisted = null;
+    }
     skipPersistRef.current = true;
     if (persisted) {
       const { autoEntries, legacyCustomInputs, idMismatches } =


### PR DESCRIPTION
**The Quori Latest breakage on main** (black eye-whites, the mouth image driven into a broken reference, missing poses/drivers) was not the asset and not the renderer: the asset is byte-identical since July 13 and a clean profile renders it fine. It was **persistence**: [`useRigPersistence`](apps/vizij-authoring/src/hooks/useRigPersistence.ts) stamps every save with `RIG_STATE_SCHEMA_VERSION` — but the restore never read it. A browser holding a save from an earlier era (in particular from before `5274c71a`, the assets' arora-serde value migration, which changed what a save *means* without bumping the version) silently re-applied stale bindings and value encodings onto today's bundle on every single load.

The fix:
- **The load gates on the schema generation**: a mismatched save is reported on the console (`discarding the saved authoring state for <faceId>…`), deleted, and the face derives fresh from the asset.
- **The version bumps 4 → 5**, retiring every pre-existing save once (they span the un-bumped migration era). The constant now carries the discipline: bump on any change to the persisted shape *or its meaning*, including bundle-side value migrations.
- **E2e** ([rig-state-gate.workflow.pw.ts](apps/vizij-authoring/e2e/rig-state-gate.workflow.pw.ts)): a real edit persists (`quori_latest`), the entry is downgraded to v4, and the reload must discard it, warn, and re-derive with identical outputs. Passing locally (28s); unit suite 733 green; lint clean (the one warning is the pre-existing VariablesPanel one).

No action needed after merge: the very next load of the deployed app discards the stale save by itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)