### PR TITLE
feat(standalone): the device serves its skills — /skill/look_at for real

### DIFF
--- a/apps/vizij-standalone/src-tauri/Cargo.lock
+++ b/apps/vizij-standalone/src-tauri/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "RustyXML"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b5ace29ee3216de37c0546865ad08edef58b0f9e76838ed8959a84a990e58c5"
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +172,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,25 +190,53 @@ dependencies = [
 ]
 
 [[package]]
-name = "arora-bridge"
-version = "4.0.0"
+name = "arora-behavior"
+version = "8.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb06e17e4b19c0655a28086bc52444906784fac5acb95d86cbf7e366c160180a"
+checksum = "f86d18b53a934aa302e725cdc9918ef7370b5eb8e5b3262ce05b794235b57169"
+dependencies = [
+ "arora-types",
+ "semver",
+ "serde",
+ "uuid",
+]
+
+[[package]]
+name = "arora-behavior-tree-types"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ab6baa6ebdc6ff637d5231f6a969a17970ac5aa8959db57e2abf3b09ce9f218"
+dependencies = [
+ "arora-behavior",
+ "arora-types",
+ "lazy_static",
+ "semver",
+ "uuid",
+]
+
+[[package]]
+name = "arora-bridge"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7848310653e25a84361cae07d1131f540b528f959e593e815e3e6a8a8f52859"
 dependencies = [
  "arora-types",
  "async-trait",
  "futures-channel",
  "futures-core",
  "futures-util",
+ "serde",
 ]
 
 [[package]]
 name = "arora-bridge-ros2"
-version = "3.1.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7efc0bc42a2cc0081f2a9028f2fa6f061a02fe80afb34104a4e4fb0afe5fbd1"
+checksum = "cacc94fb7b58235535651cfd8100ff89ea9073a9cb8804124d41fa08173142ab"
 dependencies = [
+ "arora-behavior-tree-types",
  "arora-bridge",
+ "arora-msgs-ros2",
  "arora-types",
  "async-trait",
  "futures",
@@ -222,6 +265,21 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tokio-util",
+]
+
+[[package]]
+name = "arora-msgs-ros2"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1833ed79fe0375bce005c8dc3f66d1a18433c050a72de34bd122e973a8083fc"
+dependencies = [
+ "arora-types",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde-big-array",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -265,10 +323,11 @@ dependencies = [
 
 [[package]]
 name = "arora-types"
-version = "2.0.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "750822222b2135d4c174071e3c781126cea382fe742b170db370937e6c0bf23f"
+checksum = "c506684b156b3872a7960d6e6b509db2277c8d650209b39c35de2da1e82b0abc"
 dependencies = [
+ "arora-types-derive",
  "async-trait",
  "derive_more 2.1.1",
  "indexmap 2.13.0",
@@ -278,6 +337,18 @@ dependencies = [
  "serde",
  "uuid",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "arora-types-derive"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0622342550b0cc1e349e3c09c0c8c374bbe4d5a5c4c4938d40abe076a7c53d51"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "uuid",
 ]
 
 [[package]]
@@ -2430,6 +2501,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3047,6 +3131,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "k"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dce11312d00e40c13f5c5fac13056a134f77944ab87086460ef386eed68ca08"
+dependencies = [
+ "nalgebra",
+ "simba",
+ "thiserror 1.0.69",
+ "tracing",
+ "urdf-rs",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3317,6 +3414,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f607c237553f086e7043417a51df26b2eb899d3caff94e6a67592ff992fedc7"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "md5"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3454,6 +3561,33 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "nalgebra"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb2d0de08694bed883320212c18ee3008576bfe8c306f4c3c4a58b4876998be"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3630,6 +3764,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3660,6 +3803,16 @@ name = "num-iter"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -4297,7 +4450,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.13.0",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -4597,6 +4750,16 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
@@ -4831,6 +4994,12 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rcgen"
@@ -5101,9 +5270,9 @@ dependencies = [
 
 [[package]]
 name = "ros2-client-multi-rmw"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47619bfa11de20638db4075ddbc35d9da492d928346ae3d409bd414fda5dc7c"
+checksum = "c7c88980573e47852ffc5f152dbb1cc63ba7536f19f3da4dac9931f416bbba55"
 dependencies = [
  "async-channel",
  "bstr",
@@ -5433,6 +5602,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "salsa20"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5619,6 +5797,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde-untagged"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5628,6 +5815,18 @@ dependencies = [
  "serde",
  "serde_core",
  "typeid",
+]
+
+[[package]]
+name = "serde-xml-rs"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb3aa78ecda1ebc9ec9847d5d3aba7d618823446a049ba2491940506da6e2782"
+dependencies = [
+ "log",
+ "serde",
+ "thiserror 1.0.69",
+ "xml-rs",
 ]
 
 [[package]]
@@ -5871,6 +6070,19 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "simba"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3fd720c48c53cace224ae62bef1bbff363a70c68c4802a78b5cc6159618176"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
 ]
 
 [[package]]
@@ -7304,6 +7516,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "urdf-rs"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "074515a3e6dc230bbbdcf35830fd71b67b55ae2ac22bc4ff69d89412fc84b830"
+dependencies = [
+ "RustyXML",
+ "quick-xml 0.36.2",
+ "regex",
+ "serde",
+ "serde-xml-rs",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7432,9 +7658,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "vizij-api-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8acbf5941d33b736c3d9b23f3710cff17f33e30d962032248f001a17a23d8bb"
+dependencies = [
+ "arora-types",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "uuid",
+]
+
+[[package]]
+name = "vizij-arora-behavior"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c46394e2aec611a9f6af4129a57239bef5458243b65c055627d88fda66c6cc5"
+dependencies = [
+ "arora-behavior",
+ "arora-behavior-tree-types",
+ "arora-types",
+ "log",
+ "serde",
+ "serde_json",
+ "uuid",
+ "vizij-api-core",
+ "vizij-arora-host",
+ "vizij-graph-core",
+]
+
+[[package]]
+name = "vizij-arora-host"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b4f201387ca8c3988c3980775ffbf095b3612072816e18c8d9e3c7b11c1c2fb"
+dependencies = [
+ "anyhow",
+ "arora-behavior",
+ "log",
+ "serde_json",
+ "uuid",
+ "vizij-api-core",
+]
+
+[[package]]
+name = "vizij-graph-core"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7adb72b7cbfdc48cdea42f1db2318298beca1f11720994f095f6f168abe6ca27"
+dependencies = [
+ "anyhow",
+ "arora-behavior",
+ "hashbrown 0.17.1",
+ "k",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "urdf-rs",
+ "uuid",
+ "vizij-api-core",
+]
+
+[[package]]
 name = "vizij-standalone"
 version = "0.1.0"
 dependencies = [
+ "arora-behavior",
  "arora-bridge",
  "arora-bridge-ros2",
  "arora-bridge-ws",
@@ -7461,6 +7752,9 @@ dependencies = [
  "tauri-plugin-log",
  "tokio",
  "tokio-util",
+ "vizij-arora-behavior",
+ "vizij-arora-host",
+ "vizij-graph-core",
  "windows 0.58.0",
 ]
 
@@ -7712,6 +8006,16 @@ dependencies = [
  "thiserror 2.0.18",
  "windows 0.61.3",
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]
@@ -8407,6 +8711,12 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
 ]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xxhash-rust"

--- a/apps/vizij-standalone/src-tauri/Cargo.lock
+++ b/apps/vizij-standalone/src-tauri/Cargo.lock
@@ -116,6 +116,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +199,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "arora"
+version = "9.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6738bed54ff23986e4735ca7d48439a5f71d03f40cc8eb73b4350c4c972dbd1"
+dependencies = [
+ "anyhow",
+ "arora-behavior",
+ "arora-behavior-tree",
+ "arora-bridge",
+ "arora-engine",
+ "arora-hal",
+ "arora-simple-data-store",
+ "arora-types",
+ "futures",
+ "gloo-timers",
+ "log",
+ "tokio",
+ "uuid",
+ "web-time",
+]
+
+[[package]]
 name = "arora-behavior"
 version = "8.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +229,29 @@ dependencies = [
  "arora-types",
  "semver",
  "serde",
+ "uuid",
+]
+
+[[package]]
+name = "arora-behavior-tree"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e765bed1cd96ecc8d160e45baecc7237a87953c918b3e956f6c4b0ec017512a"
+dependencies = [
+ "anyhow",
+ "arora-behavior",
+ "arora-behavior-tree-types",
+ "arora-buffers",
+ "arora-module-rust",
+ "arora-registry",
+ "arora-types",
+ "derive_more 2.1.1",
+ "lazy_static",
+ "quick-xml 0.40.1",
+ "semver",
+ "serde",
+ "serde_yaml",
+ "tokio",
  "uuid",
 ]
 
@@ -268,6 +322,106 @@ dependencies = [
 ]
 
 [[package]]
+name = "arora-buffers"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ce00d45413fbb68ac324475a7fd495d5da1983cdec98d3d7e11ac60f47524b"
+dependencies = [
+ "arora-types",
+ "bytes",
+ "cbindgen 0.20.0",
+ "serde",
+ "serde_yaml",
+ "uuid",
+]
+
+[[package]]
+name = "arora-engine"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd685c0799d615dd23d5931cf8e4548058f980f1af1f0a9c0ed99101c3f2ae70"
+dependencies = [
+ "anyhow",
+ "arora-buffers",
+ "arora-types",
+ "async-trait",
+ "bytes",
+ "cbindgen 0.29.4",
+ "console_error_panic_hook",
+ "derive_more 2.1.1",
+ "getrandom 0.4.3",
+ "js-sys",
+ "lazy_static",
+ "rand 0.10.2",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "uuid",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "arora-hal"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3bbdcf56318450a5601d25db2d23ace3a582ebfacddfb17353b9d3b78d0a739"
+dependencies = [
+ "arora-types",
+ "async-trait",
+ "futures-channel",
+ "futures-core",
+]
+
+[[package]]
+name = "arora-module-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e254adb2d910455e3116db83bc08ce0f40886b760d709062bf2ae21341619883"
+dependencies = [
+ "arora-registry",
+ "arora-types",
+ "arora-vfs",
+ "bytes",
+ "convert_case 0.11.0",
+ "derive_more 2.1.1",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "arora-module-rust"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445833061354fcc19f6efeec0902b6b15eb1cc7b0c09036ecb4e386bf166b180"
+dependencies = [
+ "anyhow",
+ "arora-module-core",
+ "arora-registry",
+ "arora-types",
+ "arora-vfs",
+ "async-recursion",
+ "clap 3.2.25",
+ "convert_case 0.11.0",
+ "derive_more 2.1.1",
+ "itertools",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "arora-msgs-ros2"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,6 +434,24 @@ dependencies = [
  "serde-big-array",
  "serde_json",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "arora-registry"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c9d15505c15804abd15226a6f0112d68d20c3d0bb93826890cbaa5ea8722cef"
+dependencies = [
+ "anyhow",
+ "arora-types",
+ "async-trait",
+ "derive_more 2.1.1",
+ "semver",
+ "serde",
+ "serde_yaml",
+ "tokio",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -349,6 +521,18 @@ dependencies = [
  "quote",
  "syn 2.0.114",
  "uuid",
+]
+
+[[package]]
+name = "arora-vfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c007ee20c55b8c04e5cfa56fa704b29cb35f2f3bfa4d654dcb7874a74f6a5130"
+dependencies = [
+ "async-recursion",
+ "derive_more 2.1.1",
+ "serde",
+ "sha2",
 ]
 
 [[package]]
@@ -427,6 +611,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,6 +682,17 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "autocfg"
@@ -851,6 +1057,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbindgen"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e3973b165dc0f435831a9e426de67e894de532754ff7a3f307c03ee5dec7dc"
+dependencies = [
+ "clap 2.34.0",
+ "heck 0.3.3",
+ "indexmap 1.9.3",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 1.0.109",
+ "tempfile",
+ "toml 0.5.11",
+]
+
+[[package]]
+name = "cbindgen"
+version = "0.29.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ecb53484c9c167ba674026b656d8a27d7657a58e6066aa902bfb1a4aa00ae20"
+dependencies = [
+ "clap 4.5.54",
+ "heck 0.5.0",
+ "indexmap 2.13.0",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 2.0.114",
+ "tempfile",
+ "toml 0.9.11+spec-1.1.0",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,12 +1239,44 @@ dependencies = [
 
 [[package]]
 name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags 1.3.2",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+dependencies = [
+ "atty",
+ "bitflags 1.3.2",
+ "clap_derive 3.2.25",
+ "clap_lex 0.2.4",
+ "indexmap 1.9.3",
+ "once_cell",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap 0.16.2",
+]
+
+[[package]]
+name = "clap"
 version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
 dependencies = [
  "clap_builder",
- "clap_derive",
+ "clap_derive 4.5.49",
 ]
 
 [[package]]
@@ -1011,8 +1287,21 @@ checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex",
- "strsim",
+ "clap_lex 0.7.7",
+ "strsim 0.11.1",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1025,6 +1314,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -1114,6 +1412,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if 1.0.4",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1160,6 +1468,15 @@ name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -1390,7 +1707,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.114",
 ]
 
@@ -1404,7 +1721,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.114",
 ]
 
@@ -2380,6 +2697,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "gobject-sys"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2515,6 +2844,15 @@ dependencies = [
 
 [[package]]
 name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
@@ -2524,6 +2862,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -3834,7 +4181,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.5.2",
  "libc",
 ]
 
@@ -4039,6 +4386,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "pango"
@@ -4768,6 +5121,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5250,7 +5612,7 @@ dependencies = [
  "bytes",
  "cdr-encoding-size",
  "chrono",
- "clap",
+ "clap 4.5.54",
  "futures",
  "itertools",
  "lazy_static",
@@ -5281,7 +5643,7 @@ dependencies = [
  "cdr-encoding 0.10.2",
  "cdr-encoding-size",
  "chrono",
- "clap",
+ "clap 4.5.54",
  "futures",
  "itertools",
  "lazy_static",
@@ -5818,6 +6180,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde-xml-rs"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6349,6 +6722,18 @@ dependencies = [
 
 [[package]]
 name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -6847,6 +7232,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "tendril"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6856,6 +7254,30 @@ dependencies = [
  "mac",
  "utf-8",
 ]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 
 [[package]]
 name = "thiserror"
@@ -7060,6 +7482,15 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -7477,6 +7908,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7725,6 +8162,7 @@ dependencies = [
 name = "vizij-standalone"
 version = "0.1.0"
 dependencies = [
+ "arora",
  "arora-behavior",
  "arora-bridge",
  "arora-bridge-ros2",
@@ -7734,7 +8172,7 @@ dependencies = [
  "arora-types",
  "async-trait",
  "base64 0.22.1",
- "clap",
+ "clap 4.5.54",
  "crypto_secretbox",
  "dotenvy",
  "futures-util",

--- a/apps/vizij-standalone/src-tauri/Cargo.toml
+++ b/apps/vizij-standalone/src-tauri/Cargo.toml
@@ -20,13 +20,22 @@ tauri-build = { version = "2.5.6", features = [] }
 # standalone stays on the stable toolchain. (Depending on `arora`/`arora-engine`
 # would drag in their `artifact = "cdylib"` dev-bindeps, which need a nightly
 # `-Z bindeps` toolchain even to resolve.)
-arora-bridge = "4"
+arora-bridge = "4.1"
 arora-bridge-ws = "4"
 # The dual-backend ROS 2 bridge: DDS (default) or the rmw_zenoh-compatible Zenoh
-# backend, selected by this crate's `ros2-dds` / `ros2-zenoh` features.
-arora-bridge-ros2 = { version = "3.1", optional = true, default-features = false }
+# backend, selected by this crate's `ros2-dds` / `ros2-zenoh` features. 5 adds
+# the skill plane the ROS4HRI exposure profile binds `/skill/look_at` through.
+arora-bridge-ros2 = { version = "5", optional = true, default-features = false }
 arora-simple-data-store = "2"
 arora-types = "2"
+# The behavior-interpreter seam (trait, interpreter-module ABI, built-in keys):
+# the host runs a `ProcessingGraph` against the shared store, so the device
+# SERVES its skills — still no `arora` engine, still plain stable.
+arora-behavior = "8"
+# Vizij's graph interpreter and the gaze skill's contract + shipped fragment.
+vizij-arora-behavior = "1"
+vizij-arora-host = "1"
+vizij-graph-core = "1"
 # Opt-in (`studio-bridge` feature): the studio-bridge Zenoh device client — the
 # same `ZenohDeviceClient` arora uses for its Studio connection, which implements
 # arora's `Bridge`. A plain crates.io crate (no artifact bindeps).

--- a/apps/vizij-standalone/src-tauri/Cargo.toml
+++ b/apps/vizij-standalone/src-tauri/Cargo.toml
@@ -13,13 +13,11 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2.5.6", features = [] }
 
 [dependencies]
-# Multi-bridge host on plain stable: one `SimpleDataStore` blackboard with
-# several `arora_bridge::Bridge` endpoints attached (WebSocket + optional ROS 2
-# + optional Studio), plus a hand-rolled pump. These published crates depend
-# only on `arora-types`/`arora-bridge` — NOT the `arora` engine — so the whole
-# standalone stays on the stable toolchain. (Depending on `arora`/`arora-engine`
-# would drag in their `artifact = "cdylib"` dev-bindeps, which need a nightly
-# `-Z bindeps` toolchain even to resolve.)
+# The device host on plain stable: one `SimpleDataStore` blackboard, ONE
+# `arora` run (its portable slice) owning the interpreter, the modules, and
+# the WS/ROS 2 bridge pumps, plus the opt-in Studio bridge on its own thread
+# (it re-registers live as owners change). The published arora carries no
+# artifact bindeps, so stable is enough.
 arora-bridge = "4.1"
 arora-bridge-ws = "4"
 # The dual-backend ROS 2 bridge: DDS (default) or the rmw_zenoh-compatible Zenoh
@@ -28,9 +26,12 @@ arora-bridge-ws = "4"
 arora-bridge-ros2 = { version = "5", optional = true, default-features = false }
 arora-simple-data-store = "2"
 arora-types = "2"
-# The behavior-interpreter seam (trait, interpreter-module ABI, built-in keys):
-# the host runs a `ProcessingGraph` against the shared store, so the device
-# SERVES its skills — still no `arora` engine, still plain stable.
+# The device engine, in its portable slice (no `native` feature: no wasmtime,
+# no TUI — the same wasmtime-free core the browser runtime builds on, so the
+# Android targets stay buildable). ONE arora run owns the interpreter, the
+# modules, the built-in keys, and every bridge pump.
+arora = { version = "9.11.1", default-features = false }
+# The behavior-interpreter seam (trait, interpreter-module ABI, built-in keys).
 arora-behavior = "8"
 # Vizij's graph interpreter and the gaze skill's contract + shipped fragment.
 vizij-arora-behavior = "1"

--- a/apps/vizij-standalone/src-tauri/src/host.rs
+++ b/apps/vizij-standalone/src-tauri/src/host.rs
@@ -38,6 +38,8 @@ use log::{debug, info, warn};
 use tauri::{AppHandle, Emitter};
 use tokio_util::sync::CancellationToken;
 
+use crate::skills::SharedSkillHost;
+
 /// Drive a set of bridge endpoints against a shared store until `cancel` fires
 /// (or every endpoint disconnects).
 ///
@@ -48,6 +50,7 @@ use tokio_util::sync::CancellationToken;
 pub async fn run_pump(
     store: SimpleDataStore,
     app: AppHandle,
+    skills: SharedSkillHost,
     mut bridges: Vec<Box<dyn Bridge>>,
     cancel: CancellationToken,
 ) {
@@ -87,7 +90,7 @@ pub async fn run_pump(
             }
             maybe_event = inbound.next() => {
                 match maybe_event {
-                    Some(event) => handle_inbound(&store, &app, event),
+                    Some(event) => handle_inbound(&store, &app, &skills, event),
                     // Every endpoint's inbound stream ended: all disconnected.
                     None => break,
                 }
@@ -105,7 +108,12 @@ pub async fn run_pump(
 /// enumerates the live keys. Note the webview mirror (the `publish_values`
 /// command) writes to the store WITHOUT going through here, so its own values
 /// are never echoed back to it as `update-values`.
-pub fn handle_inbound(store: &SimpleDataStore, app: &AppHandle, event: Inbound) {
+pub fn handle_inbound(
+    store: &SimpleDataStore,
+    app: &AppHandle,
+    skills: &SharedSkillHost,
+    event: Inbound,
+) {
     match event {
         Inbound::Command(cmd) => {
             let result = match &cmd.op {
@@ -145,13 +153,35 @@ pub fn handle_inbound(store: &SimpleDataStore, app: &AppHandle, event: Inbound) 
                         mutated: Vec::new(),
                     })
                 }
-                // Methods live on the WS registry, not the store, and this host
-                // runs no engine, so there is nothing to enumerate/dispatch here.
-                BridgeOp::ListMethods { .. } => Ok(CallResult {
-                    ret: Value::ArrayValue(Vec::new()),
-                    mutated: Vec::new(),
-                }),
-                BridgeOp::Call(_) => Err("calls are not supported by this host".to_string()),
+                // The skill plane: the described methods and the interpreter
+                // module's SPAWN/HALT, served by the graph interpreter
+                // ([`crate::skills`]). This is what a ROS 2 bridge's ROS4HRI
+                // profile binds `/skill/look_at` through. (The WS-registry app
+                // methods — reset, speak, transport — are a separate surface.)
+                #[allow(deprecated)] // ListMethods stays answered for old callers.
+                BridgeOp::ListMethods { prefix } => match skills.lock() {
+                    Ok(host) => Ok(CallResult {
+                        ret: Value::ArrayValue(
+                            host.method_names(prefix.as_deref())
+                                .into_iter()
+                                .map(Value::String)
+                                .collect(),
+                        ),
+                        mutated: Vec::new(),
+                    }),
+                    Err(_) => Err("the skill host is unavailable".to_string()),
+                },
+                BridgeOp::DescribeMethods { prefix } => match skills.lock() {
+                    Ok(host) => Ok(CallResult {
+                        ret: host.signatures(prefix.as_deref()),
+                        mutated: Vec::new(),
+                    }),
+                    Err(_) => Err("the skill host is unavailable".to_string()),
+                },
+                BridgeOp::Call(call) => match skills.lock() {
+                    Ok(mut host) => host.dispatch(call),
+                    Err(_) => Err("the skill host is unavailable".to_string()),
+                },
             };
             cmd.reply(result);
         }

--- a/apps/vizij-standalone/src-tauri/src/host.rs
+++ b/apps/vizij-standalone/src-tauri/src/host.rs
@@ -1,130 +1,35 @@
-//! The multi-bridge host.
+//! The Studio pump's plumbing.
 //!
-//! One [`SimpleDataStore`] is the device's blackboard; several
-//! [`arora_bridge::Bridge`] endpoints attach to it — a WebSocket bridge
-//! ([`arora_bridge_ws`]), an optional ROS 2 data-topic bridge
-//! ([`arora_bridge_ros2`]), and (built in `lib.rs`) the Studio Zenoh bridge —
-//! each sharing the SAME store.
-//!
-//! This module reimplements arora's multi-bridge write/read loop on plain
-//! stable, without the engine or a HAL (so it never touches the nightly
-//! `-Z bindeps` toolchain arora's `run_with_*` would pull in): each endpoint's
-//! inbound stream is taken once and merged with `select_all`; inbound `Update`s
-//! are applied to the store (and mirrored to the webview via the `update-values`
-//! Tauri event) and `Get`s answered from it; and every store change is fanned
-//! back out to every attached endpoint through `try_send`.
-//!
-//! # Why several small pumps rather than one
-//!
-//! The store is `Clone`-to-share (clones back the same storage), so each pump
-//! subscribes to the same blackboard and cross-pump propagation happens for
-//! free: a write from any endpoint notifies every pump's subscription. Splitting
-//! the pumps lets each bridge follow its own lifecycle — the WS bridge's
-//! handlers must be registered *before* the server starts serving (the serve
-//! loop snapshots them once), the ROS 2 bridge must be rebuilt when the input
-//! key set changes (a ROS 2 topic is typed and declared up front), and the
-//! Studio bridge lives for the whole process on its own thread. One shared store
-//! is the spine; [`run_pump`] is the reusable body.
+//! The device itself is ONE `arora` run (built in `lib.rs`): the interpreter,
+//! the modules, the built-in keys, and the WS/ROS 2 bridge pumps all live
+//! there. Only the Studio bridge stays outside the run, on its own thread —
+//! its device registration follows the in-UI owner prompt live, a lifecycle
+//! the run does not model — and this module is its inbound handler: `Update`s
+//! land in the shared store (the store-mirror thread forwards them to the
+//! webview; the store's subscription fans them to the run's bridges), `Get`s
+//! and `ListKeys` answer from it, and the method plane defers to the run.
 
-use std::collections::HashMap;
-
-use arora_bridge::{AccessDecision, AccessRequestStream, Bridge, BridgeOp, Inbound};
+use arora_bridge::{AccessDecision, AccessRequestStream, BridgeOp, Inbound};
 use arora_simple_data_store::SimpleDataStore;
 use arora_types::call::CallResult;
-use arora_types::data::{DataStore, StateChange};
+use arora_types::data::DataStore;
 use arora_types::value::Value;
-use futures_util::stream::{select_all, StreamExt};
+use futures_util::stream::StreamExt;
 use log::{debug, info, warn};
-use tauri::{AppHandle, Emitter};
 use tokio_util::sync::CancellationToken;
 
-use crate::skills::SharedSkillHost;
-
-/// Drive a set of bridge endpoints against a shared store until `cancel` fires
-/// (or every endpoint disconnects).
-///
-/// This is the hand-rolled equivalent of arora's step loop restricted to the
-/// bridge seam (no HAL, no behavior, no engine): merge every endpoint's inbound
-/// stream, apply its commands to the store (mirroring writes to the webview),
-/// and fan every store change back out to every endpoint.
-pub async fn run_pump(
-    store: SimpleDataStore,
-    app: AppHandle,
-    skills: SharedSkillHost,
-    mut bridges: Vec<Box<dyn Bridge>>,
-    cancel: CancellationToken,
-) {
-    // Take each endpoint's inbound stream once (the take-once seam), then merge.
-    let streams: Vec<_> = bridges.iter_mut().map(|b| b.take_inbound()).collect();
-    let mut inbound = select_all(streams);
-
-    // Bridge the store's std-channel subscription into an async channel so the
-    // select loop can await state changes alongside the inbound stream. The
-    // forwarding thread ends when the pump is torn down (its send fails once the
-    // receiver is dropped), which drops the `Subscription` and prunes it from
-    // the store.
-    let subscription = store.subscribe();
-    let (change_tx, mut change_rx) = tokio::sync::mpsc::unbounded_channel::<StateChange>();
-    std::thread::spawn(move || {
-        while let Some(change) = subscription.recv() {
-            if change_tx.send(change).is_err() {
-                break;
-            }
-        }
-    });
-
-    loop {
-        tokio::select! {
-            _ = cancel.cancelled() => break,
-            maybe_change = change_rx.recv() => {
-                match maybe_change {
-                    // Phase 6b — fan the change out to every endpoint. Each
-                    // buffers onto its own transport; none blocks.
-                    Some(change) => {
-                        for bridge in bridges.iter_mut() {
-                            bridge.try_send(&change);
-                        }
-                    }
-                    None => break,
-                }
-            }
-            maybe_event = inbound.next() => {
-                match maybe_event {
-                    Some(event) => handle_inbound(&store, &app, &skills, event),
-                    // Every endpoint's inbound stream ended: all disconnected.
-                    None => break,
-                }
-            }
-        }
-    }
-}
-
-/// Apply one inbound event against the store, mirroring writes to the webview.
-///
-/// Shared by every pump ([`run_pump`] here and the Studio pump in `lib.rs`).
-/// `Update`s land in the store (which fans them to every endpoint via the
-/// subscription) and are emitted to the webview as `update-values` so the wasm
-/// runtime applies them; `Get`s are answered from the store; `ListKeys`
-/// enumerates the live keys. Note the webview mirror (the `publish_values`
-/// command) writes to the store WITHOUT going through here, so its own values
-/// are never echoed back to it as `update-values`.
-pub fn handle_inbound(
-    store: &SimpleDataStore,
-    app: &AppHandle,
-    skills: &SharedSkillHost,
-    event: Inbound,
-) {
+/// Apply one inbound Studio event against the shared store.
+pub fn handle_inbound(store: &SimpleDataStore, event: Inbound) {
     match event {
         Inbound::Command(cmd) => {
             let result = match &cmd.op {
                 BridgeOp::Update(change) => match store.write(change.clone()) {
-                    Ok(()) => {
-                        emit_update_values(app, change);
-                        Ok(CallResult {
-                            ret: Value::Unit,
-                            mutated: Vec::new(),
-                        })
-                    }
+                    // The store-mirror thread forwards the change to the
+                    // webview — one path for every writer.
+                    Ok(()) => Ok(CallResult {
+                        ret: Value::Unit,
+                        mutated: Vec::new(),
+                    }),
                     Err(e) => Err(e.to_string()),
                 },
                 BridgeOp::Get(keys) => {
@@ -153,35 +58,19 @@ pub fn handle_inbound(
                         mutated: Vec::new(),
                     })
                 }
-                // The skill plane: the described methods and the interpreter
-                // module's SPAWN/HALT, served by the graph interpreter
-                // ([`crate::skills`]). This is what a ROS 2 bridge's ROS4HRI
-                // profile binds `/skill/look_at` through. (The WS-registry app
-                // methods — reset, speak, transport — are a separate surface.)
-                #[allow(deprecated)] // ListMethods stays answered for old callers.
-                BridgeOp::ListMethods { prefix } => match skills.lock() {
-                    Ok(host) => Ok(CallResult {
-                        ret: Value::ArrayValue(
-                            host.method_names(prefix.as_deref())
-                                .into_iter()
-                                .map(Value::String)
-                                .collect(),
-                        ),
-                        mutated: Vec::new(),
-                    }),
-                    Err(_) => Err("the skill host is unavailable".to_string()),
-                },
-                BridgeOp::DescribeMethods { prefix } => match skills.lock() {
-                    Ok(host) => Ok(CallResult {
-                        ret: host.signatures(prefix.as_deref()),
-                        mutated: Vec::new(),
-                    }),
-                    Err(_) => Err("the skill host is unavailable".to_string()),
-                },
-                BridgeOp::Call(call) => match skills.lock() {
-                    Ok(mut host) => host.dispatch(call),
-                    Err(_) => Err("the skill host is unavailable".to_string()),
-                },
+                // The method plane (ListMethods/DescribeMethods/Call) lives on
+                // the device run's bridges; this pump serves the Studio data
+                // plane only.
+                #[allow(deprecated)]
+                BridgeOp::ListMethods { .. } => Ok(CallResult {
+                    ret: Value::ArrayValue(Vec::new()),
+                    mutated: Vec::new(),
+                }),
+                BridgeOp::DescribeMethods { .. } => Ok(CallResult {
+                    ret: Value::ArrayValue(Vec::new()),
+                    mutated: Vec::new(),
+                }),
+                BridgeOp::Call(_) => Err("calls are not served on this endpoint".to_string()),
             };
             cmd.reply(result);
         }
@@ -191,23 +80,6 @@ pub fn handle_inbound(
         Inbound::DeviceInfo(Ok(Some(_info))) => {}
         Inbound::DeviceInfo(Err(e)) => warn!("bridge endpoint error: {e}"),
         Inbound::DataRequested(requested) => debug!("bridge data requested: {requested}"),
-    }
-}
-
-/// Mirror the `set` side of a change to the webview as an `update-values` event,
-/// so the wasm runtime applies remote writes. Unset keys have no webview
-/// representation and are dropped.
-fn emit_update_values(app: &AppHandle, change: &StateChange) {
-    let mut values: HashMap<String, Value> = HashMap::new();
-    for (key, value) in &change.set {
-        if let Some(value) = value {
-            values.insert(key.path.clone(), value.clone());
-        }
-    }
-    if !values.is_empty() {
-        if let Err(e) = app.emit("update-values", &values) {
-            warn!("failed to emit update-values: {e}");
-        }
     }
 }
 

--- a/apps/vizij-standalone/src-tauri/src/lib.rs
+++ b/apps/vizij-standalone/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ use arora_simple_data_store::SimpleDataStore;
 use arora_types::data::{DataStore, Key, StateChange};
 
 mod host;
+mod skills;
 
 /// Application state.
 ///
@@ -27,6 +28,9 @@ mod host;
 struct AppState {
     /// The one shared blackboard every bridge reads/writes. Clones share storage.
     store: SimpleDataStore,
+    /// The graph interpreter serving the device's skills (`/skill/look_at`),
+    /// ticked for the whole process and dispatched to by every pump.
+    skills: skills::SharedSkillHost,
     /// The WebSocket server (`arora-bridge-ws`), created once for the process. Its
     /// registry (advertised keys + methods) is updated live; the serve loop is
     /// started/stopped under `cancel_token`.
@@ -568,6 +572,7 @@ fn transport_stop(app: &AppHandle, args: &HashMap<String, Value>) -> InvokeResul
 /// auto-allow access server per bridge, then [`host::run_pump`] itself.
 fn spawn_bridge_pump(app: &AppHandle, bridges: Vec<Box<dyn Bridge>>, cancel: CancellationToken) {
     let store = app.state::<AppState>().store.clone();
+    let skills = app.state::<AppState>().skills.clone();
     let app = app.clone();
     tauri::async_runtime::spawn(async move {
         for bridge in &bridges {
@@ -577,7 +582,7 @@ fn spawn_bridge_pump(app: &AppHandle, bridges: Vec<Box<dyn Bridge>>, cancel: Can
                 cancel.child_token(),
             ));
         }
-        host::run_pump(store, app, bridges, cancel).await;
+        host::run_pump(store, app, skills, bridges, cancel).await;
     });
 }
 
@@ -682,7 +687,11 @@ async fn respawn_ros2(app: &AppHandle) {
     let config = {
         let state = app.state::<AppState>();
         let keys = state.keys.lock().unwrap();
-        let mut config = Ros2BridgeConfig::new(state.ros2_namespace.clone(), state.ros2_domain_id);
+        // The ROS4HRI exposure preset: the typed face topics and the
+        // `/skill/look_at` action binding, resolved against this host's
+        // described methods at bridge startup.
+        let mut config = Ros2BridgeConfig::new(state.ros2_namespace.clone(), state.ros2_domain_id)
+            .with_profile(arora_bridge_ros2::ExposureProfile::ros4hri());
         for key in keys.iter() {
             // Only input keys accept inbound commands (become subscribed topics);
             // outputs are published on demand from `try_send`.
@@ -899,7 +908,9 @@ async fn run_studio_pump(
     let on_error = move |message: String| {
         let _ = error_app.emit(STUDIO_BRIDGE_ERROR_EVENT, message);
     };
-    let on_inbound = move |store: &SimpleDataStore, event| host::handle_inbound(store, &app, event);
+    let skills = app.state::<AppState>().skills.clone();
+    let on_inbound =
+        move |store: &SimpleDataStore, event| host::handle_inbound(store, &app, &skills, event);
     run_studio_pump_core(
         store,
         bridge,
@@ -1530,8 +1541,27 @@ pub fn run() {
                 )
             };
 
+            // The skill plane: the graph interpreter serving /skill/look_at,
+            // ticked against the shared store for the whole process.
+            let skills: skills::SharedSkillHost =
+                std::sync::Arc::new(StdMutex::new(skills::SkillHost::new()));
+            {
+                let skills = skills.clone();
+                let store = store.clone();
+                std::thread::Builder::new()
+                    .name("skill-tick".into())
+                    .spawn(move || loop {
+                        if let Ok(mut host) = skills.lock() {
+                            host.tick(&store);
+                        }
+                        std::thread::sleep(std::time::Duration::from_millis(30));
+                    })
+                    .expect("failed to spawn the skill tick thread");
+            }
+
             app.manage(AppState {
                 store: store.clone(),
+                skills,
                 ws_server,
                 cancel_token: StdMutex::new(None),
                 #[cfg(feature = "ros2")]

--- a/apps/vizij-standalone/src-tauri/src/lib.rs
+++ b/apps/vizij-standalone/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ use std::sync::{Arc, Mutex as StdMutex};
 use tauri::{AppHandle, Emitter, Manager};
 use tokio_util::sync::CancellationToken;
 
+#[cfg(feature = "studio-bridge")]
 use arora_bridge::Bridge;
 use arora_bridge_ws::bridge::WsBridge;
 use arora_bridge_ws::{
@@ -15,6 +16,7 @@ use arora_bridge_ws::{
 use arora_simple_data_store::SimpleDataStore;
 use arora_types::data::{DataStore, Key, StateChange};
 
+#[cfg(feature = "studio-bridge")]
 mod host;
 mod skills;
 
@@ -28,9 +30,6 @@ mod skills;
 struct AppState {
     /// The one shared blackboard every bridge reads/writes. Clones share storage.
     store: SimpleDataStore,
-    /// The graph interpreter serving the device's skills (`/skill/look_at`),
-    /// ticked for the whole process and dispatched to by every pump.
-    skills: skills::SharedSkillHost,
     /// The WebSocket server (`arora-bridge-ws`), created once for the process. Its
     /// registry (advertised keys + methods) is updated live; the serve loop is
     /// started/stopped under `cancel_token`.
@@ -38,10 +37,6 @@ struct AppState {
     /// Governs the WS serve loop and the WS bridge pump (the start/stop lifecycle).
     /// `Some` iff the host is running.
     cancel_token: StdMutex<Option<CancellationToken>>,
-    /// Governs the ROS 2 bridge pump. Replaced whenever the input-key catalog
-    /// changes (a ROS 2 topic is typed and its inputs are declared up front).
-    #[cfg(feature = "ros2")]
-    ros2_token: StdMutex<Option<CancellationToken>>,
     #[cfg(feature = "ros2")]
     ros2_domain_id: u16,
     #[cfg(feature = "ros2")]
@@ -568,24 +563,6 @@ fn transport_stop(app: &AppHandle, args: &HashMap<String, Value>) -> InvokeResul
 // Bridge host lifecycle
 // =============================================================================
 
-/// Spawn a pump for one set of bridge endpoints against the shared store: an
-/// auto-allow access server per bridge, then [`host::run_pump`] itself.
-fn spawn_bridge_pump(app: &AppHandle, bridges: Vec<Box<dyn Bridge>>, cancel: CancellationToken) {
-    let store = app.state::<AppState>().store.clone();
-    let skills = app.state::<AppState>().skills.clone();
-    let app = app.clone();
-    tauri::async_runtime::spawn(async move {
-        for bridge in &bridges {
-            let requests = bridge.access_requests().await;
-            tauri::async_runtime::spawn(host::serve_access_auto_allow(
-                requests,
-                cancel.child_token(),
-            ));
-        }
-        host::run_pump(store, app, skills, bridges, cancel).await;
-    });
-}
-
 /// Start the bridge host: register the WS methods, bind + serve the WS server,
 /// and spawn the WS pump (plus the ROS 2 pump). Idempotent — returns `Ok` if the
 /// host is already running. The Studio bridge is independent (its own thread) and
@@ -635,12 +612,72 @@ async fn start_host(app: &AppHandle, emit_started: bool) -> Result<(), String> {
         });
     }
 
-    // WS pump — owns the WS bridge's inbound stream; ends when the server stops.
-    spawn_bridge_pump(app, vec![Box::new(ws_bridge)], cancel.child_token());
-
-    // ROS 2 pump — built from the current key catalog.
-    #[cfg(feature = "ros2")]
-    respawn_ros2(app).await;
+    // The device: ONE arora run owns the interpreter (the look_at fragment),
+    // the gaze module, the built-in keys, and every bridge pump — the engine
+    // seams this host used to hand-roll. Built inside its own thread (an
+    // `Arora` is single-owner and not `Send`), stopped through the host's
+    // cancel token.
+    {
+        let store = app.state::<AppState>().store.clone();
+        #[cfg(feature = "ros2")]
+        let ros2_parts = {
+            let state = app.state::<AppState>();
+            let keys = state.keys.lock().unwrap().clone();
+            (state.ros2_namespace.clone(), state.ros2_domain_id, keys)
+        };
+        let device_cancel = cancel.child_token();
+        std::thread::Builder::new()
+            .name("arora-device".into())
+            .spawn(move || {
+                let rt = match tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                {
+                    Ok(rt) => rt,
+                    Err(e) => return log::error!("device runtime: {e}"),
+                };
+                rt.block_on(async move {
+                    #[cfg_attr(not(feature = "ros2"), allow(unused_mut))]
+                    let mut builder = arora::Arora::builder()
+                        .with_data_store(Box::new(store))
+                        .with_host_module(skills::gaze_module())
+                        .with_behavior_interpreter(Box::new(skills::interpreter()))
+                        .with_bridge(Box::new(ws_bridge));
+                    #[cfg(feature = "ros2")]
+                    {
+                        use arora_bridge_ros2::{ExposureProfile, Ros2Bridge, Ros2BridgeConfig};
+                        let (namespace, domain_id, keys) = ros2_parts;
+                        // The ROS4HRI exposure preset: the typed face topics
+                        // and the /skill/look_at action binding, resolved
+                        // against this device's described methods at startup.
+                        let mut config = Ros2BridgeConfig::new(namespace, domain_id)
+                            .with_profile(ExposureProfile::ros4hri());
+                        for key in &keys {
+                            // Only input keys accept inbound commands (become
+                            // subscribed topics); outputs publish on demand.
+                            if key.kind.as_deref() == Some("input") {
+                                let value_type = key.value_type.clone().unwrap_or(Type::F64);
+                                config = config.with_input(key.path.clone(), value_type);
+                            }
+                        }
+                        builder = builder.with_bridge(Box::new(Ros2Bridge::new(config).await));
+                    }
+                    let mut arora = match builder.build() {
+                        Ok(arora) => arora,
+                        Err(e) => return log::error!("device build failed: {e:?}"),
+                    };
+                    tokio::select! {
+                        result = arora.run(arora::Arora::DEFAULT_STEP_PERIOD) => {
+                            if let Err(e) = result {
+                                log::error!("device run ended: {e}");
+                            }
+                        }
+                        _ = device_cancel.cancelled() => {}
+                    }
+                });
+            })
+            .map_err(|e| format!("failed to spawn the device thread: {e}"))?;
+    }
 
     if emit_started {
         app.emit("ws:started", port).map_err(|e| e.to_string())?;
@@ -653,10 +690,6 @@ async fn start_host(app: &AppHandle, emit_started: bool) -> Result<(), String> {
 /// Stop the bridge host: cancel the WS serve loop + all pumps.
 async fn stop_host(app: &AppHandle) -> Result<(), String> {
     let state = app.state::<AppState>();
-    #[cfg(feature = "ros2")]
-    if let Some(token) = state.ros2_token.lock().unwrap().take() {
-        token.cancel();
-    }
     let token = state.cancel_token.lock().unwrap().take();
     if let Some(token) = token {
         token.cancel();
@@ -665,49 +698,6 @@ async fn stop_host(app: &AppHandle) -> Result<(), String> {
     } else {
         Err("Connection servers are not running".to_string())
     }
-}
-
-/// (Re)build the ROS 2 pump from the current key catalog. ROS 2 topics are typed
-/// and their inputs declared up front, so a changed catalog means a rebuilt
-/// bridge (no hot-reload). No-op when the host is not running.
-#[cfg(feature = "ros2")]
-async fn respawn_ros2(app: &AppHandle) {
-    use arora_bridge_ros2::{Ros2Bridge, Ros2BridgeConfig};
-
-    let parent = app.state::<AppState>().cancel_token.lock().unwrap().clone();
-    let Some(parent) = parent else {
-        return; // host not running
-    };
-
-    // Cancel the previous ROS 2 pump before building the next.
-    if let Some(old) = app.state::<AppState>().ros2_token.lock().unwrap().take() {
-        old.cancel();
-    }
-
-    let config = {
-        let state = app.state::<AppState>();
-        let keys = state.keys.lock().unwrap();
-        // The ROS4HRI exposure preset: the typed face topics and the
-        // `/skill/look_at` action binding, resolved against this host's
-        // described methods at bridge startup.
-        let mut config = Ros2BridgeConfig::new(state.ros2_namespace.clone(), state.ros2_domain_id)
-            .with_profile(arora_bridge_ros2::ExposureProfile::ros4hri());
-        for key in keys.iter() {
-            // Only input keys accept inbound commands (become subscribed topics);
-            // outputs are published on demand from `try_send`.
-            if key.kind.as_deref() == Some("input") {
-                let value_type = key.value_type.clone().unwrap_or(Type::F64);
-                config = config.with_input(key.path.clone(), value_type);
-            }
-        }
-        config
-    };
-
-    let bridge = Ros2Bridge::new(config).await;
-    let cancel = parent.child_token();
-    *app.state::<AppState>().ros2_token.lock().unwrap() = Some(cancel.clone());
-    spawn_bridge_pump(app, vec![Box::new(bridge)], cancel);
-    info!("ROS2 bridge (re)built");
 }
 
 // =============================================================================
@@ -908,9 +898,7 @@ async fn run_studio_pump(
     let on_error = move |message: String| {
         let _ = error_app.emit(STUDIO_BRIDGE_ERROR_EVENT, message);
     };
-    let skills = app.state::<AppState>().skills.clone();
-    let on_inbound =
-        move |store: &SimpleDataStore, event| host::handle_inbound(store, &app, &skills, event);
+    let on_inbound = move |store: &SimpleDataStore, event| host::handle_inbound(store, event);
     run_studio_pump_core(
         store,
         bridge,
@@ -1196,10 +1184,20 @@ async fn set_slots(app_handle: AppHandle, slots: Vec<KeyInfo>) -> Result<(), Str
 
     *app_handle.state::<AppState>().keys.lock().unwrap() = slots;
 
-    // ROS 2 inputs are declared up front, so rebuild that pump with the new
-    // catalog. The WS bridge is untouched, so connected WS clients stay up.
+    // ROS 2 inputs are declared up front, at device build. With the host
+    // running, a changed catalog rebuilds the whole run (bridges are fixed at
+    // build) — a brief blip on model load, ros2 builds only.
     #[cfg(feature = "ros2")]
-    respawn_ros2(&app_handle).await;
+    if app_handle
+        .state::<AppState>()
+        .cancel_token
+        .lock()
+        .unwrap()
+        .is_some()
+    {
+        let _ = stop_host(&app_handle).await;
+        start_host(&app_handle, false).await?;
+    }
 
     info!("Key catalog updated: {} key(s) advertised", count);
     Ok(())
@@ -1541,31 +1539,41 @@ pub fn run() {
                 )
             };
 
-            // The skill plane: the graph interpreter serving /skill/look_at,
-            // ticked against the shared store for the whole process.
-            let skills: skills::SharedSkillHost =
-                std::sync::Arc::new(StdMutex::new(skills::SkillHost::new()));
+            // Mirror the store to the webview: every writer's set-changes
+            // reach the renderer — bridge updates and the skill runs' gaze
+            // intent alike. The engine's built-in keys (arora/*) stay out,
+            // they tick at run rate. The webview's own publish_values writes
+            // echo back through here; the webview applies values
+            // idempotently, so the echo is redundant, not harmful.
             {
-                let skills = skills.clone();
-                let store = store.clone();
+                let subscription = store.subscribe();
+                let app_handle = app.handle().clone();
                 std::thread::Builder::new()
-                    .name("skill-tick".into())
-                    .spawn(move || loop {
-                        if let Ok(mut host) = skills.lock() {
-                            host.tick(&store);
+                    .name("store-mirror".into())
+                    .spawn(move || {
+                        while let Some(change) = subscription.recv() {
+                            let mut values: HashMap<String, arora_types::value::Value> =
+                                HashMap::new();
+                            for (key, value) in &change.set {
+                                if key.path.starts_with(arora_behavior::built_in::PREFIX) {
+                                    continue;
+                                }
+                                if let Some(value) = value {
+                                    values.insert(key.path.clone(), value.clone());
+                                }
+                            }
+                            if !values.is_empty() {
+                                let _ = app_handle.emit("update-values", &values);
+                            }
                         }
-                        std::thread::sleep(std::time::Duration::from_millis(30));
                     })
-                    .expect("failed to spawn the skill tick thread");
+                    .expect("failed to spawn the store mirror thread");
             }
 
             app.manage(AppState {
                 store: store.clone(),
-                skills,
                 ws_server,
                 cancel_token: StdMutex::new(None),
-                #[cfg(feature = "ros2")]
-                ros2_token: StdMutex::new(None),
                 #[cfg(feature = "ros2")]
                 ros2_domain_id: cli.ros2_domain_id,
                 #[cfg(feature = "ros2")]

--- a/apps/vizij-standalone/src-tauri/src/skills.rs
+++ b/apps/vizij-standalone/src-tauri/src/skills.rs
@@ -1,0 +1,241 @@
+//! The device's skill plane: a Vizij graph interpreter serving `look_at`.
+//!
+//! The standalone's host runs no `arora` engine, so this module carries the
+//! two engine seams a bridge needs to serve a skill as a ROS 2 action:
+//!
+//! - **DescribeMethods** — the described `look_at` signature
+//!   ([`vizij_arora_behavior::gaze`]), answered on the value plane as
+//!   `Vec<MethodSignature>`, which `arora-bridge-ros2`'s ROS4HRI exposure
+//!   profile binds to `/skill/look_at`.
+//! - **The interpreter module** — SPAWN/HALT calls (the well-known
+//!   [`arora_behavior::interpreter_module`] ABI) dispatched into a
+//!   [`ProcessingGraph`] holding the shipped look_at fragment. A spawned run
+//!   grafts the fragment; [`tick`](SkillHost::tick) advances it against the
+//!   shared store, where its gaze intent lands on the `standard/ros4hri/*`
+//!   keys — mirrored to the webview and served over every attached bridge.
+//!
+//! The behavior stays data (the `skills/look_at.json` asset), exactly as on
+//! the native app; only the hosting differs.
+
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::Instant;
+
+use arora_behavior::{interpreter_module, BehaviorContext, BehaviorInterpreter};
+use arora_bridge::MethodSignature;
+use arora_simple_data_store::SimpleDataStore;
+use std::rc::Rc;
+
+use arora_types::call::{Call, CallBridge, CallError, CallResult, Callable, CallableId};
+use arora_types::data::{DataStore, StateChange};
+use arora_types::value::Value;
+use vizij_arora_behavior::{gaze, ProcessingGraph};
+use vizij_arora_host::skills::LOOK_AT_FUNCTION;
+use vizij_graph_core::types::GraphSpec;
+
+/// The interpreter and its clock, shared between the tick loop and the pumps.
+pub type SharedSkillHost = Arc<StdMutex<SkillHost>>;
+
+/// The graph interpreter hosting the device's skills.
+pub struct SkillHost {
+    graph: ProcessingGraph,
+    last_tick: Option<Instant>,
+}
+
+impl SkillHost {
+    /// An interpreter over an empty graph with the shipped look_at fragment
+    /// registered: runs exist only while goals are live.
+    pub fn new() -> Self {
+        let mut graph =
+            ProcessingGraph::from_spec(GraphSpec::default()).expect("an empty graph spec encodes");
+        graph.set_task_fragment(gaze::look_at_id(), gaze::look_at_fragment());
+        Self {
+            graph,
+            last_tick: None,
+        }
+    }
+
+    /// The described methods this device serves — what a bridge's
+    /// `DescribeMethods` learns and the ROS4HRI profile binds against.
+    pub fn signatures(&self, prefix: Option<&str>) -> Value {
+        let all = [MethodSignature {
+            module_id: gaze::module_id(),
+            id: gaze::look_at_id(),
+            name: LOOK_AT_FUNCTION.to_string(),
+            function: gaze::look_at_signature(),
+        }];
+        let matching: Vec<&MethodSignature> = all
+            .iter()
+            .filter(|s| prefix.is_none_or(|p| s.name.starts_with(p)))
+            .collect();
+        arora_types::value_serde::to_value(&matching)
+            .expect("method signatures encode on the value plane")
+    }
+
+    /// The served method names — the deprecated `ListMethods` answer.
+    pub fn method_names(&self, prefix: Option<&str>) -> Vec<String> {
+        [LOOK_AT_FUNCTION]
+            .iter()
+            .filter(|n| prefix.is_none_or(|p| n.starts_with(p)))
+            .map(|n| n.to_string())
+            .collect()
+    }
+
+    /// Dispatch a bridge's `Call`: the interpreter module's SPAWN/HALT (how a
+    /// bridge starts and cancels a task run). Anything else is refused — the
+    /// skill functions themselves are graph content, not callables.
+    pub fn dispatch(&mut self, call: &Call) -> Result<CallResult, String> {
+        if call.module_id != Some(interpreter_module::ID) {
+            return Err(format!(
+                "calls are served only for the interpreter module (got {:?})",
+                call.module_id
+            ));
+        }
+        if call.id == interpreter_module::SPAWN {
+            let (inner, policy) = interpreter_module::decode_spawn(call)?;
+            if inner.id != gaze::look_at_id() {
+                return Err(format!("no task-run function {}", inner.id));
+            }
+            let handle = self.graph.spawn(inner, policy).map_err(|e| e.message)?;
+            return Ok(CallResult {
+                ret: interpreter_module::encode_spawn_result(&handle),
+                mutated: Vec::new(),
+            });
+        }
+        if call.id == interpreter_module::HALT {
+            let task = interpreter_module::decode_halt(call)?;
+            self.graph.halt(task).map_err(|e| e.message)?;
+            return Ok(CallResult {
+                ret: Value::Unit,
+                mutated: Vec::new(),
+            });
+        }
+        Err(format!("unsupported interpreter call {}", call.id))
+    }
+
+    /// Advance the interpreter one step against the store: publish the
+    /// built-in `dt` (nanoseconds since the previous tick) the graph's
+    /// time-driven nodes read, then tick. Errors are transient by the
+    /// interpreter contract; they are logged and the next tick retries.
+    pub fn tick(&mut self, store: &SimpleDataStore) {
+        let now = Instant::now();
+        let dt = self
+            .last_tick
+            .map(|last| now.duration_since(last).as_nanos() as u64)
+            .unwrap_or(0);
+        self.last_tick = Some(now);
+        if let Err(e) = store.write(StateChange::set(
+            arora_behavior::built_in::DT,
+            Value::U64(dt),
+        )) {
+            log::warn!("skills: dt write failed: {e}");
+        }
+        let mut calls = NoModules;
+        let mut ctx = BehaviorContext {
+            store,
+            call_bridge: &mut calls,
+        };
+        if let Err(e) = self.graph.tick(&mut ctx) {
+            log::warn!("skills: tick failed: {}", e.message);
+        }
+    }
+}
+
+/// The tick context's call bridge: this host loads no modules, and the
+/// shipped fragments are pure graph content, so a call is a misconfiguration.
+struct NoModules;
+
+impl CallBridge for NoModules {
+    fn arora_call(&mut self, call: Call) -> Result<CallResult, CallError> {
+        Err(CallError::Generic {
+            message: format!("this host serves no module calls (function {})", call.id),
+        })
+    }
+
+    fn arora_register_callable(&mut self, _callable: Rc<dyn Callable>) -> CallableId {
+        CallableId { id: 0 }
+    }
+
+    fn arora_unregister_callable(&mut self, _callable_id: &CallableId) {}
+
+    fn arora_call_indirect(&mut self, _callable_id: &CallableId) -> Result<Value, CallError> {
+        Err(CallError::Generic {
+            message: "this host serves no indirect calls".to_string(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arora_behavior::RunPolicy;
+    use arora_types::data::Key;
+    use arora_types::value::StructureField;
+    use vizij_arora_behavior::task;
+    use vizij_arora_host::ros4hri;
+
+    /// A look_at goal spawned over the interpreter-module wire (the bridge's
+    /// path) grafts the shipped fragment: ticks write the gaze target, the
+    /// status runs, and the handle's stop call ends the run.
+    #[test]
+    fn the_skill_host_serves_a_look_at_run() {
+        let store = SimpleDataStore::new();
+        let mut host = SkillHost::new();
+
+        // The routed spawn call the bound action would build: policy "" =
+        // track, target in the face frame.
+        let parameters = gaze::look_at_parameters();
+        let arg = |name: &str, value: Value| StructureField {
+            id: *parameters
+                .iter()
+                .find(|(_, n)| n == &name)
+                .expect("a declared parameter")
+                .0,
+            value: Box::new(value),
+        };
+        let inner = Call {
+            module_id: Some(gaze::module_id()),
+            id: gaze::look_at_id(),
+            args: vec![
+                arg("policy", Value::String(String::new())),
+                arg("target", Value::ArrayF32(vec![1.0, 0.3, 0.1])),
+                arg("frame", Value::String("face".to_string())),
+            ],
+        };
+        let spawn = interpreter_module::encode_spawn(&inner, RunPolicy::Concurrent);
+        let result = host.dispatch(&spawn).expect("the spawn is served");
+        let handle = interpreter_module::decode_spawn_result(&result.ret)
+            .expect("the reply is the run's handle");
+
+        for _ in 0..5 {
+            host.tick(&store);
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+
+        // The fragment steers the gaze surface and reports Running.
+        let gaze_target = store
+            .read(&[Key::from(ros4hri::GAZE_TARGET_KEY)])
+            .into_iter()
+            .next()
+            .flatten()
+            .expect("the run writes the gaze target");
+        assert_eq!(gaze_target, Value::ArrayF32(vec![1.0, 0.3, 0.1]));
+        let status = store
+            .read(&[handle.status.clone()])
+            .into_iter()
+            .next()
+            .flatten()
+            .expect("the run reports its status");
+        assert_eq!(status, task::running());
+
+        // The handle's stop call (what a cancel dispatches) ends the run.
+        host.dispatch(&handle.stop).expect("the halt is served");
+        host.tick(&store);
+        let status = store
+            .read(&[handle.status])
+            .into_iter()
+            .next()
+            .flatten()
+            .expect("the status key outlives the run");
+        assert_ne!(status, task::running());
+    }
+}

--- a/apps/vizij-standalone/src-tauri/src/skills.rs
+++ b/apps/vizij-standalone/src-tauri/src/skills.rs
@@ -1,188 +1,76 @@
-//! The device's skill plane: a Vizij graph interpreter serving `look_at`.
+//! The device's skill plane: the pieces the arora run composes to serve
+//! `look_at`.
 //!
-//! The standalone's host runs no `arora` engine, so this module carries the
-//! two engine seams a bridge needs to serve a skill as a ROS 2 action:
-//!
-//! - **DescribeMethods** — the described `look_at` signature
-//!   ([`vizij_arora_behavior::gaze`]), answered on the value plane as
-//!   `Vec<MethodSignature>`, which `arora-bridge-ros2`'s ROS4HRI exposure
-//!   profile binds to `/skill/look_at`.
-//! - **The interpreter module** — SPAWN/HALT calls (the well-known
-//!   [`arora_behavior::interpreter_module`] ABI) dispatched into a
-//!   [`ProcessingGraph`] holding the shipped look_at fragment. A spawned run
-//!   grafts the fragment; [`tick`](SkillHost::tick) advances it against the
-//!   shared store, where its gaze intent lands on the `standard/ros4hri/*`
-//!   keys — mirrored to the webview and served over every attached bridge.
-//!
-//! The behavior stays data (the `skills/look_at.json` asset), exactly as on
-//! the native app; only the hosting differs.
+//! The arora runtime owns everything operational — the step loop, the
+//! built-in keys, bridge pumping, `DescribeMethods`, and the interpreter
+//! module's SPAWN/HALT — so this module only *builds*: the gaze host module
+//! (the described `look_at` contract, from [`vizij_arora_behavior::gaze`])
+//! and the graph interpreter holding the shipped look_at fragment. The
+//! behavior stays data (the `skills/look_at.json` asset), exactly as on the
+//! native app.
 
-use std::sync::{Arc, Mutex as StdMutex};
-use std::time::Instant;
-
-use arora_behavior::{interpreter_module, BehaviorContext, BehaviorInterpreter};
-use arora_bridge::MethodSignature;
-use arora_simple_data_store::SimpleDataStore;
-use std::rc::Rc;
-
-use arora_types::call::{Call, CallBridge, CallError, CallResult, Callable, CallableId};
-use arora_types::data::{DataStore, StateChange};
-use arora_types::value::Value;
-use vizij_arora_behavior::{gaze, ProcessingGraph};
+use arora::{HostModule, ModuleBuilder};
+use arora_types::call::CallResult;
+use vizij_arora_behavior::{gaze, task, ProcessingGraph};
 use vizij_arora_host::skills::LOOK_AT_FUNCTION;
 use vizij_graph_core::types::GraphSpec;
 
-/// The interpreter and its clock, shared between the tick loop and the pumps.
-pub type SharedSkillHost = Arc<StdMutex<SkillHost>>;
-
-/// The graph interpreter hosting the device's skills.
-pub struct SkillHost {
-    graph: ProcessingGraph,
-    last_tick: Option<Instant>,
+/// The graph interpreter the device runs: an empty graph with the shipped
+/// look_at fragment registered — runs exist only while goals are live.
+pub fn interpreter() -> ProcessingGraph {
+    let mut graph =
+        ProcessingGraph::from_spec(GraphSpec::default()).expect("an empty graph spec encodes");
+    graph.set_task_fragment(gaze::look_at_id(), gaze::look_at_fragment());
+    graph
 }
 
-impl SkillHost {
-    /// An interpreter over an empty graph with the shipped look_at fragment
-    /// registered: runs exist only while goals are live.
-    pub fn new() -> Self {
-        let mut graph =
-            ProcessingGraph::from_spec(GraphSpec::default()).expect("an empty graph spec encodes");
-        graph.set_task_fragment(gaze::look_at_id(), gaze::look_at_fragment());
-        Self {
-            graph,
-            last_tick: None,
-        }
-    }
-
-    /// The described methods this device serves — what a bridge's
-    /// `DescribeMethods` learns and the ROS4HRI profile binds against.
-    pub fn signatures(&self, prefix: Option<&str>) -> Value {
-        let all = [MethodSignature {
-            module_id: gaze::module_id(),
-            id: gaze::look_at_id(),
-            name: LOOK_AT_FUNCTION.to_string(),
-            function: gaze::look_at_signature(),
-        }];
-        let matching: Vec<&MethodSignature> = all
-            .iter()
-            .filter(|s| prefix.is_none_or(|p| s.name.starts_with(p)))
-            .collect();
-        arora_types::value_serde::to_value(&matching)
-            .expect("method signatures encode on the value plane")
-    }
-
-    /// The served method names — the deprecated `ListMethods` answer.
-    pub fn method_names(&self, prefix: Option<&str>) -> Vec<String> {
-        [LOOK_AT_FUNCTION]
-            .iter()
-            .filter(|n| prefix.is_none_or(|p| n.starts_with(p)))
-            .map(|n| n.to_string())
-            .collect()
-    }
-
-    /// Dispatch a bridge's `Call`: the interpreter module's SPAWN/HALT (how a
-    /// bridge starts and cancels a task run). Anything else is refused — the
-    /// skill functions themselves are graph content, not callables.
-    pub fn dispatch(&mut self, call: &Call) -> Result<CallResult, String> {
-        if call.module_id != Some(interpreter_module::ID) {
-            return Err(format!(
-                "calls are served only for the interpreter module (got {:?})",
-                call.module_id
-            ));
-        }
-        if call.id == interpreter_module::SPAWN {
-            let (inner, policy) = interpreter_module::decode_spawn(call)?;
-            if inner.id != gaze::look_at_id() {
-                return Err(format!("no task-run function {}", inner.id));
-            }
-            let handle = self.graph.spawn(inner, policy).map_err(|e| e.message)?;
-            return Ok(CallResult {
-                ret: interpreter_module::encode_spawn_result(&handle),
-                mutated: Vec::new(),
-            });
-        }
-        if call.id == interpreter_module::HALT {
-            let task = interpreter_module::decode_halt(call)?;
-            self.graph.halt(task).map_err(|e| e.message)?;
-            return Ok(CallResult {
-                ret: Value::Unit,
-                mutated: Vec::new(),
-            });
-        }
-        Err(format!("unsupported interpreter call {}", call.id))
-    }
-
-    /// Advance the interpreter one step against the store: publish the
-    /// built-in `dt` (nanoseconds since the previous tick) the graph's
-    /// time-driven nodes read, then tick. Errors are transient by the
-    /// interpreter contract; they are logged and the next tick retries.
-    pub fn tick(&mut self, store: &SimpleDataStore) {
-        let now = Instant::now();
-        let dt = self
-            .last_tick
-            .map(|last| now.duration_since(last).as_nanos() as u64)
-            .unwrap_or(0);
-        self.last_tick = Some(now);
-        if let Err(e) = store.write(StateChange::set(
-            arora_behavior::built_in::DT,
-            Value::U64(dt),
-        )) {
-            log::warn!("skills: dt write failed: {e}");
-        }
-        let mut calls = NoModules;
-        let mut ctx = BehaviorContext {
-            store,
-            call_bridge: &mut calls,
-        };
-        if let Err(e) = self.graph.tick(&mut ctx) {
-            log::warn!("skills: tick failed: {}", e.message);
-        }
-    }
-}
-
-/// The tick context's call bridge: this host loads no modules, and the
-/// shipped fragments are pure graph content, so a call is a misconfiguration.
-struct NoModules;
-
-impl CallBridge for NoModules {
-    fn arora_call(&mut self, call: Call) -> Result<CallResult, CallError> {
-        Err(CallError::Generic {
-            message: format!("this host serves no module calls (function {})", call.id),
-        })
-    }
-
-    fn arora_register_callable(&mut self, _callable: Rc<dyn Callable>) -> CallableId {
-        CallableId { id: 0 }
-    }
-
-    fn arora_unregister_callable(&mut self, _callable_id: &CallableId) {}
-
-    fn arora_call_indirect(&mut self, _callable_id: &CallableId) -> Result<Value, CallError> {
-        Err(CallError::Generic {
-            message: "this host serves no indirect calls".to_string(),
-        })
-    }
+/// The gaze module: the look_at contract, described so bridges discover it
+/// (and the ROS4HRI exposure profile binds `/skill/look_at` to it). The
+/// closure is only reached when the device did not register the fragment —
+/// it fails the run rather than pretending to gaze.
+pub fn gaze_module() -> HostModule {
+    ModuleBuilder::new(gaze::module_id())
+        .described_function(
+            gaze::look_at_id(),
+            LOOK_AT_FUNCTION,
+            gaze::look_at_signature(),
+            |_call| {
+                log::warn!("look_at invoked as a module call: no task fragment is registered");
+                Ok(CallResult {
+                    ret: task::failure(),
+                    mutated: Vec::new(),
+                })
+            },
+        )
+        .build()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arora_behavior::RunPolicy;
-    use arora_types::data::Key;
-    use arora_types::value::StructureField;
-    use vizij_arora_behavior::task;
+    use std::time::Duration;
+
+    use arora_behavior::{interpreter_module, RunPolicy};
+    use arora_simple_data_store::SimpleDataStore;
+    use arora_types::call::Call;
+    use arora_types::data::{DataStore, Key};
+    use arora_types::value::{StructureField, Value};
     use vizij_arora_host::ros4hri;
 
-    /// A look_at goal spawned over the interpreter-module wire (the bridge's
-    /// path) grafts the shipped fragment: ticks write the gaze target, the
-    /// status runs, and the handle's stop call ends the run.
+    /// The standalone's composition end to end: an arora over the SHARED
+    /// store serves a look_at goal — spawn through the engine, the fragment
+    /// grafts, steps write the gaze surface into the store the webview and
+    /// bridges observe, and the handle's stop call ends the run.
     #[test]
-    fn the_skill_host_serves_a_look_at_run() {
+    fn the_arora_serves_a_look_at_run_on_the_shared_store() {
         let store = SimpleDataStore::new();
-        let mut host = SkillHost::new();
+        let mut arora = arora::Arora::builder()
+            .with_data_store(Box::new(store.clone()))
+            .with_host_module(gaze_module())
+            .with_behavior_interpreter(Box::new(interpreter()))
+            .build()
+            .expect("the device composes");
 
-        // The routed spawn call the bound action would build: policy "" =
-        // track, target in the face frame.
         let parameters = gaze::look_at_parameters();
         let arg = |name: &str, value: Value| StructureField {
             id: *parameters
@@ -192,7 +80,7 @@ mod tests {
                 .0,
             value: Box::new(value),
         };
-        let inner = Call {
+        let look_at = Call {
             module_id: Some(gaze::module_id()),
             id: gaze::look_at_id(),
             args: vec![
@@ -201,41 +89,34 @@ mod tests {
                 arg("frame", Value::String("face".to_string())),
             ],
         };
-        let spawn = interpreter_module::encode_spawn(&inner, RunPolicy::Concurrent);
-        let result = host.dispatch(&spawn).expect("the spawn is served");
-        let handle = interpreter_module::decode_spawn_result(&result.ret)
-            .expect("the reply is the run's handle");
+        let spawned = arora
+            .call(interpreter_module::encode_spawn(
+                &look_at,
+                RunPolicy::Concurrent,
+            ))
+            .expect("SPAWN dispatches through the engine");
+        let handle =
+            interpreter_module::decode_spawn_result(&spawned.ret).expect("a TaskHandle comes back");
 
-        for _ in 0..5 {
-            host.tick(&store);
-            std::thread::sleep(std::time::Duration::from_millis(5));
-        }
+        let read = |key: &Key| {
+            store
+                .read(std::slice::from_ref(key))
+                .into_iter()
+                .next()
+                .flatten()
+        };
+        arora.step(Duration::from_millis(16)).expect("step");
+        assert_eq!(
+            read(&Key::from(ros4hri::GAZE_TARGET_KEY)),
+            Some(Value::ArrayF32(vec![1.0, 0.3, 0.1])),
+            "the run's gaze intent lands on the shared store"
+        );
+        assert_eq!(read(&handle.status), Some(task::running()));
 
-        // The fragment steers the gaze surface and reports Running.
-        let gaze_target = store
-            .read(&[Key::from(ros4hri::GAZE_TARGET_KEY)])
-            .into_iter()
-            .next()
-            .flatten()
-            .expect("the run writes the gaze target");
-        assert_eq!(gaze_target, Value::ArrayF32(vec![1.0, 0.3, 0.1]));
-        let status = store
-            .read(&[handle.status.clone()])
-            .into_iter()
-            .next()
-            .flatten()
-            .expect("the run reports its status");
-        assert_eq!(status, task::running());
-
-        // The handle's stop call (what a cancel dispatches) ends the run.
-        host.dispatch(&handle.stop).expect("the halt is served");
-        host.tick(&store);
-        let status = store
-            .read(&[handle.status])
-            .into_iter()
-            .next()
-            .flatten()
-            .expect("the status key outlives the run");
-        assert_ne!(status, task::running());
+        arora
+            .call(handle.stop.clone())
+            .expect("the halt dispatches through the engine");
+        arora.step(Duration::from_millis(16)).expect("step");
+        assert_ne!(read(&handle.status), Some(task::running()));
     }
 }

--- a/apps/vizij-standalone/src/components/EndpointsPanel.tsx
+++ b/apps/vizij-standalone/src/components/EndpointsPanel.tsx
@@ -148,8 +148,8 @@ export function EndpointsPanel({ className }: { className?: string }) {
               </div>
               <div className="text-neutral-500">{skill.description}</div>
               <div className="text-neutral-500">
-                served as the <code>/skill/{skill.id}</code> action where the
-                device&apos;s bridge exposes the skill plane
+                served by this device as the <code>/skill/{skill.id}</code>{" "}
+                action when built with ROS 2
               </div>
             </div>
           ))}


### PR DESCRIPTION
The standalone **serves** its skills — as ONE `arora` run, per Victor's architecture call.

## The device is an arora now
The Tauri host's device thread builds an `Arora` over the **shared** `SimpleDataStore` — the gaze host module (described `look_at`, from `vizij_arora_behavior::gaze`), the graph interpreter holding the shipped look_at fragment, the WS bridge, and (under `ros2`) the ROS 2 bridge with `ExposureProfile::ros4hri()` — and runs the portable `arora.run(DEFAULT_STEP_PERIOD)` under the host's cancel token. Everything the earlier revision of this PR hand-rolled (skill tick, `arora/dt`, `DescribeMethods`, SPAWN/HALT dispatch, per-bridge pumps) is deleted: the engine owns its own seams. A `--features ros2` build joins the ROS graph with the typed face topics **and the `/skill/look_at` action**, bound at bridge startup against the run's own described methods.

- **Store→webview mirror**: one store subscription forwards every writer's set-changes to the renderer — bridges and skill runs alike (the pump-based revision's gaze writes never reached the webview; now they do). Engine built-ins (`arora/*`) stay out.
- **Background serving** — the decisive reason for this architecture: the device keeps serving goals, topics, and its Studio registration while the window is hidden or the Android activity sleeps.
- The **Studio bridge** stays on its own thread (its registration follows the in-UI owner prompt live), now data-plane only.
- A changed key catalog (`set_slots`) rebuilds the run — bridges are typed and fixed at build.

## The prerequisite this unblocked upstream
arora's no-`native` path never compiled on a native target (browser-executor assumption), and `native` means wasmtime — impossible on the APK's `armv7`/`i686`. Fixed in [arora-sdk #216](https://github.com/semio-ai/arora-sdk/pull/216) / **arora 9.11.1** ([ARORA-90](https://linear.app/semio-ai/issue/ARORA-90/a-wasmtime-free-engine-feature-for-host-modules-only-devices)): the no-native engine on native targets carries **no executor at all** — host modules dispatch directly. This PR consumes `arora = { version = "9.11.1", default-features = false }`; the Android CI job is the 32-bit proof.

## Proof
`the_arora_serves_a_look_at_run_on_the_shared_store`: an `Arora` built exactly as the device — shared store, gaze module, interpreter — serves a goal end to end (engine SPAWN → fragment graft → gaze intent on the shared store → `Running` → the handle's stop → terminal). Green in default / `ros2` / `studio-bridge` configs; clippy clean in all three; studio pump suite green. The bound ROS action plane is E2E-proven live in vizij-rs.

Closes the serving half of [VIZ-99](https://linear.app/semio-ai/issue/VIZ-99/standalone-as-one-arora-run-the-device-serves-in-the-background); the webview's ros4hri profile composition (`composeFace`) remains VIZ-99's visual follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)