### PR TITLE
feat(standalone): device-side ROS4HRI + the shared say module

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -98,6 +98,7 @@ jobs:
         with:
           api-level: 34
           arch: x86_64
+          disk-size: 8192M
           target: google_apis
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
@@ -128,6 +129,7 @@ jobs:
         with:
           api-level: 34
           arch: x86_64
+          disk-size: 8192M
           target: google_apis
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none -no-metrics
@@ -142,6 +144,7 @@ jobs:
         with:
           api-level: 34
           arch: x86_64
+          disk-size: 8192M
           target: google_apis
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none -no-metrics

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,10 +1,19 @@
 name: android
 
+# The debug APK + emulator smoke run ON DEMAND (workflow_dispatch): the
+# package is asked for, not rebuilt per PR — the PR gate is the test jobs in
+# ci.yml. Pushes to main keep driving the release path (version detect +
+# release APK).
 on:
-  pull_request:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      abi:
+        description: "Debug APK ABI (a device ABI, or universal — x86_64/universal also run the emulator smoke)"
+        type: choice
+        default: aarch64
+        options: [aarch64, armv7, x86_64, universal]
 
 concurrency:
   group: android-${{ github.ref }}
@@ -15,11 +24,11 @@ env:
   ANDROID_DIR: apps/vizij-standalone/src-tauri/gen/android
 
 jobs:
-  # PRs (and manual runs): build an installable, auto-signed DEBUG APK and run
-  # the instrumented launch smoke test on an emulator.
+  # On demand: build an installable, auto-signed DEBUG APK and run the
+  # instrumented launch smoke test on an emulator.
   debug-apk:
     name: Debug APK + emulator smoke test
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -67,7 +76,10 @@ jobs:
         # `arora-studio-bridge-client` crate bakes in the public Firebase config
         # and the production bridge endpoint, so nothing is injected here.
         working-directory: ${{ env.APP_DIR }}
-        run: pnpm exec tauri android build --debug --apk -- --no-default-features --features studio-bridge
+        run: >-
+          pnpm exec tauri android build --debug --apk
+          ${{ inputs.abi != 'universal' && format('--target {0}', inputs.abi) || '' }}
+          -- --no-default-features --features studio-bridge
 
       - name: Upload debug APK
         uses: actions/upload-artifact@v4
@@ -77,13 +89,17 @@ jobs:
           if-no-files-found: error
 
       # --- Emulator smoke test ---
+      # Everything below runs the emulator smoke — only for an APK the
+      # x86_64 emulator can install.
       - name: Enable KVM
+        if: inputs.abi == 'universal' || inputs.abi == 'x86_64'
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
       - name: AVD cache
+        if: inputs.abi == 'universal' || inputs.abi == 'x86_64'
         uses: actions/cache@v4
         id: avd-cache
         with:
@@ -93,7 +109,7 @@ jobs:
           key: avd-api34-x86_64
 
       - name: Create AVD snapshot
-        if: steps.avd-cache.outputs.cache-hit != 'true'
+        if: (inputs.abi == 'universal' || inputs.abi == 'x86_64') && steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 34
@@ -123,6 +139,7 @@ jobs:
       #   `tauri android build`/`dev` process); the prior "Build debug APK" step
       #   already produced the .so, so the test reuses them.
       - name: Run instrumented smoke test
+        if: inputs.abi == 'universal' || inputs.abi == 'x86_64'
         id: smoke-1
         continue-on-error: true
         uses: reactivecircus/android-emulator-runner@v2
@@ -152,7 +169,7 @@ jobs:
           script: bash .github/scripts/run-android-smoke.sh
 
       - name: Assert smoke test passed
-        if: always()
+        if: always() && (inputs.abi == 'universal' || inputs.abi == 'x86_64')
         run: |
           if [ "${{ steps.smoke-1.outcome }}" = "success" ] || [ "${{ steps.smoke-2.outcome }}" = "success" ]; then
             echo "Emulator smoke test passed (attempt-1=${{ steps.smoke-1.outcome }}, attempt-2=${{ steps.smoke-2.outcome }})."

--- a/apps/vizij-standalone/src-tauri/Cargo.lock
+++ b/apps/vizij-standalone/src-tauri/Cargo.lock
@@ -90,6 +90,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alsa"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+dependencies = [
+ "alsa-sys",
+ "bitflags 2.13.0",
+ "cfg-if 1.0.4",
+ "libc",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "android_log-sys"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,7 +431,7 @@ dependencies = [
  "clap 3.2.25",
  "convert_case 0.11.0",
  "derive_more 2.1.1",
- "itertools",
+ "itertools 0.14.0",
  "lazy_static",
  "proc-macro2",
  "quote",
@@ -808,6 +830,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.13.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,6 +1203,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "cfb"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1235,6 +1284,17 @@ dependencies = [
  "crypto-common",
  "inout",
  "zeroize",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -1332,6 +1392,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
+name = "claxon"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bfbf56724aa9eca8afa4fcfadeb479e722935bb2a0900c2d37e0cc477af0688"
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,7 +1415,7 @@ dependencies = [
  "bitflags 2.13.0",
  "block",
  "cocoa-foundation",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "foreign-types",
  "libc",
@@ -1364,7 +1430,7 @@ checksum = "81411967c50ee9a1fc11365f8c585f863a22a9697c89239c452292c40ba79b0d"
 dependencies = [
  "bitflags 2.13.0",
  "block",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "objc",
 ]
@@ -1493,6 +1559,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -1514,7 +1590,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
  "bitflags 2.13.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -1527,8 +1603,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.13.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
+]
+
+[[package]]
+name = "coreaudio-rs"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation-sys",
+ "coreaudio-sys",
+]
+
+[[package]]
+name = "coreaudio-sys"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b4739a805a62757a83e5654fa3faabec0442666b263bb2287d5a8185bfd953"
+dependencies = [
+ "bindgen",
+]
+
+[[package]]
+name = "cpal"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
+dependencies = [
+ "alsa",
+ "core-foundation-sys",
+ "coreaudio-rs",
+ "dasp_sample",
+ "jni 0.21.1",
+ "js-sys",
+ "libc",
+ "mach2",
+ "ndk 0.8.0",
+ "ndk-context",
+ "oboe",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.54.0",
 ]
 
 [[package]]
@@ -1746,6 +1865,12 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "dasp_sample"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "data-encoding"
@@ -2018,6 +2143,15 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if 1.0.4",
+]
 
 [[package]]
 name = "enumflags2"
@@ -2903,6 +3037,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hound"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
+
+[[package]]
 name = "html5ever"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3035,9 +3175,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.1",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -3297,6 +3439,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -3578,6 +3729,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
 
 [[package]]
+name = "lewton"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777b48df9aaab155475a83a7df3070395ea1ac6902f5cd062b8f2b028075c030"
+dependencies = [
+ "byteorder",
+ "ogg",
+ "tinyvec",
+]
+
+[[package]]
 name = "libappindicator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3704,6 +3866,15 @@ name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "malloc_buf"
@@ -3948,6 +4119,20 @@ dependencies = [
 
 [[package]]
 name = "ndk"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
+dependencies = [
+ "bitflags 2.13.0",
+ "jni-sys 0.3.0",
+ "log",
+ "ndk-sys 0.5.0+25.2.9519653",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
@@ -3955,7 +4140,7 @@ dependencies = [
  "bitflags 2.13.0",
  "jni-sys 0.3.0",
  "log",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "num_enum",
  "raw-window-handle",
  "thiserror 1.0.69",
@@ -3966,6 +4151,15 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-sys"
+version = "0.5.0+25.2.9519653"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+dependencies = [
+ "jni-sys 0.3.0",
+]
 
 [[package]]
 name = "ndk-sys"
@@ -4346,6 +4540,38 @@ dependencies = [
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-foundation",
+]
+
+[[package]]
+name = "oboe"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
+dependencies = [
+ "jni 0.21.1",
+ "ndk 0.8.0",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "oboe-sys",
+]
+
+[[package]]
+name = "oboe-sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "ogg"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6951b4e8bf21c8193da321bcce9c9dd2e13c858fe078bf9054a288b419ae5d6e"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -5066,7 +5292,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -5463,6 +5689,7 @@ checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
  "h2",
@@ -5474,6 +5701,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "mime_guess",
  "percent-encoding",
  "pin-project-lite",
@@ -5576,6 +5804,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rodio"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ceb6607dd738c99bc8cb28eff249b7cd5c8ec88b9db96c0608c1480d140fb1"
+dependencies = [
+ "claxon",
+ "cpal",
+ "hound",
+ "lewton",
+ "symphonia",
+]
+
+[[package]]
 name = "ron"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5614,7 +5855,7 @@ dependencies = [
  "chrono",
  "clap 4.5.54",
  "futures",
- "itertools",
+ "itertools 0.14.0",
  "lazy_static",
  "libc",
  "log",
@@ -5645,7 +5886,7 @@ dependencies = [
  "chrono",
  "clap 4.5.54",
  "futures",
- "itertools",
+ "itertools 0.14.0",
  "lazy_static",
  "libc",
  "log",
@@ -5877,7 +6118,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni 0.21.1",
  "log",
@@ -5898,7 +6139,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni 0.22.4",
  "log",
@@ -6104,7 +6345,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.13.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -6557,7 +6798,7 @@ checksum = "aac18da81ebbf05109ab275b157c22a653bb3c12cf884450179942f81bcbf6c3"
 dependencies = [
  "bytemuck",
  "js-sys",
- "ndk",
+ "ndk 0.9.0",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -6782,6 +7023,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "symphonia"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
+dependencies = [
+ "lazy_static",
+ "symphonia-bundle-mp3",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-bundle-mp3"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
+dependencies = [
+ "arrayvec",
+ "bitflags 1.3.2",
+ "bytemuck",
+ "lazy_static",
+ "log",
+]
+
+[[package]]
+name = "symphonia-metadata"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16"
+dependencies = [
+ "encoding_rs",
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6824,6 +7114,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6844,7 +7155,7 @@ checksum = "6682a07cf5bab0b8a2bd20d0a542917ab928b5edb75ebd4eda6b05cbaab872da"
 dependencies = [
  "bitflags 2.13.0",
  "cocoa",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dispatch",
@@ -6858,9 +7169,9 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "ndk",
+ "ndk 0.9.0",
  "ndk-context",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "objc",
  "once_cell",
  "parking_lot",
@@ -6883,7 +7194,7 @@ checksum = "f3a753bdc39c07b192151523a3f77cd0394aa75413802c883a0f6f6a0e5ee2e7"
 dependencies = [
  "bitflags 2.13.0",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dispatch",
@@ -6896,9 +7207,9 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "ndk",
+ "ndk 0.9.0",
  "ndk-context",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
@@ -8141,6 +8452,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "vizij-arora-tts"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e12ab3c01c11fb071ed0a641e2b1bf75eefa2882bccd731b3a028eff109992d"
+dependencies = [
+ "arora-behavior-tree-types",
+ "arora-engine",
+ "arora-types",
+ "log",
+ "reqwest",
+ "rodio",
+ "serde",
+ "tokio",
+ "uuid",
+ "vizij-graph-core",
+]
+
+[[package]]
 name = "vizij-graph-core"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8192,6 +8521,7 @@ dependencies = [
  "tokio-util",
  "vizij-arora-behavior",
  "vizij-arora-host",
+ "vizij-arora-tts",
  "windows 0.58.0",
 ]
 
@@ -8521,6 +8851,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
@@ -8549,6 +8889,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8655,6 +9005,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8670,6 +9040,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -8689,6 +9068,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -9067,7 +9455,7 @@ dependencies = [
  "jni 0.21.1",
  "kuchikiki",
  "libc",
- "ndk",
+ "ndk 0.9.0",
  "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",
@@ -9209,7 +9597,7 @@ dependencies = [
  "flume",
  "futures",
  "git-version",
- "itertools",
+ "itertools 0.14.0",
  "json5",
  "lazy_static",
  "nonempty-collections",

--- a/apps/vizij-standalone/src-tauri/Cargo.lock
+++ b/apps/vizij-standalone/src-tauri/Cargo.lock
@@ -8192,7 +8192,6 @@ dependencies = [
  "tokio-util",
  "vizij-arora-behavior",
  "vizij-arora-host",
- "vizij-graph-core",
  "windows 0.58.0",
 ]
 

--- a/apps/vizij-standalone/src-tauri/Cargo.toml
+++ b/apps/vizij-standalone/src-tauri/Cargo.toml
@@ -36,7 +36,6 @@ arora-behavior = "8"
 # Vizij's graph interpreter and the gaze skill's contract + shipped fragment.
 vizij-arora-behavior = "1"
 vizij-arora-host = "1"
-vizij-graph-core = "1"
 # Opt-in (`studio-bridge` feature): the studio-bridge Zenoh device client — the
 # same `ZenohDeviceClient` arora uses for its Studio connection, which implements
 # arora's `Bridge`. A plain crates.io crate (no artifact bindeps).

--- a/apps/vizij-standalone/src-tauri/Cargo.toml
+++ b/apps/vizij-standalone/src-tauri/Cargo.toml
@@ -36,6 +36,9 @@ arora-behavior = "8"
 # Vizij's graph interpreter and the gaze skill's contract + shipped fragment.
 vizij-arora-behavior = "1"
 vizij-arora-host = "1"
+# The say module (contract + cloud provider) — the same host module the
+# native vizij app registers; the bridge serves it on the action plane.
+vizij-arora-tts = "1"
 # Opt-in (`studio-bridge` feature): the studio-bridge Zenoh device client — the
 # same `ZenohDeviceClient` arora uses for its Studio connection, which implements
 # arora's `Bridge`. A plain crates.io crate (no artifact bindeps).

--- a/apps/vizij-standalone/src-tauri/src/lib.rs
+++ b/apps/vizij-standalone/src-tauri/src/lib.rs
@@ -619,11 +619,13 @@ async fn start_host(app: &AppHandle, emit_started: bool) -> Result<(), String> {
     // cancel token.
     {
         let store = app.state::<AppState>().store.clone();
+        let catalog = app.state::<AppState>().keys.lock().unwrap().clone();
+        // The face the webview advertised namespaces the profile's outputs.
+        let rig_prefix = skills::rig_prefix_of(catalog.iter().map(|key| key.path.clone()));
         #[cfg(feature = "ros2")]
         let ros2_parts = {
             let state = app.state::<AppState>();
-            let keys = state.keys.lock().unwrap().clone();
-            (state.ros2_namespace.clone(), state.ros2_domain_id, keys)
+            (state.ros2_namespace.clone(), state.ros2_domain_id)
         };
         let device_cancel = cancel.child_token();
         std::thread::Builder::new()
@@ -641,18 +643,19 @@ async fn start_host(app: &AppHandle, emit_started: bool) -> Result<(), String> {
                     let mut builder = arora::Arora::builder()
                         .with_data_store(Box::new(store))
                         .with_host_module(skills::gaze_module())
-                        .with_behavior_interpreter(Box::new(skills::interpreter()))
+                        .with_behavior_interpreter(Box::new(skills::interpreter(&rig_prefix)))
                         .with_bridge(Box::new(ws_bridge));
                     #[cfg(feature = "ros2")]
                     {
                         use arora_bridge_ros2::{ExposureProfile, Ros2Bridge, Ros2BridgeConfig};
-                        let (namespace, domain_id, keys) = ros2_parts;
+                        let (namespace, domain_id) = ros2_parts;
+                        let keys = &catalog;
                         // The ROS4HRI exposure preset: the typed face topics
                         // and the /skill/look_at action binding, resolved
                         // against this device's described methods at startup.
                         let mut config = Ros2BridgeConfig::new(namespace, domain_id)
                             .with_profile(ExposureProfile::ros4hri());
-                        for key in &keys {
+                        for key in keys {
                             // Only input keys accept inbound commands (become
                             // subscribed topics); outputs publish on demand.
                             if key.kind.as_deref() == Some("input") {
@@ -1184,10 +1187,9 @@ async fn set_slots(app_handle: AppHandle, slots: Vec<KeyInfo>) -> Result<(), Str
 
     *app_handle.state::<AppState>().keys.lock().unwrap() = slots;
 
-    // ROS 2 inputs are declared up front, at device build. With the host
-    // running, a changed catalog rebuilds the whole run (bridges are fixed at
-    // build) — a brief blip on model load, ros2 builds only.
-    #[cfg(feature = "ros2")]
+    // The catalog is read at device build — the profile's rig prefix and (under
+    // ros2) the typed input topics. With the host running, a changed catalog
+    // rebuilds the run — a brief blip on model load.
     if app_handle
         .state::<AppState>()
         .cancel_token

--- a/apps/vizij-standalone/src-tauri/src/lib.rs
+++ b/apps/vizij-standalone/src-tauri/src/lib.rs
@@ -643,6 +643,7 @@ async fn start_host(app: &AppHandle, emit_started: bool) -> Result<(), String> {
                     let mut builder = arora::Arora::builder()
                         .with_data_store(Box::new(store))
                         .with_host_module(skills::gaze_module())
+                        .with_host_module(vizij_arora_tts::host_module())
                         .with_behavior_interpreter(Box::new(skills::interpreter(&rig_prefix)))
                         .with_bridge(Box::new(ws_bridge));
                     #[cfg(feature = "ros2")]

--- a/apps/vizij-standalone/src-tauri/src/skills.rs
+++ b/apps/vizij-standalone/src-tauri/src/skills.rs
@@ -13,15 +13,34 @@ use arora::{HostModule, ModuleBuilder};
 use arora_types::call::CallResult;
 use vizij_arora_behavior::{gaze, task, ProcessingGraph};
 use vizij_arora_host::skills::LOOK_AT_FUNCTION;
-use vizij_graph_core::types::GraphSpec;
 
-/// The graph interpreter the device runs: an empty graph with the shipped
-/// look_at fragment registered — runs exist only while goals are live.
-pub fn interpreter() -> ProcessingGraph {
-    let mut graph =
-        ProcessingGraph::from_spec(GraphSpec::default()).expect("an empty graph spec encodes");
+/// The graph interpreter the device runs: the shipped ROS4HRI profile as the
+/// base graph — `standard/ros4hri/*` keys (typed topics, the gaze skill's
+/// writes) become the face's `standard/vizij/*` controls right on the device,
+/// so the webview only renders — with the look_at fragment registered on top
+/// (runs exist only while goals are live). `rig_prefix` namespaces the
+/// profile's outputs onto the face the webview advertised (empty: none did).
+pub fn interpreter(rig_prefix: &str) -> ProcessingGraph {
+    let (_, profile) = vizij_arora_host::ros4hri::ros4hri_source(rig_prefix);
+    let spec = vizij_arora_behavior::parse_spec(&profile.to_string())
+        .expect("the shipped ros4hri profile parses");
+    let mut graph = ProcessingGraph::from_spec(spec).expect("the ros4hri profile encodes");
     graph.set_task_fragment(gaze::look_at_id(), gaze::look_at_fragment());
     graph
+}
+
+/// The rig prefix of the face the webview advertised — the path segment its
+/// standard controls live under (e.g. `rig/quori_latest/` out of
+/// `rig/quori_latest/standard/vizij/mouth/morph/jaw_open`). Empty until a
+/// face with standard coverage loads.
+pub fn rig_prefix_of(key_paths: impl Iterator<Item = String>) -> String {
+    key_paths
+        .filter_map(|path| {
+            path.find("standard/vizij/")
+                .map(|at| path[..at].to_string())
+        })
+        .next()
+        .unwrap_or_default()
 }
 
 /// The gaze module: the look_at contract, described so bridges discover it
@@ -67,7 +86,7 @@ mod tests {
         let mut arora = arora::Arora::builder()
             .with_data_store(Box::new(store.clone()))
             .with_host_module(gaze_module())
-            .with_behavior_interpreter(Box::new(interpreter()))
+            .with_behavior_interpreter(Box::new(interpreter("rig/test_face/")))
             .build()
             .expect("the device composes");
 
@@ -118,5 +137,30 @@ mod tests {
             .expect("the halt dispatches through the engine");
         arora.step(Duration::from_millis(16)).expect("step");
         assert_ne!(read(&handle.status), Some(task::running()));
+
+        // The ROS4HRI profile runs as the interpreter's base graph: the gaze
+        // intent the run wrote onto standard/ros4hri/* comes out as the
+        // face's rig-prefixed standard controls — ROS4HRI understanding on
+        // the device itself, the webview only renders.
+        let snapshot = store.snapshot();
+        assert!(
+            snapshot.storage.iter().any(|(key, value)| key
+                .path
+                .starts_with("rig/test_face/standard/vizij/")
+                && value.is_some()),
+            "the profile writes the face's standard controls"
+        );
+    }
+
+    /// The rig prefix is read off the advertised catalog: the segment before
+    /// the face's standard controls.
+    #[test]
+    fn the_rig_prefix_comes_from_the_catalog() {
+        let paths = [
+            "gaze/pupil/left/x".to_string(),
+            "rig/quori_latest/standard/vizij/mouth/morph/jaw_open".to_string(),
+        ];
+        assert_eq!(rig_prefix_of(paths.into_iter()), "rig/quori_latest/");
+        assert_eq!(rig_prefix_of(std::iter::empty()), "");
     }
 }


### PR DESCRIPTION
The two halves Victor named on top of the one-run device (#110):

- **ROS4HRI understanding runs on the device.** The interpreter's base graph is the shipped **ros4hri profile**: `standard/ros4hri/*` (the bridge's typed face topics, the gaze skill's writes) becomes the face's standard controls in the device run itself, namespaced onto the face the webview advertised — the rig prefix is read off the key catalog (`rig/<faceId>/standard/vizij/…`), and a changed catalog now rebuilds the run regardless of `ros2`. The store mirror carries the produced controls to the webview, which only renders. Proof extended: the look_at run's gaze intent comes out as `rig/test_face/standard/vizij/*` in the device test.
- **The device speaks with the same module as the native app**: [`vizij-arora-tts` 1.0.0](https://crates.io/crates/vizij-arora-tts) ([vizij-rs #100](https://github.com/vizij-ai/vizij-rs/pull/100)) registers `say(text, voice) → Status` with the streaming viseme out-parameter; described, so the ROS 2 task-run plane serves it as an action alongside `/skill/look_at`. Provider selection stays consumer-side (the split into per-provider crates is [VIZ-100](https://linear.app/semio-ai/issue/VIZ-100/split-vizij-arora-tts-per-provider-trusted-publisher-for-the-crates)).

Green: tests (device look_at→profile→prefixed standard controls; catalog→prefix), default/`ros2` configs, fmt/clippy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)