### PR TITLE
docs(standalone): the README tells the served truth

### DIFF
--- a/apps/vizij-standalone/README.md
+++ b/apps/vizij-standalone/README.md
@@ -108,8 +108,9 @@ naming is gone.)
 
 For protocol details, inspect:
 
-- [`src-tauri/src/host.rs`](./src-tauri/src/host.rs) — the multi-bridge pump
-- [`src-tauri/src/lib.rs`](./src-tauri/src/lib.rs) — the Tauri commands + method surface
+- [`src-tauri/src/lib.rs`](./src-tauri/src/lib.rs) — the device run, the Tauri commands + WS method surface
+- [`src-tauri/src/skills.rs`](./src-tauri/src/skills.rs) — what the run composes (the ROS4HRI profile, the gaze contract)
+- [`src-tauri/src/host.rs`](./src-tauri/src/host.rs) — the Studio pump's plumbing
 
 For quick manual testing (the built-in control panel speaks this vocabulary too):
 
@@ -125,18 +126,23 @@ The server binds loopback by default; expose it only on trusted networks.
 
 ## ROS2 Control Surface
 
-When built with the default `ros2` feature, the host also attaches an
-`arora-bridge-ros2` bridge sharing the same store.
+When built with the `ros2` feature, the device's arora run attaches an
+`arora-bridge-ros2` bridge (5.x) with the **ROS4HRI exposure preset** —
+the standalone joins the ROS graph as a ROS4HRI face renderer:
 
-Current behavior:
-
-- keys are exposed as ROS 2 topics under `/{namespace}/keys/...` — the device
-  **publishes** each changed key to its topic and **subscribes** to the input
-  keys (the input topics are declared up front from the key catalog, so the
-  ROS 2 bridge is rebuilt when the catalog changes)
-- **data topics only** — there is **no** ROS 2 method/service surface. The
-  `reset` / `speak` / `mute` / `transport` methods stay on the WebSocket (and
-  Studio) bridge. Restoring ROS 2 method parity is tracked in **ARORA-62**.
+- **typed face topics** — `/robot_face/{expression,look_at,tts}` and
+  `/expressive_face/{look_at,speech}` land on the profile's
+  `standard/ros4hri/*` keys; the ROS4HRI profile graph runs **in the device**
+  and turns them into the face's standard controls (the webview only renders)
+- **actions** — `/skill/look_at` (`interaction_skills/LookAt`: track / glance /
+  reset, priorities, standard error codes) and the device's described task-run
+  methods (e.g. `say`) under `/{namespace}/actions/...`
+- **data topics** — every key under `/{namespace}/keys/...`: the device
+  publishes each changed key and subscribes to the input keys (declared up
+  front from the key catalog; a changed catalog rebuilds the run)
+- the `reset` / `speak` / `mute` / `transport` app methods stay on the
+  WebSocket (and Studio) bridge — they are WS-registry methods, not device
+  methods
 - the namespace defaults to `vizij`; the DDS domain defaults to `0`
 
 Relevant files:
@@ -517,7 +523,7 @@ WebSocket/manual panel checks:
 - call `reset` from the panel or `wscat`
 - if a bundle contains transport items, verify the Transport tab can list, play, pause, and stop them
 
-ROS2 data-topic check (data topics only — no method services; see ARORA-62):
+ROS2 check (topics and the served actions):
 
 ```bash
 # with the app running (default `ros2` feature), from src-tauri/:

--- a/apps/vizij-standalone/src-tauri/Cargo.toml
+++ b/apps/vizij-standalone/src-tauri/Cargo.toml
@@ -73,12 +73,13 @@ windows = { version = "0.58", features = ["Win32_System_Console"] }
 
 [features]
 default = []
-# ROS 2 data-topic bridge (`arora-bridge-ros2`). Opt-in — build with
-# `--features ros2` (or `pnpm tauri ... -- --features ros2`) for robot/ROS
-# deployments; the default standalone build has no ROS 2 stack. Data topics only:
-# the device's keys are exposed under `/{ns}/keys/{path}`; there is no ROS 2
-# method/service surface (that parity is tracked in ARORA-62). reset/speak/mute/
-# transport stay on the WebSocket + Studio bridges.
+# ROS 2 bridge (`arora-bridge-ros2`). Opt-in — build with `--features ros2`
+# (or `pnpm tauri ... -- --features ros2`) for robot/ROS deployments; the
+# default standalone build has no ROS 2 stack. Attached with the ROS4HRI
+# exposure preset: the typed face topics, the /skill/look_at action (and the
+# described task-run methods as actions), and every key as a data topic under
+# `/{ns}/keys/{path}`. The reset/speak/mute/transport app methods stay on the
+# WebSocket + Studio bridges (WS-registry methods, not device methods).
 # `ros2` defaults to the DDS backend (`ros2-dds`); `ros2-zenoh` selects the
 # rmw_zenoh-compatible Zenoh backend instead. Exactly one backend is active
 # (arora-bridge-ros2 forwards to ros2-client's mutually-exclusive `dds`/`zenoh`).


### PR DESCRIPTION
Doc sweep after #110/#111: the standalone README's ROS 2 section and the src-tauri feature docs still described the pre-device era (data topics only, method parity 'tracked in ARORA-62', the multi-bridge pump). Now they state what is served: the ROS4HRI typed face topics, `/skill/look_at` + described task-run methods as actions, data topics, the profile running in the device — and which methods deliberately remain WS-registry ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)