### PR TITLE
Profiles in authoring: import one, see its controls, bind them

### DIFF
--- a/apps/vizij-authoring/package.json
+++ b/apps/vizij-authoring/package.json
@@ -33,7 +33,7 @@
     "@vizij/node-graph-react": "workspace:*",
     "@vizij/node-graph": "^0.7.0",
     "@vizij/render": "workspace:*",
-    "@vizij/runtime": "^2.4.0",
+    "@vizij/runtime": "^2.5.0",
     "@vizij/runtime-react": "workspace:*",
     "@vizij/utils": "workspace:*",
     "@vizij/value-json": "^0.2.0",

--- a/apps/vizij-authoring/package.json
+++ b/apps/vizij-authoring/package.json
@@ -33,7 +33,7 @@
     "@vizij/node-graph-react": "workspace:*",
     "@vizij/node-graph": "^0.7.0",
     "@vizij/render": "workspace:*",
-    "@vizij/runtime": "^2.5.0",
+    "@vizij/runtime": "^2.4.0",
     "@vizij/runtime-react": "workspace:*",
     "@vizij/utils": "workspace:*",
     "@vizij/value-json": "^0.2.0",

--- a/apps/vizij-authoring/src/App.tsx
+++ b/apps/vizij-authoring/src/App.tsx
@@ -99,6 +99,7 @@ import {
   embeddedProfileId,
   useStandardProfiles,
 } from "./hooks/useStandardProfiles";
+import { DeclaredProfilesProvider } from "./state/DeclaredProfilesContext";
 import { useProfileInputs } from "./hooks/useProfileInputs";
 import { useProfiles } from "./hooks/useProfiles";
 import { ProfileImportDialog } from "./components/app/ProfileImportDialog";
@@ -4881,286 +4882,292 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
 
   return (
     <ReferenceFaceProvider value={referenceFaceContextValue}>
-      <SharedVariableSyncProvider value={sharedVariableSync}>
-        {memoryInvestigation.enabled ? (
-          <MemoryDebugBridge loader={loader} />
-        ) : null}
-        <WorkspaceLayout
-          menuBar={menuBar}
-          // Left
-          leftTopVisible={effectiveHierarchyPanelVisible}
-          leftTopPanel={
-            <HierarchyPanel
-              showSelectionGlow={showSelectionGlow}
-              onToggleSelectionGlow={setShowSelectionGlow}
-              onSelectObject={handleSelectObjectWithInspectorSync}
-              referenceFaceFile={referenceFaceContextValue.file}
-              onClosePanel={handleHideHierarchyPanel}
-            />
-          }
-          leftBottomPanel={
-            <VariablesPanel
-              selectedRigId={selectedRigId}
-              selectedPoseId={selectedPoseId}
-              selectedSceneId={selectedSceneId}
-              onSelectRig={handleSelectRigWithInspectorSync}
-              onSelectPose={handleSelectPoseWithInspectorSync}
-              onSelectScene={handleSelectObjectWithInspectorSync}
-              availableSurfaces={authoringSurfaces}
-              activeSurfaceOverride={activeAuthoringSurface}
-              onActiveSurfaceChange={(surface) => {
-                if (surface === "inputs") {
-                  return;
+      <DeclaredProfilesProvider profiles={declaredProfiles}>
+        <SharedVariableSyncProvider value={sharedVariableSync}>
+          {memoryInvestigation.enabled ? (
+            <MemoryDebugBridge loader={loader} />
+          ) : null}
+          <WorkspaceLayout
+            menuBar={menuBar}
+            // Left
+            leftTopVisible={effectiveHierarchyPanelVisible}
+            leftTopPanel={
+              <HierarchyPanel
+                showSelectionGlow={showSelectionGlow}
+                onToggleSelectionGlow={setShowSelectionGlow}
+                onSelectObject={handleSelectObjectWithInspectorSync}
+                referenceFaceFile={referenceFaceContextValue.file}
+                onClosePanel={handleHideHierarchyPanel}
+              />
+            }
+            leftBottomPanel={
+              <VariablesPanel
+                selectedRigId={selectedRigId}
+                selectedPoseId={selectedPoseId}
+                selectedSceneId={selectedSceneId}
+                onSelectRig={handleSelectRigWithInspectorSync}
+                onSelectPose={handleSelectPoseWithInspectorSync}
+                onSelectScene={handleSelectObjectWithInspectorSync}
+                availableSurfaces={authoringSurfaces}
+                activeSurfaceOverride={activeAuthoringSurface}
+                onActiveSurfaceChange={(surface) => {
+                  if (surface === "inputs") {
+                    return;
+                  }
+                  setActiveAuthoringSurface(surface);
+                }}
+                selectedPoseGroup={selectedPoseGroup}
+                onSelectPoseGroup={handleSelectPoseGroupWithInspectorSync}
+                selectedBlendStage={selectedBlendStage}
+                onSelectBlendStage={handleSelectBlendStageWithInspectorSync}
+                animationTargets={authoringAnimationTargets}
+                onSelectAnimationTarget={handleInspectAnimationTarget}
+                onCreateAnimationTarget={handleCreateAndInspectAnimationTarget}
+                onDuplicateAnimationTarget={handleDuplicateAnimationTarget}
+                onDeleteAnimationTarget={deleteAnimationTargetById}
+                onPlayAnimationTarget={handlePlayAnimationTarget}
+                onPauseAnimationTarget={handlePauseAnimationTarget}
+                onStopAnimationTarget={handleStopAnimationTarget}
+                programTargets={authoringProgramTargets}
+                onSelectProgramTarget={handleInspectProgramTarget}
+                onCreateProgramTarget={handleCreateAndInspectProgramTarget}
+                onDuplicateProgramTarget={handleDuplicateProgramTarget}
+                onDeleteProgramTarget={deleteProceduralTargetById}
+                onPlayProgramTarget={handlePlayProgramTarget}
+                onPauseProgramTarget={handlePauseProgramTarget}
+                onStopProgramTarget={handleStopProgramTarget}
+                panelTitle="Authoring"
+                panelDescription="Author and organize drivers, poses, pose groups, animations, and programs."
+                onClosePanel={handleHideControlAuthoringPanel}
+                animationActive={effectiveAnimationPanelVisible}
+                centerAuthoringMode={centerAuthoringMode}
+                runtimeFaceId={faceId}
+                enableMotionGraphPruning={false}
+              />
+            }
+            leftBottomVisible2={false}
+            leftBottomVisible3={false}
+            leftBottomPanel3={null}
+            leftMiddleVisible={effectiveInputControlsPanelVisible}
+            leftMiddlePanel={
+              <VariablesPanel
+                selectedRigId={selectedRigId}
+                selectedPoseId={selectedPoseId}
+                selectedSceneId={selectedSceneId}
+                onSelectRig={handleSelectRigWithInspectorSync}
+                onSelectPose={handleSelectPoseWithInspectorSync}
+                onSelectScene={handleSelectObjectWithInspectorSync}
+                availableSurfaces={inputControlSurfaces}
+                panelTitle="Input Controls"
+                panelDescription="Preview and adjust live rig and pose-weight inputs plus procedural animation I/O."
+                onClosePanel={handleHideInputControlsPanel}
+                motionGraphActive={effectiveMotionGraphPanelVisible}
+                animationActive={effectiveAnimationPanelVisible}
+                centerAuthoringMode={centerAuthoringMode}
+                runtimeFaceId={faceId}
+                enableMotionGraphPruning={
+                  !editingProfileId && !editingSkillId && !editingAdaptation
                 }
-                setActiveAuthoringSurface(surface);
-              }}
-              selectedPoseGroup={selectedPoseGroup}
-              onSelectPoseGroup={handleSelectPoseGroupWithInspectorSync}
-              selectedBlendStage={selectedBlendStage}
-              onSelectBlendStage={handleSelectBlendStageWithInspectorSync}
-              animationTargets={authoringAnimationTargets}
-              onSelectAnimationTarget={handleInspectAnimationTarget}
-              onCreateAnimationTarget={handleCreateAndInspectAnimationTarget}
-              onDuplicateAnimationTarget={handleDuplicateAnimationTarget}
-              onDeleteAnimationTarget={deleteAnimationTargetById}
-              onPlayAnimationTarget={handlePlayAnimationTarget}
-              onPauseAnimationTarget={handlePauseAnimationTarget}
-              onStopAnimationTarget={handleStopAnimationTarget}
-              programTargets={authoringProgramTargets}
-              onSelectProgramTarget={handleInspectProgramTarget}
-              onCreateProgramTarget={handleCreateAndInspectProgramTarget}
-              onDuplicateProgramTarget={handleDuplicateProgramTarget}
-              onDeleteProgramTarget={deleteProceduralTargetById}
-              onPlayProgramTarget={handlePlayProgramTarget}
-              onPauseProgramTarget={handlePauseProgramTarget}
-              onStopProgramTarget={handleStopProgramTarget}
-              panelTitle="Authoring"
-              panelDescription="Author and organize drivers, poses, pose groups, animations, and programs."
-              onClosePanel={handleHideControlAuthoringPanel}
-              animationActive={effectiveAnimationPanelVisible}
-              centerAuthoringMode={centerAuthoringMode}
-              runtimeFaceId={faceId}
-              enableMotionGraphPruning={false}
-            />
-          }
-          leftBottomVisible2={false}
-          leftBottomVisible3={false}
-          leftBottomPanel3={null}
-          leftMiddleVisible={effectiveInputControlsPanelVisible}
-          leftMiddlePanel={
-            <VariablesPanel
-              selectedRigId={selectedRigId}
-              selectedPoseId={selectedPoseId}
-              selectedSceneId={selectedSceneId}
-              onSelectRig={handleSelectRigWithInspectorSync}
-              onSelectPose={handleSelectPoseWithInspectorSync}
-              onSelectScene={handleSelectObjectWithInspectorSync}
-              availableSurfaces={inputControlSurfaces}
-              panelTitle="Input Controls"
-              panelDescription="Preview and adjust live rig and pose-weight inputs plus procedural animation I/O."
-              onClosePanel={handleHideInputControlsPanel}
-              motionGraphActive={effectiveMotionGraphPanelVisible}
-              animationActive={effectiveAnimationPanelVisible}
-              centerAuthoringMode={centerAuthoringMode}
-              runtimeFaceId={faceId}
-              enableMotionGraphPruning={
-                !editingProfileId && !editingSkillId && !editingAdaptation
-              }
-              onSelectMotionGraphNode={
-                handleSelectMotionGraphNodeWithInspectorSync
-              }
-            />
-          }
-          leftBottomVisible={effectiveControlAuthoringPanelVisible}
-          viewport={viewportContent}
-          bottomVisible={effectiveAnimationPanelVisible}
-          bottomPanel={
-            <AnimationPanel
-              onClosePanel={handleHideAnimationPanel}
-              onInspectTrack={handleInspectAnimationTrackFromTimeline}
-              playbackState={selectedAnimationPanelPlaybackState}
-              onPlayTransport={
-                resolvedSelectedAnimationTargetId
-                  ? handlePlayAnimationRuntime
-                  : undefined
-              }
-              onPauseTransport={
-                selectedAnimationCanPauseOrStop
-                  ? handlePauseAnimationRuntime
-                  : undefined
-              }
-              onStopTransport={
-                selectedAnimationCanPauseOrStop
-                  ? handleStopAnimationRuntime
-                  : undefined
-              }
-              statusMessage={animationPanelStatusMessage}
-            />
-          }
-          centerPanelDefaultSize={centerPanelDefaultSize}
-          // Right
-          rightTopVisible={false}
-          rightTopPanel={null}
-          rightBottomVisible={
-            (effectiveMotionGraphPanelVisible &&
-              effectiveMotionGraphPalettePanelVisible) ||
-            effectiveInspectorPanelVisible ||
-            effectiveSpeechPanelVisible ||
-            effectiveDebugPanelVisible
-          }
-          rightSidebarDefaultSize={rightSidebarDefaultSize}
-          rightSidebarResetKey={rightSidebarResetKey}
-          rightBottomPanel={
-            <div className="flex h-full min-h-0 flex-col">
-              {effectiveMotionGraphPanelVisible &&
-              effectiveMotionGraphPalettePanelVisible ? (
-                <div className="flex-1 min-h-0 overflow-y-auto">
-                  <MotionGraphPalettePanel
-                    onClosePanel={handleHideMotionGraphPalettePanel}
-                  />
-                </div>
-              ) : null}
-              {effectiveMotionGraphPanelVisible &&
-              effectiveMotionGraphPalettePanelVisible &&
-              (effectiveInspectorPanelVisible ||
-                effectiveSpeechPanelVisible ||
-                effectiveDebugPanelVisible) ? (
-                <div className="border-t border-border-default/70" />
-              ) : null}
-              {effectiveInspectorPanelVisible ? (
-                <div className="flex-1 min-h-0 overflow-y-auto">
-                  <InspectorPanel
-                    activeInspectorTarget={activeInspectorTarget}
-                    selectedPoseGroup={selectedPoseGroup}
-                    onSelectPoseGroup={handleSelectPoseGroupWithInspectorSync}
-                    selectedBlendStage={selectedBlendStage}
-                    onSelectBlendStage={handleSelectBlendStageWithInspectorSync}
-                    selectedAnimationTarget={selectedAnimationInspectorTarget}
-                    onRenameAnimationTarget={handleRenameAnimationTarget}
-                    onUpdateAnimationTargetDuration={
-                      handleUpdateAnimationTargetDuration
-                    }
-                    onInspectAnimationTrack={
-                      handleInspectAnimationTrackFromInspector
-                    }
-                    onInspectAnimationInput={
-                      handleInspectInputFromAuthoringInspector
-                    }
-                    selectedProgramTarget={selectedProgramInspectorTarget}
-                    onRenameProgramTarget={handleRenameProgramTarget}
-                    onInspectProgramNode={handleInspectProgramNodeFromInspector}
-                    onInspectProgramInput={
-                      handleInspectInputFromAuthoringInspector
-                    }
-                    hasReferenceFaceFile={Boolean(
-                      referenceFaceContextValue.file,
-                    )}
-                    onClosePanel={handleHideInspectorPanel}
-                  />
-                </div>
-              ) : null}
-              {effectiveSpeechPanelVisible ? (
-                <div className="flex-1 min-h-0 overflow-y-auto border-t border-border-default/70">
-                  <SpeechPanel onClosePanel={handleHideSpeechPanel} />
-                </div>
-              ) : null}
-              {effectiveDebugPanelVisible ? (
-                <div className="flex-1 min-h-0 overflow-y-auto border-t border-border-default/70">
-                  <DebugPanel
-                    rootId={loader.rootId}
-                    loadedBundle={loader.bundle}
-                    updateBundle={loader.updateBundle}
-                    isLoading={loader.isLoading}
-                    onClosePanel={handleHideDebugPanel}
-                  />
-                </div>
-              ) : null}
-            </div>
-          }
+                onSelectMotionGraphNode={
+                  handleSelectMotionGraphNodeWithInspectorSync
+                }
+              />
+            }
+            leftBottomVisible={effectiveControlAuthoringPanelVisible}
+            viewport={viewportContent}
+            bottomVisible={effectiveAnimationPanelVisible}
+            bottomPanel={
+              <AnimationPanel
+                onClosePanel={handleHideAnimationPanel}
+                onInspectTrack={handleInspectAnimationTrackFromTimeline}
+                playbackState={selectedAnimationPanelPlaybackState}
+                onPlayTransport={
+                  resolvedSelectedAnimationTargetId
+                    ? handlePlayAnimationRuntime
+                    : undefined
+                }
+                onPauseTransport={
+                  selectedAnimationCanPauseOrStop
+                    ? handlePauseAnimationRuntime
+                    : undefined
+                }
+                onStopTransport={
+                  selectedAnimationCanPauseOrStop
+                    ? handleStopAnimationRuntime
+                    : undefined
+                }
+                statusMessage={animationPanelStatusMessage}
+              />
+            }
+            centerPanelDefaultSize={centerPanelDefaultSize}
+            // Right
+            rightTopVisible={false}
+            rightTopPanel={null}
+            rightBottomVisible={
+              (effectiveMotionGraphPanelVisible &&
+                effectiveMotionGraphPalettePanelVisible) ||
+              effectiveInspectorPanelVisible ||
+              effectiveSpeechPanelVisible ||
+              effectiveDebugPanelVisible
+            }
+            rightSidebarDefaultSize={rightSidebarDefaultSize}
+            rightSidebarResetKey={rightSidebarResetKey}
+            rightBottomPanel={
+              <div className="flex h-full min-h-0 flex-col">
+                {effectiveMotionGraphPanelVisible &&
+                effectiveMotionGraphPalettePanelVisible ? (
+                  <div className="flex-1 min-h-0 overflow-y-auto">
+                    <MotionGraphPalettePanel
+                      onClosePanel={handleHideMotionGraphPalettePanel}
+                    />
+                  </div>
+                ) : null}
+                {effectiveMotionGraphPanelVisible &&
+                effectiveMotionGraphPalettePanelVisible &&
+                (effectiveInspectorPanelVisible ||
+                  effectiveSpeechPanelVisible ||
+                  effectiveDebugPanelVisible) ? (
+                  <div className="border-t border-border-default/70" />
+                ) : null}
+                {effectiveInspectorPanelVisible ? (
+                  <div className="flex-1 min-h-0 overflow-y-auto">
+                    <InspectorPanel
+                      activeInspectorTarget={activeInspectorTarget}
+                      selectedPoseGroup={selectedPoseGroup}
+                      onSelectPoseGroup={handleSelectPoseGroupWithInspectorSync}
+                      selectedBlendStage={selectedBlendStage}
+                      onSelectBlendStage={
+                        handleSelectBlendStageWithInspectorSync
+                      }
+                      selectedAnimationTarget={selectedAnimationInspectorTarget}
+                      onRenameAnimationTarget={handleRenameAnimationTarget}
+                      onUpdateAnimationTargetDuration={
+                        handleUpdateAnimationTargetDuration
+                      }
+                      onInspectAnimationTrack={
+                        handleInspectAnimationTrackFromInspector
+                      }
+                      onInspectAnimationInput={
+                        handleInspectInputFromAuthoringInspector
+                      }
+                      selectedProgramTarget={selectedProgramInspectorTarget}
+                      onRenameProgramTarget={handleRenameProgramTarget}
+                      onInspectProgramNode={
+                        handleInspectProgramNodeFromInspector
+                      }
+                      onInspectProgramInput={
+                        handleInspectInputFromAuthoringInspector
+                      }
+                      hasReferenceFaceFile={Boolean(
+                        referenceFaceContextValue.file,
+                      )}
+                      onClosePanel={handleHideInspectorPanel}
+                    />
+                  </div>
+                ) : null}
+                {effectiveSpeechPanelVisible ? (
+                  <div className="flex-1 min-h-0 overflow-y-auto border-t border-border-default/70">
+                    <SpeechPanel onClosePanel={handleHideSpeechPanel} />
+                  </div>
+                ) : null}
+                {effectiveDebugPanelVisible ? (
+                  <div className="flex-1 min-h-0 overflow-y-auto border-t border-border-default/70">
+                    <DebugPanel
+                      rootId={loader.rootId}
+                      loadedBundle={loader.bundle}
+                      updateBundle={loader.updateBundle}
+                      isLoading={loader.isLoading}
+                      onClosePanel={handleHideDebugPanel}
+                    />
+                  </div>
+                ) : null}
+              </div>
+            }
+          />
+        </SharedVariableSyncProvider>
+
+        <AppWizards
+          showExportDialog={showExportDialog}
+          onCloseExportDialog={() => setShowExportDialog(false)}
+          rootId={rootId}
+          exportSceneRoot={exportSceneRoot}
+          runtimeExportBodies={runtimeExportBodies}
+          sourceName={sourceName}
+          loadedBundle={loadedBundle}
+          authoredAnimationClips={authoredAnimationClipsForExport}
+          authoredProceduralPrograms={authoredProceduralProgramsForExport}
+          activeMotionGraphId={activeMotionGraphIdForExport}
+          canExport={canExport}
+          handleImportPoseGraphFile={handleImportPoseGraphFile}
+          poseGraphRemap={poseGraphRemap}
+          handlePoseGraphRemapApply={handlePoseGraphRemapApply}
+          handlePoseGraphRemapCancel={handlePoseGraphRemapCancel}
+          onExportGlbComplete={markGlbExportSaved}
+          registerGlbExportHandler={handleRegisterGlbExportHandler}
         />
-      </SharedVariableSyncProvider>
 
-      <AppWizards
-        showExportDialog={showExportDialog}
-        onCloseExportDialog={() => setShowExportDialog(false)}
-        rootId={rootId}
-        exportSceneRoot={exportSceneRoot}
-        runtimeExportBodies={runtimeExportBodies}
-        sourceName={sourceName}
-        loadedBundle={loadedBundle}
-        authoredAnimationClips={authoredAnimationClipsForExport}
-        authoredProceduralPrograms={authoredProceduralProgramsForExport}
-        activeMotionGraphId={activeMotionGraphIdForExport}
-        canExport={canExport}
-        handleImportPoseGraphFile={handleImportPoseGraphFile}
-        poseGraphRemap={poseGraphRemap}
-        handlePoseGraphRemapApply={handlePoseGraphRemapApply}
-        handlePoseGraphRemapCancel={handlePoseGraphRemapCancel}
-        onExportGlbComplete={markGlbExportSaved}
-        registerGlbExportHandler={handleRegisterGlbExportHandler}
-      />
+        <OrientationConfirmationDialog
+          open={showOrientationDialog}
+          onClose={handleOrientationDialogClose}
+          axisDegrees={orientationAxisDegrees}
+          axisAvailability={orientationAxisAvailability}
+          onRotateAxis={handleRotateSceneOrientation}
+        />
 
-      <OrientationConfirmationDialog
-        open={showOrientationDialog}
-        onClose={handleOrientationDialogClose}
-        axisDegrees={orientationAxisDegrees}
-        axisAvailability={orientationAxisAvailability}
-        onRotateAxis={handleRotateSceneOrientation}
-      />
-
-      {/* Hidden File Input for Import */}
-      <input
-        type="file"
-        ref={fileInputRef}
-        className="hidden"
-        accept=".glb,.gltf"
-        data-testid="app-import-file-input"
-        onChange={(e) => void handleFileChange(e)}
-      />
-      {/* Hidden file input for "Replace <profile> from JSON..." */}
-      <input
-        type="file"
-        ref={profileJsonInputRef}
-        className="hidden"
-        accept=".json"
-        data-testid="app-profile-json-input"
-        onChange={handleProfileJsonFileChange}
-      />
-      {/* Hidden file input for "Replace <skill> from JSON..." */}
-      <input
-        type="file"
-        ref={skillJsonInputRef}
-        className="hidden"
-        accept=".json"
-        data-testid="app-skill-json-input"
-        onChange={handleSkillJsonFileChange}
-      />
-      <ProfileImportDialog
-        open={profileImportOpen}
-        onClose={() => setProfileImportOpen(false)}
-        available={availableProfiles}
-        declaredIds={declaredProfileIds}
-        onImport={(id) => void importProfile(id).then(handleProfileDeclared)}
-        onImportFile={handleImportProfileJson}
-      />
-      {/* Hidden file input for "Import Profile from JSON..." */}
-      <input
-        type="file"
-        ref={profileImportInputRef}
-        className="hidden"
-        accept=".json"
-        data-testid="app-profile-import-input"
-        onChange={handleProfileImportFileChange}
-      />
-      {/* Hidden file input for "Replace Adaptation from JSON..." */}
-      <input
-        type="file"
-        ref={adaptationJsonInputRef}
-        className="hidden"
-        accept=".json"
-        data-testid="app-adaptation-json-input"
-        onChange={handleAdaptationJsonFileChange}
-      />
+        {/* Hidden File Input for Import */}
+        <input
+          type="file"
+          ref={fileInputRef}
+          className="hidden"
+          accept=".glb,.gltf"
+          data-testid="app-import-file-input"
+          onChange={(e) => void handleFileChange(e)}
+        />
+        {/* Hidden file input for "Replace <profile> from JSON..." */}
+        <input
+          type="file"
+          ref={profileJsonInputRef}
+          className="hidden"
+          accept=".json"
+          data-testid="app-profile-json-input"
+          onChange={handleProfileJsonFileChange}
+        />
+        {/* Hidden file input for "Replace <skill> from JSON..." */}
+        <input
+          type="file"
+          ref={skillJsonInputRef}
+          className="hidden"
+          accept=".json"
+          data-testid="app-skill-json-input"
+          onChange={handleSkillJsonFileChange}
+        />
+        <ProfileImportDialog
+          open={profileImportOpen}
+          onClose={() => setProfileImportOpen(false)}
+          available={availableProfiles}
+          declaredIds={declaredProfileIds}
+          onImport={(id) => void importProfile(id).then(handleProfileDeclared)}
+          onImportFile={handleImportProfileJson}
+        />
+        {/* Hidden file input for "Import Profile from JSON..." */}
+        <input
+          type="file"
+          ref={profileImportInputRef}
+          className="hidden"
+          accept=".json"
+          data-testid="app-profile-import-input"
+          onChange={handleProfileImportFileChange}
+        />
+        {/* Hidden file input for "Replace Adaptation from JSON..." */}
+        <input
+          type="file"
+          ref={adaptationJsonInputRef}
+          className="hidden"
+          accept=".json"
+          data-testid="app-adaptation-json-input"
+          onChange={handleAdaptationJsonFileChange}
+        />
+      </DeclaredProfilesProvider>
     </ReferenceFaceProvider>
   );
 }

--- a/apps/vizij-authoring/src/App.tsx
+++ b/apps/vizij-authoring/src/App.tsx
@@ -98,7 +98,7 @@ import {
   embeddedProfileId,
   useStandardProfiles,
 } from "./hooks/useStandardProfiles";
-import { FACE_PROFILE_ID, useProfiles } from "./hooks/useProfiles";
+import { useProfiles } from "./hooks/useProfiles";
 import { useStandardAdaptation } from "./hooks/useStandardAdaptation";
 import { embeddedSkillId, useSkills } from "./hooks/useSkills";
 import { carriedBundleGraphs } from "./hooks/useVizijExport";
@@ -4085,10 +4085,7 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
     updateBundle: loader.updateBundle,
   });
   const {
-    available: availableProfiles,
     declared: declaredProfiles,
-    declaredIds: declaredProfileIds,
-    importProfile,
     importProfileJson,
     exportProfileJson: exportDeclaredProfileJson,
     removeProfile,
@@ -4097,37 +4094,27 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
     updateBundle: loader.updateBundle,
   });
   /**
-   * The adaptation maps the Vizij face profile onto this face, so enabling it
-   * needs that profile. Use the one the face already declares; otherwise import
-   * it, which declares it on the GLB — the vocabulary travels with the asset
-   * rather than being implied by the graph built from it.
+   * The adaptation maps a profile onto this face's poses, so it needs one the
+   * face declares. There is no registry to fall back on — a profile arrives as
+   * a file the author chose — so with none declared the action refuses and says
+   * so rather than inventing a vocabulary.
    */
   const handleToggleStandardAdaptation = useCallback(
-    async (enabled: boolean) => {
+    (enabled: boolean) => {
       if (!enabled) {
         toggleStandardAdaptation(false);
         return;
       }
-      const profile =
-        declaredProfiles.find((entry) => entry.id === FACE_PROFILE_ID) ??
-        (await importProfile(FACE_PROFILE_ID));
+      const profile = declaredProfiles[0];
       if (!profile) {
-        console.error(`cannot adapt without the ${FACE_PROFILE_ID} profile`);
+        console.error(
+          "import a profile first (File → Profiles → Import Profile from JSON...)",
+        );
         return;
       }
       toggleStandardAdaptation(true, profile);
     },
-    [declaredProfiles, importProfile, toggleStandardAdaptation],
-  );
-  const handleToggleProfile = useCallback(
-    (id: string, enabled: boolean) => {
-      if (enabled) {
-        void importProfile(id);
-      } else {
-        removeProfile(id);
-      }
-    },
-    [importProfile, removeProfile],
+    [declaredProfiles, toggleStandardAdaptation],
   );
   const profileImportInputRef = useRef<HTMLInputElement>(null);
   const handleImportProfileJson = useCallback(() => {
@@ -4308,11 +4295,10 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
       onEditStandardProfileGraph={handleEditStandardProfileGraph}
       standardAdaptationEmbedded={standardAdaptationEmbedded}
       onToggleStandardAdaptation={handleToggleStandardAdaptation}
-      profiles={availableProfiles}
-      declaredProfileIds={declaredProfileIds}
-      onToggleProfile={handleToggleProfile}
+      declaredProfiles={declaredProfiles}
       onImportProfileJson={handleImportProfileJson}
       onExportProfileJson={exportDeclaredProfileJson}
+      onRemoveProfile={removeProfile}
       onExportStandardAdaptationJson={exportStandardAdaptationJson}
       onReplaceStandardAdaptationJson={handleReplaceStandardAdaptationJson}
       onEditStandardAdaptationGraph={handleEditStandardAdaptationGraph}

--- a/apps/vizij-authoring/src/App.tsx
+++ b/apps/vizij-authoring/src/App.tsx
@@ -98,6 +98,7 @@ import {
   embeddedProfileId,
   useStandardProfiles,
 } from "./hooks/useStandardProfiles";
+import { FACE_PROFILE_ID, useProfiles } from "./hooks/useProfiles";
 import { useStandardAdaptation } from "./hooks/useStandardAdaptation";
 import { embeddedSkillId, useSkills } from "./hooks/useSkills";
 import { carriedBundleGraphs } from "./hooks/useVizijExport";
@@ -4083,6 +4084,65 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
     bundle: loader.bundle,
     updateBundle: loader.updateBundle,
   });
+  const {
+    available: availableProfiles,
+    declared: declaredProfiles,
+    declaredIds: declaredProfileIds,
+    importProfile,
+    importProfileJson,
+    exportProfileJson: exportDeclaredProfileJson,
+    removeProfile,
+  } = useProfiles({
+    bundle: loader.bundle,
+    updateBundle: loader.updateBundle,
+  });
+  /**
+   * The adaptation maps the Vizij face profile onto this face, so enabling it
+   * needs that profile. Use the one the face already declares; otherwise import
+   * it, which declares it on the GLB — the vocabulary travels with the asset
+   * rather than being implied by the graph built from it.
+   */
+  const handleToggleStandardAdaptation = useCallback(
+    async (enabled: boolean) => {
+      if (!enabled) {
+        toggleStandardAdaptation(false);
+        return;
+      }
+      const profile =
+        declaredProfiles.find((entry) => entry.id === FACE_PROFILE_ID) ??
+        (await importProfile(FACE_PROFILE_ID));
+      if (!profile) {
+        console.error(`cannot adapt without the ${FACE_PROFILE_ID} profile`);
+        return;
+      }
+      toggleStandardAdaptation(true, profile);
+    },
+    [declaredProfiles, importProfile, toggleStandardAdaptation],
+  );
+  const handleToggleProfile = useCallback(
+    (id: string, enabled: boolean) => {
+      if (enabled) {
+        void importProfile(id);
+      } else {
+        removeProfile(id);
+      }
+    },
+    [importProfile, removeProfile],
+  );
+  const profileImportInputRef = useRef<HTMLInputElement>(null);
+  const handleImportProfileJson = useCallback(() => {
+    profileImportInputRef.current?.click();
+  }, []);
+  const handleProfileImportFileChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      event.target.value = "";
+      if (file) {
+        void importProfileJson(file);
+      }
+    },
+    [importProfileJson],
+  );
   /**
    * Open the face's standard adaptation in the motiongraph editor. Its
    * `standard/vizij/*` input nodes arrive as the editor's inputs, so binding a
@@ -4247,7 +4307,12 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
       onReplaceStandardProfileJson={handleReplaceStandardProfileJson}
       onEditStandardProfileGraph={handleEditStandardProfileGraph}
       standardAdaptationEmbedded={standardAdaptationEmbedded}
-      onToggleStandardAdaptation={toggleStandardAdaptation}
+      onToggleStandardAdaptation={handleToggleStandardAdaptation}
+      profiles={availableProfiles}
+      declaredProfileIds={declaredProfileIds}
+      onToggleProfile={handleToggleProfile}
+      onImportProfileJson={handleImportProfileJson}
+      onExportProfileJson={exportDeclaredProfileJson}
       onExportStandardAdaptationJson={exportStandardAdaptationJson}
       onReplaceStandardAdaptationJson={handleReplaceStandardAdaptationJson}
       onEditStandardAdaptationGraph={handleEditStandardAdaptationGraph}
@@ -5057,6 +5122,15 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
         accept=".json"
         data-testid="app-skill-json-input"
         onChange={handleSkillJsonFileChange}
+      />
+      {/* Hidden file input for "Import Profile from JSON..." */}
+      <input
+        type="file"
+        ref={profileImportInputRef}
+        className="hidden"
+        accept=".json"
+        data-testid="app-profile-import-input"
+        onChange={handleProfileImportFileChange}
       />
       {/* Hidden file input for "Replace Adaptation from JSON..." */}
       <input

--- a/apps/vizij-authoring/src/App.tsx
+++ b/apps/vizij-authoring/src/App.tsx
@@ -7,6 +7,7 @@ import {
 } from "react-resizable-panels";
 import { useDialogQueue } from "@vizij/authoring-shared";
 import { loadGLTFFromBlobWithBundle, useVizijStore } from "@vizij/render";
+import type { VizijBundleProfile } from "@vizij/render";
 import {
   normalizeStandardRigInputPath,
   type StandardRigInput,
@@ -98,6 +99,7 @@ import {
   embeddedProfileId,
   useStandardProfiles,
 } from "./hooks/useStandardProfiles";
+import { useProfileInputs } from "./hooks/useProfileInputs";
 import { useProfiles } from "./hooks/useProfiles";
 import { ProfileImportDialog } from "./components/app/ProfileImportDialog";
 import { useStandardAdaptation } from "./hooks/useStandardAdaptation";
@@ -4120,6 +4122,25 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
     },
     [declaredProfiles, toggleStandardAdaptation],
   );
+  const declareProfileInputs = useProfileInputs();
+  /**
+   * Declaring a profile records it on the face *and* creates a standard input
+   * per path, so its controls appear in Input Controls unconnected and ready to
+   * bind — visible because they are inputs, not because a panel was taught
+   * about profiles.
+   */
+  const handleProfileDeclared = useCallback(
+    (profile: VizijBundleProfile | null) => {
+      if (!profile) {
+        return;
+      }
+      const { added, existing } = declareProfileInputs(profile);
+      console.log(
+        `profile ${profile.id}: ${added} input(s) added, ${existing} already present`,
+      );
+    },
+    [declareProfileInputs],
+  );
   const [profileImportOpen, setProfileImportOpen] = useState(false);
   const profileImportInputRef = useRef<HTMLInputElement>(null);
   const handleImportProfileJson = useCallback(() => {
@@ -4130,10 +4151,10 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
       const file = event.target.files?.[0];
       event.target.value = "";
       if (file) {
-        void importProfileJson(file);
+        void importProfileJson(file).then(handleProfileDeclared);
       }
     },
-    [importProfileJson],
+    [handleProfileDeclared, importProfileJson],
   );
   /**
    * Open the face's standard adaptation in the motiongraph editor. Its
@@ -5119,7 +5140,7 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
         onClose={() => setProfileImportOpen(false)}
         available={availableProfiles}
         declaredIds={declaredProfileIds}
-        onImport={(id) => void importProfile(id)}
+        onImport={(id) => void importProfile(id).then(handleProfileDeclared)}
         onImportFile={handleImportProfileJson}
       />
       {/* Hidden file input for "Import Profile from JSON..." */}

--- a/apps/vizij-authoring/src/App.tsx
+++ b/apps/vizij-authoring/src/App.tsx
@@ -98,6 +98,7 @@ import {
   embeddedProfileId,
   useStandardProfiles,
 } from "./hooks/useStandardProfiles";
+import { useStandardAdaptation } from "./hooks/useStandardAdaptation";
 import { embeddedSkillId, useSkills } from "./hooks/useSkills";
 import { carriedBundleGraphs } from "./hooks/useVizijExport";
 import {
@@ -828,6 +829,12 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
   const [editingSkillId, setEditingSkillId] = useState<string | null>(null);
   const editingSkillIdRef = useRef<string | null>(null);
   editingSkillIdRef.current = editingSkillId;
+  // True while the face's standard adaptation owns the motiongraph editor —
+  // the same edit session the profile and skill sessions run, with the same
+  // guards (the adaptation is one per face, so a boolean is its whole identity).
+  const [editingAdaptation, setEditingAdaptation] = useState(false);
+  const editingAdaptationRef = useRef(false);
+  editingAdaptationRef.current = editingAdaptation;
   const [hiddenBundleAnimationTargetIds, setHiddenBundleAnimationTargetIds] =
     useState<Record<string, true>>({});
   const [hiddenBundleProceduralTargetIds, setHiddenBundleProceduralTargetIds] =
@@ -1457,9 +1464,13 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
   );
   const saveProceduralTarget = useCallback(
     (targetId: string) => {
-      // A profile or skill edit session owns the editor: its content must
-      // never be snapshotted into a program target.
-      if (editingProfileIdRef.current || editingSkillIdRef.current) {
+      // A profile, skill, or adaptation edit session owns the editor: its
+      // content must never be snapshotted into a program target.
+      if (
+        editingProfileIdRef.current ||
+        editingSkillIdRef.current ||
+        editingAdaptationRef.current
+      ) {
         return;
       }
       const programId = parseAuthoredProceduralTargetValue(targetId);
@@ -2048,9 +2059,14 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
   );
   const loadSelectedProceduralTarget = useCallback(
     (targetId: string | null) => {
-      // A profile or skill edit session owns the editor: target changes
-      // neither hydrate over its content nor clear it (apply/discard does).
-      if (editingProfileIdRef.current || editingSkillIdRef.current) {
+      // A profile, skill, or adaptation edit session owns the editor: target
+      // changes neither hydrate over its content nor clear it (apply/discard
+      // does).
+      if (
+        editingProfileIdRef.current ||
+        editingSkillIdRef.current ||
+        editingAdaptationRef.current
+      ) {
         return;
       }
       if (!targetId) {
@@ -4057,6 +4073,84 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
   );
 
   const {
+    embedded: standardAdaptationEmbedded,
+    entry: standardAdaptationEntry,
+    toggleAdaptation: toggleStandardAdaptation,
+    exportAdaptationJson: exportStandardAdaptationJson,
+    importAdaptationJson: importStandardAdaptationJson,
+    replaceAdaptationSpec: replaceStandardAdaptationSpec,
+  } = useStandardAdaptation({
+    bundle: loader.bundle,
+    updateBundle: loader.updateBundle,
+  });
+  /**
+   * Open the face's standard adaptation in the motiongraph editor. Its
+   * `standard/vizij/*` input nodes arrive as the editor's inputs, so binding a
+   * control to a pose is an ordinary edge — which is the whole authoring story
+   * for the adaptation.
+   */
+  const handleEditStandardAdaptationGraph = useCallback(() => {
+    if (!standardAdaptationEntry?.spec) {
+      console.error("no embedded adaptation to edit");
+      return;
+    }
+    // Park the current program's edits exactly like a target switch, then let
+    // the adaptation session own the editor.
+    if (selectedProceduralTargetId) {
+      saveProceduralTarget(selectedProceduralTargetId);
+    }
+    setSelectedProceduralTargetId(null);
+    const parsed = specToEditorState(
+      standardAdaptationEntry.spec as Record<string, unknown>,
+    );
+    hydrateProceduralEditorState({
+      nodes: parsed.nodes,
+      edges: parsed.edges,
+      enabledOutputs: Array.from(parsed.enabledOutputs),
+      enabledInputs: Array.from(parsed.enabledInputs),
+      customInputPaths: [...parsed.customInputPaths],
+    });
+    setEditingAdaptation(true);
+    setWorkspacePanelVisibility("motiongraph", true);
+  }, [
+    standardAdaptationEntry,
+    saveProceduralTarget,
+    selectedProceduralTargetId,
+    setWorkspacePanelVisibility,
+  ]);
+  const applyStandardAdaptationEdits = useCallback(() => {
+    if (!editingAdaptation) {
+      return;
+    }
+    const spec = buildProceduralExportSpec(snapshotProceduralEditorState());
+    replaceStandardAdaptationSpec(spec as Record<string, unknown>);
+    setEditingAdaptation(false);
+    const editorStore = useEditorStore.getState();
+    editorStore.clear();
+    editorStore.setSelected(null);
+  }, [editingAdaptation, replaceStandardAdaptationSpec]);
+  const discardStandardAdaptationEdits = useCallback(() => {
+    setEditingAdaptation(false);
+    const editorStore = useEditorStore.getState();
+    editorStore.clear();
+    editorStore.setSelected(null);
+  }, []);
+  const adaptationJsonInputRef = useRef<HTMLInputElement>(null);
+  const handleReplaceStandardAdaptationJson = useCallback(() => {
+    adaptationJsonInputRef.current?.click();
+  }, []);
+  const handleAdaptationJsonFileChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      event.target.value = "";
+      if (file) {
+        void importStandardAdaptationJson(file);
+      }
+    },
+    [importStandardAdaptationJson],
+  );
+
+  const {
     skills: availableSkills,
     embeddedSkillIds,
     toggleSkill,
@@ -4152,6 +4246,11 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
       onExportStandardProfileJson={exportStandardProfileJson}
       onReplaceStandardProfileJson={handleReplaceStandardProfileJson}
       onEditStandardProfileGraph={handleEditStandardProfileGraph}
+      standardAdaptationEmbedded={standardAdaptationEmbedded}
+      onToggleStandardAdaptation={toggleStandardAdaptation}
+      onExportStandardAdaptationJson={exportStandardAdaptationJson}
+      onReplaceStandardAdaptationJson={handleReplaceStandardAdaptationJson}
+      onEditStandardAdaptationGraph={handleEditStandardAdaptationGraph}
       skills={availableSkills}
       embeddedSkillIds={embeddedSkillIds}
       onToggleSkill={(skillId, enabled) => {
@@ -4634,6 +4733,37 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
                   </button>
                 </div>
               ) : null}
+              {editingAdaptation ? (
+                <div
+                  className="flex items-center gap-2 border-b border-border-default bg-bg-secondary px-3 py-1.5 text-xs text-text-secondary"
+                  data-testid="adaptation-editor-banner"
+                >
+                  <span className="flex-1">
+                    Binding the{" "}
+                    <span className="font-semibold text-text-primary">
+                      standard adaptation
+                    </span>{" "}
+                    — connect each standard control to the poses it should
+                    drive. Unwired controls drive nothing.
+                  </span>
+                  <button
+                    type="button"
+                    className="rounded bg-accent-primary px-2 py-1 text-xs font-medium text-white hover:opacity-90"
+                    data-testid="adaptation-editor-apply"
+                    onClick={applyStandardAdaptationEdits}
+                  >
+                    Apply to Adaptation
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded border border-border-default px-2 py-1 text-xs hover:bg-bg-hover"
+                    data-testid="adaptation-editor-discard"
+                    onClick={discardStandardAdaptationEdits}
+                  >
+                    Discard
+                  </button>
+                </div>
+              ) : null}
               <div className="min-h-0 flex-1">
                 <MotionGraphPanel
                   onSelectNode={handleSelectMotionGraphNodeWithInspectorSync}
@@ -4756,7 +4886,9 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
               animationActive={effectiveAnimationPanelVisible}
               centerAuthoringMode={centerAuthoringMode}
               runtimeFaceId={faceId}
-              enableMotionGraphPruning={!editingProfileId && !editingSkillId}
+              enableMotionGraphPruning={
+                !editingProfileId && !editingSkillId && !editingAdaptation
+              }
               onSelectMotionGraphNode={
                 handleSelectMotionGraphNodeWithInspectorSync
               }
@@ -4925,6 +5057,15 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
         accept=".json"
         data-testid="app-skill-json-input"
         onChange={handleSkillJsonFileChange}
+      />
+      {/* Hidden file input for "Replace Adaptation from JSON..." */}
+      <input
+        type="file"
+        ref={adaptationJsonInputRef}
+        className="hidden"
+        accept=".json"
+        data-testid="app-adaptation-json-input"
+        onChange={handleAdaptationJsonFileChange}
       />
     </ReferenceFaceProvider>
   );

--- a/apps/vizij-authoring/src/App.tsx
+++ b/apps/vizij-authoring/src/App.tsx
@@ -99,6 +99,7 @@ import {
   useStandardProfiles,
 } from "./hooks/useStandardProfiles";
 import { useProfiles } from "./hooks/useProfiles";
+import { ProfileImportDialog } from "./components/app/ProfileImportDialog";
 import { useStandardAdaptation } from "./hooks/useStandardAdaptation";
 import { embeddedSkillId, useSkills } from "./hooks/useSkills";
 import { carriedBundleGraphs } from "./hooks/useVizijExport";
@@ -4085,7 +4086,10 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
     updateBundle: loader.updateBundle,
   });
   const {
+    available: availableProfiles,
     declared: declaredProfiles,
+    declaredIds: declaredProfileIds,
+    importProfile,
     importProfileJson,
     exportProfileJson: exportDeclaredProfileJson,
     removeProfile,
@@ -4116,6 +4120,7 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
     },
     [declaredProfiles, toggleStandardAdaptation],
   );
+  const [profileImportOpen, setProfileImportOpen] = useState(false);
   const profileImportInputRef = useRef<HTMLInputElement>(null);
   const handleImportProfileJson = useCallback(() => {
     profileImportInputRef.current?.click();
@@ -4296,7 +4301,7 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
       standardAdaptationEmbedded={standardAdaptationEmbedded}
       onToggleStandardAdaptation={handleToggleStandardAdaptation}
       declaredProfiles={declaredProfiles}
-      onImportProfileJson={handleImportProfileJson}
+      onOpenProfileImport={() => setProfileImportOpen(true)}
       onExportProfileJson={exportDeclaredProfileJson}
       onRemoveProfile={removeProfile}
       onExportStandardAdaptationJson={exportStandardAdaptationJson}
@@ -5108,6 +5113,14 @@ function AppContent({ loader, onFaceLoadPhaseChange }: AppContentProps) {
         accept=".json"
         data-testid="app-skill-json-input"
         onChange={handleSkillJsonFileChange}
+      />
+      <ProfileImportDialog
+        open={profileImportOpen}
+        onClose={() => setProfileImportOpen(false)}
+        available={availableProfiles}
+        declaredIds={declaredProfileIds}
+        onImport={(id) => void importProfile(id)}
+        onImportFile={handleImportProfileJson}
       />
       {/* Hidden file input for "Import Profile from JSON..." */}
       <input

--- a/apps/vizij-authoring/src/components/app/AppMenuBar.test.tsx
+++ b/apps/vizij-authoring/src/components/app/AppMenuBar.test.tsx
@@ -28,6 +28,11 @@ function renderMenuBar() {
       onExportStandardProfileJson={vi.fn()}
       onReplaceStandardProfileJson={vi.fn()}
       onEditStandardProfileGraph={vi.fn()}
+      profiles={[]}
+      declaredProfileIds={[]}
+      onToggleProfile={vi.fn()}
+      onImportProfileJson={vi.fn()}
+      onExportProfileJson={vi.fn()}
       standardAdaptationEmbedded={false}
       onToggleStandardAdaptation={vi.fn()}
       onExportStandardAdaptationJson={vi.fn()}

--- a/apps/vizij-authoring/src/components/app/AppMenuBar.test.tsx
+++ b/apps/vizij-authoring/src/components/app/AppMenuBar.test.tsx
@@ -28,11 +28,10 @@ function renderMenuBar() {
       onExportStandardProfileJson={vi.fn()}
       onReplaceStandardProfileJson={vi.fn()}
       onEditStandardProfileGraph={vi.fn()}
-      profiles={[]}
-      declaredProfileIds={[]}
-      onToggleProfile={vi.fn()}
+      declaredProfiles={[]}
       onImportProfileJson={vi.fn()}
       onExportProfileJson={vi.fn()}
+      onRemoveProfile={vi.fn()}
       standardAdaptationEmbedded={false}
       onToggleStandardAdaptation={vi.fn()}
       onExportStandardAdaptationJson={vi.fn()}

--- a/apps/vizij-authoring/src/components/app/AppMenuBar.test.tsx
+++ b/apps/vizij-authoring/src/components/app/AppMenuBar.test.tsx
@@ -28,6 +28,11 @@ function renderMenuBar() {
       onExportStandardProfileJson={vi.fn()}
       onReplaceStandardProfileJson={vi.fn()}
       onEditStandardProfileGraph={vi.fn()}
+      standardAdaptationEmbedded={false}
+      onToggleStandardAdaptation={vi.fn()}
+      onExportStandardAdaptationJson={vi.fn()}
+      onReplaceStandardAdaptationJson={vi.fn()}
+      onEditStandardAdaptationGraph={vi.fn()}
       skills={[]}
       embeddedSkillIds={[]}
       onToggleSkill={vi.fn()}

--- a/apps/vizij-authoring/src/components/app/AppMenuBar.test.tsx
+++ b/apps/vizij-authoring/src/components/app/AppMenuBar.test.tsx
@@ -29,7 +29,7 @@ function renderMenuBar() {
       onReplaceStandardProfileJson={vi.fn()}
       onEditStandardProfileGraph={vi.fn()}
       declaredProfiles={[]}
-      onImportProfileJson={vi.fn()}
+      onOpenProfileImport={vi.fn()}
       onExportProfileJson={vi.fn()}
       onRemoveProfile={vi.fn()}
       standardAdaptationEmbedded={false}

--- a/apps/vizij-authoring/src/components/app/AppMenuBar.tsx
+++ b/apps/vizij-authoring/src/components/app/AppMenuBar.tsx
@@ -46,8 +46,8 @@ interface AppMenuBarProps {
   onEditStandardProfileGraph: (profileId: string) => void;
   /** Profiles the open GLB declares — a profile is a set of paths and types. */
   declaredProfiles: { id: string; title?: string; keys: unknown[] }[];
-  /** Declare a profile from a JSON file. */
-  onImportProfileJson: () => void;
+  /** Open the profile import dialog. */
+  onOpenProfileImport: () => void;
   /** Download a declared profile as JSON. */
   onExportProfileJson: (id: string) => void;
   /** Drop a declared profile from the open GLB. */
@@ -100,7 +100,7 @@ export function AppMenuBar({
   onReplaceStandardProfileJson,
   onEditStandardProfileGraph,
   declaredProfiles,
-  onImportProfileJson,
+  onOpenProfileImport,
   onExportProfileJson,
   onRemoveProfile,
   standardAdaptationEmbedded,
@@ -270,10 +270,10 @@ export function AppMenuBar({
         </MenuSubmenu>
         <MenuSubmenu label="Profiles" testId="app-menu-file-profiles">
           <MenuItem
-            onSelect={onImportProfileJson}
+            onSelect={onOpenProfileImport}
             testId="app-menu-file-profile-import"
           >
-            Import Profile from JSON...
+            Import Profile...
           </MenuItem>
           {declaredProfiles.length > 0 ? <MenuSeparator /> : null}
           {declaredProfiles.map((profile) => (

--- a/apps/vizij-authoring/src/components/app/AppMenuBar.tsx
+++ b/apps/vizij-authoring/src/components/app/AppMenuBar.tsx
@@ -44,6 +44,16 @@ interface AppMenuBarProps {
   onReplaceStandardProfileJson: (profileId: string) => void;
   /** Open an embedded profile's graph in the editor (apply-back session). */
   onEditStandardProfileGraph: (profileId: string) => void;
+  /** The profiles the registry ships — a profile is a set of paths and types. */
+  profiles: { id: string; version: string; title: string; keys: number }[];
+  /** Profile ids the open GLB declares (checked state of the toggles). */
+  declaredProfileIds: string[];
+  /** Declare (`enabled`) or drop a profile on the open GLB. */
+  onToggleProfile: (id: string, enabled: boolean) => void;
+  /** Declare a profile from a JSON file. */
+  onImportProfileJson: () => void;
+  /** Download a declared profile as JSON. */
+  onExportProfileJson: (id: string) => void;
   /** Whether the open GLB carries a standard adaptation. */
   standardAdaptationEmbedded: boolean;
   /** Add (`enabled`) or remove the standard adaptation in the open GLB. */
@@ -91,6 +101,11 @@ export function AppMenuBar({
   onExportStandardProfileJson,
   onReplaceStandardProfileJson,
   onEditStandardProfileGraph,
+  profiles,
+  declaredProfileIds,
+  onToggleProfile,
+  onImportProfileJson,
+  onExportProfileJson,
   standardAdaptationEmbedded,
   onToggleStandardAdaptation,
   onExportStandardAdaptationJson,
@@ -254,6 +269,42 @@ export function AppMenuBar({
                   Edit {profile.title} in Graph Editor...
                 </MenuItem>
               </React.Fragment>
+            ))}
+        </MenuSubmenu>
+        <MenuSubmenu label="Profiles" testId="app-menu-file-profiles">
+          {profiles.length === 0 ? (
+            <MenuLabel>None available</MenuLabel>
+          ) : (
+            profiles.map((profile) => (
+              <MenuCheckboxItem
+                key={profile.id}
+                checked={declaredProfileIds.includes(profile.id)}
+                onCheckedChange={(checked) =>
+                  onToggleProfile(profile.id, checked)
+                }
+                testId={`app-menu-file-profile-${profile.id}`}
+              >
+                {profile.title} ({profile.keys})
+              </MenuCheckboxItem>
+            ))
+          )}
+          <MenuSeparator />
+          <MenuItem
+            onSelect={onImportProfileJson}
+            testId="app-menu-file-profile-import"
+          >
+            Import Profile from JSON...
+          </MenuItem>
+          {profiles
+            .filter((profile) => declaredProfileIds.includes(profile.id))
+            .map((profile) => (
+              <MenuItem
+                key={profile.id}
+                onSelect={() => onExportProfileJson(profile.id)}
+                testId={`app-menu-file-profile-export-${profile.id}`}
+              >
+                Export {profile.title} as JSON...
+              </MenuItem>
             ))}
         </MenuSubmenu>
         <MenuSubmenu

--- a/apps/vizij-authoring/src/components/app/AppMenuBar.tsx
+++ b/apps/vizij-authoring/src/components/app/AppMenuBar.tsx
@@ -44,6 +44,16 @@ interface AppMenuBarProps {
   onReplaceStandardProfileJson: (profileId: string) => void;
   /** Open an embedded profile's graph in the editor (apply-back session). */
   onEditStandardProfileGraph: (profileId: string) => void;
+  /** Whether the open GLB carries a standard adaptation. */
+  standardAdaptationEmbedded: boolean;
+  /** Add (`enabled`) or remove the standard adaptation in the open GLB. */
+  onToggleStandardAdaptation: (enabled: boolean) => void;
+  /** Download the embedded adaptation as JSON, verbatim. */
+  onExportStandardAdaptationJson: () => void;
+  /** Replace the embedded adaptation from a JSON file. */
+  onReplaceStandardAdaptationJson: () => void;
+  /** Open the embedded adaptation in the editor (apply-back session). */
+  onEditStandardAdaptationGraph: () => void;
   /** The shipped skills a face may pin an override of (empty = none). */
   skills: { id: string; title: string }[];
   /** Skill ids the open GLB embeds (checked state of the toggles). */
@@ -81,6 +91,11 @@ export function AppMenuBar({
   onExportStandardProfileJson,
   onReplaceStandardProfileJson,
   onEditStandardProfileGraph,
+  standardAdaptationEmbedded,
+  onToggleStandardAdaptation,
+  onExportStandardAdaptationJson,
+  onReplaceStandardAdaptationJson,
+  onEditStandardAdaptationGraph,
   skills,
   embeddedSkillIds,
   onToggleSkill,
@@ -240,6 +255,41 @@ export function AppMenuBar({
                 </MenuItem>
               </React.Fragment>
             ))}
+        </MenuSubmenu>
+        <MenuSubmenu
+          label="Standard Adaptation"
+          testId="app-menu-file-standard-adaptation"
+        >
+          <MenuCheckboxItem
+            checked={standardAdaptationEmbedded}
+            onCheckedChange={onToggleStandardAdaptation}
+            testId="app-menu-file-standard-adaptation-toggle"
+          >
+            Drive this face from the standard
+          </MenuCheckboxItem>
+          {standardAdaptationEmbedded ? (
+            <>
+              <MenuSeparator />
+              <MenuItem
+                onSelect={onEditStandardAdaptationGraph}
+                testId="app-menu-file-standard-adaptation-edit"
+              >
+                Bind Controls to Poses...
+              </MenuItem>
+              <MenuItem
+                onSelect={onExportStandardAdaptationJson}
+                testId="app-menu-file-standard-adaptation-export"
+              >
+                Export Adaptation as JSON...
+              </MenuItem>
+              <MenuItem
+                onSelect={onReplaceStandardAdaptationJson}
+                testId="app-menu-file-standard-adaptation-replace"
+              >
+                Replace Adaptation from JSON...
+              </MenuItem>
+            </>
+          ) : null}
         </MenuSubmenu>
         <MenuSubmenu label="Skills" testId="app-menu-file-skills">
           {skills.length === 0 ? (

--- a/apps/vizij-authoring/src/components/app/AppMenuBar.tsx
+++ b/apps/vizij-authoring/src/components/app/AppMenuBar.tsx
@@ -44,16 +44,14 @@ interface AppMenuBarProps {
   onReplaceStandardProfileJson: (profileId: string) => void;
   /** Open an embedded profile's graph in the editor (apply-back session). */
   onEditStandardProfileGraph: (profileId: string) => void;
-  /** The profiles the registry ships — a profile is a set of paths and types. */
-  profiles: { id: string; version: string; title: string; keys: number }[];
-  /** Profile ids the open GLB declares (checked state of the toggles). */
-  declaredProfileIds: string[];
-  /** Declare (`enabled`) or drop a profile on the open GLB. */
-  onToggleProfile: (id: string, enabled: boolean) => void;
+  /** Profiles the open GLB declares — a profile is a set of paths and types. */
+  declaredProfiles: { id: string; title?: string; keys: unknown[] }[];
   /** Declare a profile from a JSON file. */
   onImportProfileJson: () => void;
   /** Download a declared profile as JSON. */
   onExportProfileJson: (id: string) => void;
+  /** Drop a declared profile from the open GLB. */
+  onRemoveProfile: (id: string) => void;
   /** Whether the open GLB carries a standard adaptation. */
   standardAdaptationEmbedded: boolean;
   /** Add (`enabled`) or remove the standard adaptation in the open GLB. */
@@ -101,11 +99,10 @@ export function AppMenuBar({
   onExportStandardProfileJson,
   onReplaceStandardProfileJson,
   onEditStandardProfileGraph,
-  profiles,
-  declaredProfileIds,
-  onToggleProfile,
+  declaredProfiles,
   onImportProfileJson,
   onExportProfileJson,
+  onRemoveProfile,
   standardAdaptationEmbedded,
   onToggleStandardAdaptation,
   onExportStandardAdaptationJson,
@@ -272,40 +269,33 @@ export function AppMenuBar({
             ))}
         </MenuSubmenu>
         <MenuSubmenu label="Profiles" testId="app-menu-file-profiles">
-          {profiles.length === 0 ? (
-            <MenuLabel>None available</MenuLabel>
-          ) : (
-            profiles.map((profile) => (
-              <MenuCheckboxItem
-                key={profile.id}
-                checked={declaredProfileIds.includes(profile.id)}
-                onCheckedChange={(checked) =>
-                  onToggleProfile(profile.id, checked)
-                }
-                testId={`app-menu-file-profile-${profile.id}`}
-              >
-                {profile.title} ({profile.keys})
-              </MenuCheckboxItem>
-            ))
-          )}
-          <MenuSeparator />
           <MenuItem
             onSelect={onImportProfileJson}
             testId="app-menu-file-profile-import"
           >
             Import Profile from JSON...
           </MenuItem>
-          {profiles
-            .filter((profile) => declaredProfileIds.includes(profile.id))
-            .map((profile) => (
+          {declaredProfiles.length > 0 ? <MenuSeparator /> : null}
+          {declaredProfiles.map((profile) => (
+            <MenuSubmenu
+              key={profile.id}
+              label={`${profile.title ?? profile.id} (${profile.keys.length})`}
+              testId={`app-menu-file-profile-${profile.id}`}
+            >
               <MenuItem
-                key={profile.id}
                 onSelect={() => onExportProfileJson(profile.id)}
                 testId={`app-menu-file-profile-export-${profile.id}`}
               >
-                Export {profile.title} as JSON...
+                Export as JSON...
               </MenuItem>
-            ))}
+              <MenuItem
+                onSelect={() => onRemoveProfile(profile.id)}
+                testId={`app-menu-file-profile-remove-${profile.id}`}
+              >
+                Remove from Face
+              </MenuItem>
+            </MenuSubmenu>
+          ))}
         </MenuSubmenu>
         <MenuSubmenu
           label="Standard Adaptation"

--- a/apps/vizij-authoring/src/components/app/ProfileImportDialog.tsx
+++ b/apps/vizij-authoring/src/components/app/ProfileImportDialog.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { ProfileSummary } from "@vizij/runtime";
+import { Badge, Button, Modal, PanelSearch } from "../ui";
+import { EmptyState } from "../ui/EmptyState";
+
+interface ProfileImportDialogProps {
+  open: boolean;
+  onClose: () => void;
+  /** The profiles the registry offers. */
+  available: ProfileSummary[];
+  /** Ids the open face already declares — shown as such, and re-importable. */
+  declaredIds: string[];
+  /** Declare a registry profile on the face. */
+  onImport: (id: string) => void;
+  /** Declare a profile from a JSON file instead. */
+  onImportFile: () => void;
+}
+
+/**
+ * Pick a profile to declare on the open face.
+ *
+ * A profile is a set of paths and their types, and the registry is expected to
+ * carry tens of them, so this is a searchable list rather than a menu: search
+ * covers the id, title and description, because someone looking for a face
+ * vocabulary is as likely to type "viseme" or "ROS" as the profile's name.
+ *
+ * A profile already declared stays listed and importable — re-importing is how
+ * you pick up a newer version of the same id.
+ */
+export function ProfileImportDialog({
+  open,
+  onClose,
+  available,
+  declaredIds,
+  onImport,
+  onImportFile,
+}: ProfileImportDialogProps) {
+  const [query, setQuery] = useState("");
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  // Reopening starts from the full list, and the search takes focus so the
+  // dialog is usable without reaching for the mouse.
+  useEffect(() => {
+    if (open) {
+      setQuery("");
+      const id = window.setTimeout(() => searchRef.current?.focus(), 0);
+      return () => window.clearTimeout(id);
+    }
+    return undefined;
+  }, [open]);
+
+  const matches = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) {
+      return available;
+    }
+    return available.filter((profile) =>
+      [profile.id, profile.title, profile.description]
+        .join(" ")
+        .toLowerCase()
+        .includes(needle),
+    );
+  }, [available, query]);
+
+  return (
+    <Modal open={open} onClose={onClose} title="Import Profile" maxWidth="2xl">
+      <div className="flex flex-col gap-3">
+        <p className="text-xs text-text-secondary">
+          A profile names and types the paths a face is driven through.
+          Declaring one records it on the face, so the vocabulary travels with
+          the export.
+        </p>
+
+        <PanelSearch
+          ref={searchRef}
+          value={query}
+          onChange={setQuery}
+          placeholder="Search profiles..."
+        />
+
+        <div
+          className="flex max-h-96 flex-col gap-1 overflow-y-auto"
+          data-testid="profile-import-list"
+        >
+          {matches.length === 0 ? (
+            <EmptyState
+              title={
+                available.length === 0
+                  ? "No profiles available"
+                  : "No profiles match"
+              }
+              description={
+                available.length === 0
+                  ? "The registry could not be read. You can still import a profile from a JSON file."
+                  : "Try a different search, or import a profile from a JSON file."
+              }
+            />
+          ) : (
+            matches.map((profile) => {
+              const declared = declaredIds.includes(profile.id);
+              return (
+                <div
+                  key={profile.id}
+                  className="flex items-start gap-3 rounded border border-border-default p-3 hover:bg-bg-hover"
+                  data-testid={`profile-import-row-${profile.id}`}
+                >
+                  <div className="flex min-w-0 flex-1 flex-col gap-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-sm font-medium text-text-primary">
+                        {profile.title}
+                      </span>
+                      <Badge>{profile.version}</Badge>
+                      <span className="text-xs text-text-secondary">
+                        {profile.keys} paths
+                      </span>
+                      {declared ? <Badge>declared</Badge> : null}
+                    </div>
+                    <span className="text-xs text-text-secondary">
+                      {profile.description}
+                    </span>
+                  </div>
+                  <Button
+                    onClick={() => {
+                      onImport(profile.id);
+                      onClose();
+                    }}
+                    data-testid={`profile-import-${profile.id}`}
+                  >
+                    {declared ? "Re-import" : "Import"}
+                  </Button>
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        <div className="flex items-center justify-between border-t border-border-default pt-3">
+          <Button
+            onClick={() => {
+              onImportFile();
+              onClose();
+            }}
+            data-testid="profile-import-from-file"
+          >
+            Import from JSON file...
+          </Button>
+          <Button onClick={onClose} data-testid="profile-import-close">
+            Close
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/vizij-authoring/src/components/app/StdFeatureSpacesControls.test.ts
+++ b/apps/vizij-authoring/src/components/app/StdFeatureSpacesControls.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { deriveNamespaceAndChannelFromPath } from "./StdFeatureSpacesControls";
+
+/** The face declares `vizij-face`, whose paths live under `standard/vizij/`. */
+const DECLARED = new Map([["vizij", "Vizij face standard"]]);
+const NONE = new Map<string, string>();
+
+describe("deriveNamespaceAndChannelFromPath", () => {
+  // The bug: the old rule needed 4+ segments after `standard`, so one profile
+  // split across two groups purely by how deep each path happened to be.
+  it("groups a declared namespace regardless of path depth", () => {
+    const deep = deriveNamespaceAndChannelFromPath(
+      "/standard/vizij/left_eye/pos/x",
+      DECLARED,
+    );
+    const shallow = deriveNamespaceAndChannelFromPath(
+      "/standard/vizij/expression/happy",
+      DECLARED,
+    );
+    expect(deep.namespace).toBe("vizij");
+    expect(shallow.namespace).toBe("vizij");
+    expect(deep.channel).toBe("left_eye");
+    expect(shallow.channel).toBe("expression");
+  });
+
+  it("without the declaration, the shallow path falls back and splits", () => {
+    expect(
+      deriveNamespaceAndChannelFromPath(
+        "/standard/vizij/expression/happy",
+        NONE,
+      ).namespace,
+    ).toBe("");
+    expect(
+      deriveNamespaceAndChannelFromPath("/standard/vizij/left_eye/pos/x", NONE)
+        .namespace,
+    ).toBe("vizij");
+  });
+
+  // A legacy face has no namespace at all; declaring nothing must not promote
+  // its channels into groups.
+  it("leaves legacy un-namespaced paths alone", () => {
+    const legacy = deriveNamespaceAndChannelFromPath(
+      "/standard/left_eye/pos/x",
+      DECLARED,
+    );
+    expect(legacy.namespace).toBe("");
+    expect(legacy.channel).toBe("left_eye");
+  });
+
+  it("subdivides a declared namespace by the next segment", () => {
+    expect(
+      deriveNamespaceAndChannelFromPath(
+        "/standard/vizij/face/jaw_open",
+        DECLARED,
+      ),
+    ).toStrictEqual({ namespace: "vizij", channel: "face" });
+    expect(
+      deriveNamespaceAndChannelFromPath("/standard/vizij/viseme/aa", DECLARED),
+    ).toStrictEqual({ namespace: "vizij", channel: "viseme" });
+  });
+
+  it("handles a path with no standard segment", () => {
+    expect(
+      deriveNamespaceAndChannelFromPath("/propsrig/mouth/jawud/value", DECLARED)
+        .namespace,
+    ).toBe("");
+  });
+});

--- a/apps/vizij-authoring/src/components/app/StdFeatureSpacesControls.tsx
+++ b/apps/vizij-authoring/src/components/app/StdFeatureSpacesControls.tsx
@@ -4,6 +4,10 @@ import { normalizeStandardRigInputPath } from "@vizij/utils";
 import { SidebarSection } from "../common/SidebarSection";
 import { Button, RowSlider } from "../ui";
 import { useReferenceFace } from "../../state/ReferenceFaceContext";
+import {
+  useDeclaredNamespaces,
+  type DeclaredNamespaces,
+} from "../../state/DeclaredProfilesContext";
 import { useBindingAuthoring } from "../../state/RigControllerProvider";
 import { GroupMappingEditor } from "./StdFeatureSpacesMappingEditor";
 
@@ -34,50 +38,46 @@ function getFaceStatusClass(status: FaceStatus): string {
  * For paths like "/standard/semio/left_eye/pos/x", returns { namespace: "semio", channel: "left_eye" }
  * For paths like "/standard/left_eye/pos/x", returns { namespace: "", channel: "left_eye" }
  */
-function deriveNamespaceAndChannelFromPath(path: string): {
+export function deriveNamespaceAndChannelFromPath(
+  path: string,
+  declared: DeclaredNamespaces,
+): {
   namespace: string;
   channel: string;
 } {
   // Extract the /standard/... portion from the path
   const standardMatch = path.match(/\/standard\/(.+)/);
-  if (!standardMatch || !standardMatch[1]) {
-    // Fallback: try normalizing and splitting
+  const afterStandard = standardMatch?.[1];
+  if (!afterStandard) {
     const normalized = normalizeStandardRigInputPath(path);
     const withoutLeading = normalized.startsWith("/")
       ? normalized.slice(1)
       : normalized;
-    if (!withoutLeading) return { namespace: "", channel: "custom" };
-    const segments = withoutLeading.split("/");
-    if (segments[0] === "standard" && segments.length > 1) {
-      // Check if there's a namespace (4+ parts after standard means namespace exists)
-      const afterStandard = segments.slice(1);
-      if (afterStandard.length >= 4) {
-        return {
-          namespace: afterStandard[0] || "",
-          channel: afterStandard[1] || "custom",
-        };
-      }
-      return { namespace: "", channel: afterStandard[0] || "custom" };
-    }
+    const segments = withoutLeading.split("/").filter(Boolean);
     return { namespace: "", channel: segments[0] || "custom" };
   }
 
-  const afterStandard = standardMatch[1];
   const segments = afterStandard.split("/");
+  const first = segments[0] ?? "";
 
-  // Path structure: namespace/channel/track/attribute (4+ segments after /standard/)
-  // Or: channel/track/attribute (3 segments - no namespace)
-  if (segments.length >= 4) {
-    // Has namespace: namespace/channel/track/attribute
-    return { namespace: segments[0], channel: segments[1] || "custom" };
-  } else {
-    // No namespace: channel/track/attribute
-    return { namespace: "", channel: segments[0] || "custom" };
+  // A declared profile names its namespace, so no guessing is needed: the
+  // segment after `standard` is the group and everything under it subdivides
+  // it, however deep the path happens to be.
+  if (declared.has(first)) {
+    return { namespace: first, channel: segments[1] || "custom" };
   }
+
+  // Otherwise fall back to the length heuristic, which is all a legacy path
+  // (`/standard/left_eye/pos/x`, no namespace at all) gives us to go on.
+  if (segments.length >= 4) {
+    return { namespace: first, channel: segments[1] || "custom" };
+  }
+  return { namespace: "", channel: first || "custom" };
 }
 
 export function StdFeatureSpacesControls() {
   const referenceFace = useReferenceFace();
+  const declaredNamespaces = useDeclaredNamespaces();
   const [selectedNamespace, setSelectedNamespace] = useState<string | null>(
     null,
   );
@@ -193,6 +193,7 @@ export function StdFeatureSpacesControls() {
     for (const input of combinedInputsByPath.values()) {
       const { namespace, channel } = deriveNamespaceAndChannelFromPath(
         input.path,
+        declaredNamespaces,
       );
       if (!namespaces.has(namespace)) {
         namespaces.set(namespace, new Map());
@@ -210,7 +211,7 @@ export function StdFeatureSpacesControls() {
       }
     }
     return namespaces;
-  }, [combinedInputsByPath]);
+  }, [combinedInputsByPath, declaredNamespaces]);
 
   const namespaceNames = useMemo(
     () => Array.from(groupedByNamespaceAndChannel.keys()),
@@ -385,7 +386,9 @@ export function StdFeatureSpacesControls() {
                           setSelectedChannel(null); // Reset channel when namespace changes
                         }}
                       >
-                        {ns === "" ? "Root" : formatGroupName(ns)}
+                        {ns === ""
+                          ? "Root"
+                          : (declaredNamespaces.get(ns) ?? formatGroupName(ns))}
                       </button>
                     ))}
                   </div>

--- a/apps/vizij-authoring/src/components/panels/VariablesPanel.tsx
+++ b/apps/vizij-authoring/src/components/panels/VariablesPanel.tsx
@@ -19,6 +19,7 @@ import {
   Trash2,
   Search,
   Sliders,
+  Unplug,
   Users,
   X,
   Camera,
@@ -2878,6 +2879,18 @@ function FlatInputControlRow({
       <div className="flex items-center gap-1.5 min-w-0">
         <Sliders size={12} className="text-cyan-300 shrink-0" />
         <span className="text-xs text-text-primary truncate">{row.label}</span>
+        {row.driven === false ? (
+          // The control exists but nothing downstream reads it — the state a
+          // profile's controls arrive in, and where a rig input lands when its
+          // binding is removed. Worth marking: moving the slider does nothing.
+          <Unplug
+            size={11}
+            className="text-amber-300 shrink-0"
+            aria-label="Not connected"
+          >
+            <title>Not connected — nothing reads this input yet</title>
+          </Unplug>
+        ) : null}
         <div className="ml-auto flex items-center gap-1 shrink-0">
           {actions}
         </div>

--- a/apps/vizij-authoring/src/components/panels/inputCatalog.driven.test.ts
+++ b/apps/vizij-authoring/src/components/panels/inputCatalog.driven.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import type { StandardRigInput } from "@vizij/utils";
+import type { ManagedStandardInput } from "../../types/standardInputs";
+import { buildVisibleInputCatalog } from "./inputCatalog";
+
+function managed(
+  path: string,
+  derivedChildren: string[] | undefined,
+): ManagedStandardInput {
+  return {
+    input: {
+      id: path,
+      path,
+      label: path.split("/").pop() ?? path,
+      group: "custom",
+      defaultValue: 0,
+      range: { min: 0, max: 1 },
+      derivedChildren,
+    } as StandardRigInput,
+    source: "custom",
+    disabled: false,
+  };
+}
+
+function catalog(inputs: ManagedStandardInput[]) {
+  return buildVisibleInputCatalog({
+    managedStandardInputs: inputs,
+    fullyLockedFaceElementIds: new Set(),
+    lockedPropsRigComponentIds: new Set(),
+    inputValues: {},
+    poseNameById: new Map(),
+    resolveManagedSource: () => "custom",
+    poseGroups: [],
+    blendStages: [],
+    poseGroupBlendModeFallback: "add",
+    poseCountByGroupId: new Map(),
+    poseGroupLabelById: new Map(),
+  } as Parameters<typeof buildVisibleInputCatalog>[0]);
+}
+
+describe("input catalog: driven", () => {
+  // A profile's controls arrive with nothing reading them; that is what the
+  // disconnect marker in the panel is keyed off.
+  it("marks an input nothing derives from as not driven", () => {
+    const rows = catalog([
+      managed("/standard/vizij/expression/happy", []),
+      managed("/standard/vizij/viseme/aa", undefined),
+    ]);
+    expect(rows.map((r) => r.driven)).toStrictEqual([false, false]);
+  });
+
+  it("marks an input with a child as driven", () => {
+    const rows = catalog([
+      managed("/standard/vizij/expression/happy", ["pose_happy"]),
+    ]);
+    expect(rows[0]!.driven).toBe(true);
+  });
+
+  it("distinguishes the two in one catalog", () => {
+    const rows = catalog([
+      managed("/standard/vizij/expression/happy", ["pose_happy"]),
+      managed("/standard/vizij/expression/sad", []),
+    ]);
+    const byLabel = new Map(rows.map((r) => [r.label, r.driven]));
+    expect(byLabel.get("happy")).toBe(true);
+    expect(byLabel.get("sad")).toBe(false);
+  });
+});

--- a/apps/vizij-authoring/src/components/panels/inputCatalog.ts
+++ b/apps/vizij-authoring/src/components/panels/inputCatalog.ts
@@ -34,6 +34,15 @@ export interface InputCatalogRow {
   provenance?: string;
   editable: boolean;
   selectable: boolean;
+  /**
+   * Whether anything downstream derives from this input.
+   *
+   * `false` means the control exists but drives nothing — the state a profile's
+   * controls arrive in, and the state a rig input is left in when its binding is
+   * removed. Undefined for rows where the question does not apply (a derived
+   * pose output is downstream by construction).
+   */
+  driven?: boolean;
 }
 
 export interface InputCatalogTreeNode {
@@ -155,6 +164,9 @@ function buildManagedInputRows(
           : undefined,
         editable: true,
         selectable: true,
+        // `derivedChildren` is every input that names this one as its source,
+        // so an empty list is precisely "nothing reads this".
+        driven: (entry.input.derivedChildren?.length ?? 0) > 0,
       } satisfies InputCatalogRow;
     });
 }

--- a/apps/vizij-authoring/src/hooks/useProfileInputs.test.ts
+++ b/apps/vizij-authoring/src/hooks/useProfileInputs.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { VizijBundleProfile } from "@vizij/render";
+import { useProfileInputs } from "./useProfileInputs";
+
+const { createMock, byPath } = vi.hoisted(() => ({
+  createMock: vi.fn(),
+  byPath: new Map<string, unknown>(),
+}));
+
+// The hook reads two things off the binding-authoring store; stand them up
+// directly so what is under test is the skip-and-create decision.
+vi.mock("../state/RigControllerProvider", () => ({
+  useBindingAuthoring: (
+    selector: (state: {
+      handleCreateCustomStandardInput: unknown;
+      standardInputsByPath: Map<string, unknown>;
+    }) => unknown,
+  ) =>
+    selector({
+      handleCreateCustomStandardInput: createMock,
+      standardInputsByPath: byPath,
+    }),
+}));
+
+const profileOf = (paths: string[]): VizijBundleProfile => ({
+  id: "vizij-face",
+  version: "v1",
+  keys: paths.map((path) => ({ path })),
+});
+
+beforeEach(() => {
+  createMock.mockReset().mockImplementation((path: string) => ({ id: path }));
+  byPath.clear();
+});
+
+describe("useProfileInputs", () => {
+  it("creates a standard input for every path the rig lacks", () => {
+    const { result } = renderHook(() => useProfileInputs());
+    const report = result.current(
+      profileOf([
+        "rig/quori_latest/standard/vizij/expression/happy",
+        "rig/quori_latest/standard/vizij/viseme/aa",
+      ]),
+    );
+    expect(report).toStrictEqual({ added: 2, existing: 0 });
+    expect(createMock).toHaveBeenCalledTimes(2);
+  });
+
+  // Standard inputs are keyed rig-relative, so the face prefix a declared
+  // profile carries has to come off before the lookup or the create.
+  it("normalizes the face prefix off the path", () => {
+    const { result } = renderHook(() => useProfileInputs());
+    result.current(
+      profileOf(["rig/quori_latest/standard/vizij/expression/happy"]),
+    );
+    expect(createMock).toHaveBeenCalledWith("/standard/vizij/expression/happy");
+  });
+
+  // The underlying entry point de-duplicates by id and would mint `happy_2`
+  // on a re-import, quietly doubling the control surface.
+  it("skips a path the rig already carries rather than duplicating it", () => {
+    byPath.set("/standard/vizij/expression/happy", { id: "happy" });
+    const { result } = renderHook(() => useProfileInputs());
+    const report = result.current(
+      profileOf([
+        "rig/quori_latest/standard/vizij/expression/happy",
+        "rig/quori_latest/standard/vizij/viseme/aa",
+      ]),
+    );
+    expect(report).toStrictEqual({ added: 1, existing: 1 });
+    expect(createMock).toHaveBeenCalledTimes(1);
+    expect(createMock).toHaveBeenCalledWith("/standard/vizij/viseme/aa");
+  });
+
+  it("re-importing an unchanged profile adds nothing", () => {
+    byPath.set("/standard/vizij/expression/happy", { id: "happy" });
+    byPath.set("/standard/vizij/viseme/aa", { id: "aa" });
+    const { result } = renderHook(() => useProfileInputs());
+    expect(
+      result.current(
+        profileOf([
+          "rig/quori_latest/standard/vizij/expression/happy",
+          "rig/quori_latest/standard/vizij/viseme/aa",
+        ]),
+      ),
+    ).toStrictEqual({ added: 0, existing: 2 });
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it("does not count an input the rig refused to create", () => {
+    createMock.mockReturnValue(null);
+    const { result } = renderHook(() => useProfileInputs());
+    expect(
+      result.current(profileOf(["rig/quori_latest/standard/vizij/viseme/aa"])),
+    ).toStrictEqual({ added: 0, existing: 0 });
+  });
+
+  it("is a no-op for a profile that defines nothing", () => {
+    const { result } = renderHook(() => useProfileInputs());
+    expect(result.current(profileOf([]))).toStrictEqual({
+      added: 0,
+      existing: 0,
+    });
+  });
+});

--- a/apps/vizij-authoring/src/hooks/useProfileInputs.ts
+++ b/apps/vizij-authoring/src/hooks/useProfileInputs.ts
@@ -1,0 +1,55 @@
+import { useCallback } from "react";
+import { normalizeStandardRigInputPath } from "@vizij/utils";
+import type { VizijBundleProfile } from "@vizij/render";
+import { useBindingAuthoring } from "../state/RigControllerProvider";
+
+/**
+ * Turn a declared profile's paths into standard rig inputs.
+ *
+ * A profile is a set of paths and their types, and the rig's standard inputs
+ * are exactly that — so importing one creates ordinary standard inputs rather
+ * than a parallel structure. They then appear in Input Controls and group by
+ * namespace in Std Feature Spaces because they *are* inputs, not because those
+ * panels learned about profiles.
+ *
+ * They arrive unconnected. That is the point: an author needs to see a control
+ * before binding it to a pose, and a profile's whole job is to say which
+ * controls exist.
+ */
+export function useProfileInputs() {
+  const createStandardInput = useBindingAuthoring(
+    (state) => state.handleCreateCustomStandardInput,
+  );
+  const standardInputsByPath = useBindingAuthoring(
+    (state) => state.standardInputsByPath,
+  );
+
+  /**
+   * Create a standard input for each of `profile`'s paths that the rig does not
+   * already carry, and report how many were added.
+   *
+   * Existing paths are skipped rather than re-created: the underlying entry
+   * point de-duplicates by *id* and would otherwise mint `happy_2` on a
+   * re-import, quietly doubling the control surface.
+   */
+  return useCallback(
+    (profile: VizijBundleProfile): { added: number; existing: number } => {
+      let added = 0;
+      let existing = 0;
+      for (const key of profile.keys) {
+        // Standard inputs are keyed by the rig-relative path, so the face
+        // prefix a declared profile carries is normalized away here.
+        const normalized = normalizeStandardRigInputPath(key.path);
+        if (standardInputsByPath.has(normalized)) {
+          existing += 1;
+          continue;
+        }
+        if (createStandardInput(normalized)) {
+          added += 1;
+        }
+      }
+      return { added, existing };
+    },
+    [createStandardInput, standardInputsByPath],
+  );
+}

--- a/apps/vizij-authoring/src/hooks/useProfiles.test.ts
+++ b/apps/vizij-authoring/src/hooks/useProfiles.test.ts
@@ -1,7 +1,18 @@
-import { describe, expect, it } from "vitest";
-import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import type { VizijBundleExtension } from "@vizij/render";
 import { useProfiles } from "./useProfiles";
+
+// The registry is the runtime's, not this app's — stub it so the hook's own
+// behaviour is under test. `vi.mock` is hoisted above the imports.
+const { profilesMock, profileMock } = vi.hoisted(() => ({
+  profilesMock: vi.fn(),
+  profileMock: vi.fn(),
+}));
+vi.mock("@vizij/runtime", () => ({
+  profiles: profilesMock,
+  profile: profileMock,
+}));
 
 const PORTABLE_KEYS = [
   { path: "standard/vizij/expression/happy" },
@@ -41,7 +52,65 @@ const portable = (id = "vizij-face") => ({
   keys: PORTABLE_KEYS,
 });
 
+beforeEach(() => {
+  profilesMock.mockReset().mockResolvedValue([
+    {
+      id: "vizij-face",
+      version: "v1",
+      title: "Vizij face",
+      description: "",
+      keys: 81,
+    },
+  ]);
+  // The registry applies the rig prefix itself, so its paths arrive addressed.
+  profileMock
+    .mockReset()
+    .mockImplementation(async (id: string, rigPrefix: string) =>
+      id === "vizij-face"
+        ? {
+            id,
+            version: "v1",
+            keys: PORTABLE_KEYS.map((k) => ({ path: `${rigPrefix}${k.path}` })),
+          }
+        : null,
+    );
+});
+
 describe("useProfiles", () => {
+  describe("the registry", () => {
+    it("lists what the runtime offers", async () => {
+      const harness = renderAgainst(bundleWith());
+      await waitFor(() =>
+        expect(harness.view.result.current.available).toHaveLength(1),
+      );
+      expect(harness.view.result.current.available[0]!.id).toBe("vizij-face");
+    });
+
+    it("declares a registry profile, asked for with this face's prefix", async () => {
+      const harness = renderAgainst(bundleWith());
+      await act(async () => {
+        await harness.view.result.current.importProfile("vizij-face");
+      });
+      expect(profileMock).toHaveBeenCalledWith(
+        "vizij-face",
+        "rig/quori_latest/",
+      );
+      expect((harness.bundle()?.profiles ?? [])[0]!.keys[0]!.path).toBe(
+        "rig/quori_latest/standard/vizij/expression/happy",
+      );
+    });
+
+    it("declares nothing for an unknown id", async () => {
+      const harness = renderAgainst(bundleWith());
+      let result: unknown;
+      await act(async () => {
+        result = await harness.view.result.current.importProfile("nope");
+      });
+      expect(result).toBeNull();
+      expect(harness.bundle()?.profiles ?? []).toHaveLength(0);
+    });
+  });
+
   it("declares an imported profile on the bundle", async () => {
     const harness = renderAgainst(bundleWith());
     await act(async () => {

--- a/apps/vizij-authoring/src/hooks/useProfiles.test.ts
+++ b/apps/vizij-authoring/src/hooks/useProfiles.test.ts
@@ -1,23 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { act, renderHook } from "@testing-library/react";
 import type { VizijBundleExtension } from "@vizij/render";
 import { useProfiles } from "./useProfiles";
 
-// The registry is the runtime's, not this app's — stub it so the hook's own
-// behaviour is under test rather than the wasm's. `vi.mock` is hoisted above
-// the imports, so the stub is in place before `useProfiles` resolves it.
-const { profilesMock, profileMock } = vi.hoisted(() => ({
-  profilesMock: vi.fn(),
-  profileMock: vi.fn(),
-}));
-vi.mock("@vizij/runtime", () => ({
-  profiles: profilesMock,
-  profile: profileMock,
-}));
-
-const KEYS = [
-  { path: "rig/quori_latest/standard/vizij/expression/happy" },
-  { path: "rig/quori_latest/standard/vizij/viseme/aa" },
+const PORTABLE_KEYS = [
+  { path: "standard/vizij/expression/happy" },
+  { path: "standard/vizij/viseme/aa" },
 ];
 
 function bundleWith(
@@ -43,53 +31,68 @@ function renderAgainst(initial: VizijBundleExtension | null) {
   return { view, bundle: () => current };
 }
 
-beforeEach(() => {
-  profilesMock
-    .mockReset()
-    .mockResolvedValue([
-      {
-        id: "vizij-face",
-        version: "v1",
-        title: "Vizij face",
-        description: "",
-        keys: 81,
-      },
-    ]);
-  profileMock
-    .mockReset()
-    .mockImplementation(async (id: string) =>
-      id === "vizij-face" ? { id, version: "v1", keys: KEYS } : null,
-    );
+const asFile = (body: unknown, name = "p.json") =>
+  ({ name, text: async () => JSON.stringify(body) }) as File;
+
+const portable = (id = "vizij-face") => ({
+  id,
+  version: "v1",
+  title: "Vizij face",
+  keys: PORTABLE_KEYS,
 });
 
 describe("useProfiles", () => {
-  it("lists the registry the runtime serves", async () => {
-    const harness = renderAgainst(bundleWith());
-    await waitFor(() =>
-      expect(harness.view.result.current.available).toHaveLength(1),
-    );
-    expect(harness.view.result.current.available[0]!.id).toBe("vizij-face");
-  });
-
-  // A profile's paths address one face's store, so the import asks for it with
-  // the open face's rig prefix.
-  it("fetches the profile with this face's rig prefix", async () => {
+  it("declares an imported profile on the bundle", async () => {
     const harness = renderAgainst(bundleWith());
     await act(async () => {
-      await harness.view.result.current.importProfile("vizij-face");
-    });
-    expect(profileMock).toHaveBeenCalledWith("vizij-face", "rig/quori_latest/");
-  });
-
-  it("declares the imported profile on the bundle", async () => {
-    const harness = renderAgainst(bundleWith());
-    await act(async () => {
-      await harness.view.result.current.importProfile("vizij-face");
+      await harness.view.result.current.importProfileJson(asFile(portable()));
     });
     const declared = harness.bundle()?.profiles ?? [];
     expect(declared).toHaveLength(1);
     expect(declared[0]!.id).toBe("vizij-face");
-    expect(declared[0]!.keys).toHaveLength(2);
+  });
+
+  // A profile file is portable — the paths are unprefixed — but the store is
+  // not, so importing addresses them to the open face.
+  it("addresses portable paths to the open face", async () => {
+    const harness = renderAgainst(bundleWith());
+    await act(async () => {
+      await harness.view.result.current.importProfileJson(asFile(portable()));
+    });
+    expect(
+      (harness.bundle()?.profiles ?? [])[0]!.keys.map((k) => k.path),
+    ).toStrictEqual([
+      "rig/quori_latest/standard/vizij/expression/happy",
+      "rig/quori_latest/standard/vizij/viseme/aa",
+    ]);
+  });
+
+  // A file exported from a face already carries a prefix; re-importing it must
+  // not stack a second one.
+  it("leaves an already-addressed path alone", async () => {
+    const harness = renderAgainst(bundleWith());
+    await act(async () => {
+      await harness.view.result.current.importProfileJson(
+        asFile({
+          id: "vizij-face",
+          version: "v1",
+          keys: [{ path: "rig/other_face/standard/vizij/expression/happy" }],
+        }),
+      );
+    });
+    expect((harness.bundle()?.profiles ?? [])[0]!.keys[0]!.path).toBe(
+      "rig/other_face/standard/vizij/expression/happy",
+    );
+  });
+
+  it("imports portable paths verbatim when the face has no id", async () => {
+    const harness = renderAgainst(bundleWith(undefined, {}));
+    await act(async () => {
+      await harness.view.result.current.importProfileJson(asFile(portable()));
+    });
+    expect((harness.bundle()?.profiles ?? [])[0]!.keys[0]!.path).toBe(
+      "standard/vizij/expression/happy",
+    );
   });
 
   it("replaces rather than duplicates when re-imported", async () => {
@@ -97,27 +100,17 @@ describe("useProfiles", () => {
       bundleWith([{ id: "vizij-face", version: "v0", keys: [] }]),
     );
     await act(async () => {
-      await harness.view.result.current.importProfile("vizij-face");
+      await harness.view.result.current.importProfileJson(asFile(portable()));
     });
     const declared = harness.bundle()?.profiles ?? [];
     expect(declared).toHaveLength(1);
     expect(declared[0]!.version).toBe("v1");
   });
 
-  it("resolves null and declares nothing for an unknown id", async () => {
-    const harness = renderAgainst(bundleWith());
-    let result: unknown;
-    await act(async () => {
-      result = await harness.view.result.current.importProfile("nope");
-    });
-    expect(result).toBeNull();
-    expect(harness.bundle()?.profiles ?? []).toHaveLength(0);
-  });
-
-  it("removes a declared profile and leaves the others", async () => {
+  it("removes a declared profile and leaves the others", () => {
     const harness = renderAgainst(
       bundleWith([
-        { id: "vizij-face", version: "v1", keys: KEYS },
+        { id: "vizij-face", version: "v1", keys: PORTABLE_KEYS },
         { id: "ros4hri", version: "v1", keys: [] },
       ]),
     );
@@ -131,57 +124,39 @@ describe("useProfiles", () => {
 
   it("reports the paths a declared profile defines", () => {
     const harness = renderAgainst(
-      bundleWith([{ id: "vizij-face", version: "v1", keys: KEYS }]),
+      bundleWith([{ id: "vizij-face", version: "v1", keys: PORTABLE_KEYS }]),
     );
     expect(
       harness.view.result.current.profilePaths("vizij-face"),
-    ).toStrictEqual(KEYS.map((k) => k.path));
+    ).toStrictEqual(PORTABLE_KEYS.map((k) => k.path));
     expect(harness.view.result.current.profilePaths("absent")).toStrictEqual(
       [],
     );
   });
 
-  // A face with no id has no rig prefix; the profile is then the portable form.
-  it("asks for the unprefixed profile when the bundle declares no face id", async () => {
-    const harness = renderAgainst(bundleWith(undefined, {}));
-    await act(async () => {
-      await harness.view.result.current.importProfile("vizij-face");
-    });
-    expect(profileMock).toHaveBeenCalledWith("vizij-face", "");
+  describe("refuses a file that is not a profile", () => {
+    const refuses = async (body: unknown) => {
+      const harness = renderAgainst(bundleWith());
+      await act(async () => {
+        await harness.view.result.current.importProfileJson(asFile(body));
+      });
+      expect(harness.bundle()?.profiles ?? []).toHaveLength(0);
+    };
+
+    it("a graph spec", () => refuses({ nodes: [], edges: [] }));
+    it("keys that are not paths", () =>
+      refuses({ id: "lab", version: "v2", keys: [{ name: "oops" }] }));
+    it("a missing version", () => refuses({ id: "lab", keys: PORTABLE_KEYS }));
   });
 
-  describe("importing from a file", () => {
-    const asFile = (body: unknown) =>
-      ({ name: "p.json", text: async () => JSON.stringify(body) }) as File;
-
-    it("declares a well-formed profile", async () => {
-      const harness = renderAgainst(bundleWith());
-      await act(async () => {
-        await harness.view.result.current.importProfileJson(
-          asFile({ id: "lab", version: "v2", keys: KEYS }),
-        );
-      });
-      expect((harness.bundle()?.profiles ?? [])[0]?.id).toBe("lab");
+  it("refuses JSON that does not parse", async () => {
+    const harness = renderAgainst(bundleWith());
+    await act(async () => {
+      await harness.view.result.current.importProfileJson({
+        name: "bad.json",
+        text: async () => "{not json",
+      } as File);
     });
-
-    it("refuses JSON that is not a profile", async () => {
-      const harness = renderAgainst(bundleWith());
-      await act(async () => {
-        await harness.view.result.current.importProfileJson(
-          asFile({ nodes: [], edges: [] }),
-        );
-      });
-      expect(harness.bundle()?.profiles ?? []).toHaveLength(0);
-    });
-
-    it("refuses a profile whose keys are not paths", async () => {
-      const harness = renderAgainst(bundleWith());
-      await act(async () => {
-        await harness.view.result.current.importProfileJson(
-          asFile({ id: "lab", version: "v2", keys: [{ name: "oops" }] }),
-        );
-      });
-      expect(harness.bundle()?.profiles ?? []).toHaveLength(0);
-    });
+    expect(harness.bundle()?.profiles ?? []).toHaveLength(0);
   });
 });

--- a/apps/vizij-authoring/src/hooks/useProfiles.test.ts
+++ b/apps/vizij-authoring/src/hooks/useProfiles.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { VizijBundleExtension } from "@vizij/render";
+import { useProfiles } from "./useProfiles";
+
+// The registry is the runtime's, not this app's — stub it so the hook's own
+// behaviour is under test rather than the wasm's. `vi.mock` is hoisted above
+// the imports, so the stub is in place before `useProfiles` resolves it.
+const { profilesMock, profileMock } = vi.hoisted(() => ({
+  profilesMock: vi.fn(),
+  profileMock: vi.fn(),
+}));
+vi.mock("@vizij/runtime", () => ({
+  profiles: profilesMock,
+  profile: profileMock,
+}));
+
+const KEYS = [
+  { path: "rig/quori_latest/standard/vizij/expression/happy" },
+  { path: "rig/quori_latest/standard/vizij/viseme/aa" },
+];
+
+function bundleWith(
+  profiles?: VizijBundleExtension["profiles"],
+  metadata: Record<string, unknown> = { faceId: "quori_latest" },
+): VizijBundleExtension {
+  return { version: 1, metadata, graphs: [], profiles } as VizijBundleExtension;
+}
+
+function renderAgainst(initial: VizijBundleExtension | null) {
+  let current = initial;
+  const view = renderHook(() =>
+    useProfiles({
+      bundle: current,
+      updateBundle: (updater) => {
+        current =
+          typeof updater === "function"
+            ? (updater as (p: typeof current) => typeof current)(current)
+            : updater;
+      },
+    }),
+  );
+  return { view, bundle: () => current };
+}
+
+beforeEach(() => {
+  profilesMock
+    .mockReset()
+    .mockResolvedValue([
+      {
+        id: "vizij-face",
+        version: "v1",
+        title: "Vizij face",
+        description: "",
+        keys: 81,
+      },
+    ]);
+  profileMock
+    .mockReset()
+    .mockImplementation(async (id: string) =>
+      id === "vizij-face" ? { id, version: "v1", keys: KEYS } : null,
+    );
+});
+
+describe("useProfiles", () => {
+  it("lists the registry the runtime serves", async () => {
+    const harness = renderAgainst(bundleWith());
+    await waitFor(() =>
+      expect(harness.view.result.current.available).toHaveLength(1),
+    );
+    expect(harness.view.result.current.available[0]!.id).toBe("vizij-face");
+  });
+
+  // A profile's paths address one face's store, so the import asks for it with
+  // the open face's rig prefix.
+  it("fetches the profile with this face's rig prefix", async () => {
+    const harness = renderAgainst(bundleWith());
+    await act(async () => {
+      await harness.view.result.current.importProfile("vizij-face");
+    });
+    expect(profileMock).toHaveBeenCalledWith("vizij-face", "rig/quori_latest/");
+  });
+
+  it("declares the imported profile on the bundle", async () => {
+    const harness = renderAgainst(bundleWith());
+    await act(async () => {
+      await harness.view.result.current.importProfile("vizij-face");
+    });
+    const declared = harness.bundle()?.profiles ?? [];
+    expect(declared).toHaveLength(1);
+    expect(declared[0]!.id).toBe("vizij-face");
+    expect(declared[0]!.keys).toHaveLength(2);
+  });
+
+  it("replaces rather than duplicates when re-imported", async () => {
+    const harness = renderAgainst(
+      bundleWith([{ id: "vizij-face", version: "v0", keys: [] }]),
+    );
+    await act(async () => {
+      await harness.view.result.current.importProfile("vizij-face");
+    });
+    const declared = harness.bundle()?.profiles ?? [];
+    expect(declared).toHaveLength(1);
+    expect(declared[0]!.version).toBe("v1");
+  });
+
+  it("resolves null and declares nothing for an unknown id", async () => {
+    const harness = renderAgainst(bundleWith());
+    let result: unknown;
+    await act(async () => {
+      result = await harness.view.result.current.importProfile("nope");
+    });
+    expect(result).toBeNull();
+    expect(harness.bundle()?.profiles ?? []).toHaveLength(0);
+  });
+
+  it("removes a declared profile and leaves the others", async () => {
+    const harness = renderAgainst(
+      bundleWith([
+        { id: "vizij-face", version: "v1", keys: KEYS },
+        { id: "ros4hri", version: "v1", keys: [] },
+      ]),
+    );
+    act(() => {
+      harness.view.result.current.removeProfile("vizij-face");
+    });
+    expect((harness.bundle()?.profiles ?? []).map((p) => p.id)).toStrictEqual([
+      "ros4hri",
+    ]);
+  });
+
+  it("reports the paths a declared profile defines", () => {
+    const harness = renderAgainst(
+      bundleWith([{ id: "vizij-face", version: "v1", keys: KEYS }]),
+    );
+    expect(
+      harness.view.result.current.profilePaths("vizij-face"),
+    ).toStrictEqual(KEYS.map((k) => k.path));
+    expect(harness.view.result.current.profilePaths("absent")).toStrictEqual(
+      [],
+    );
+  });
+
+  // A face with no id has no rig prefix; the profile is then the portable form.
+  it("asks for the unprefixed profile when the bundle declares no face id", async () => {
+    const harness = renderAgainst(bundleWith(undefined, {}));
+    await act(async () => {
+      await harness.view.result.current.importProfile("vizij-face");
+    });
+    expect(profileMock).toHaveBeenCalledWith("vizij-face", "");
+  });
+
+  describe("importing from a file", () => {
+    const asFile = (body: unknown) =>
+      ({ name: "p.json", text: async () => JSON.stringify(body) }) as File;
+
+    it("declares a well-formed profile", async () => {
+      const harness = renderAgainst(bundleWith());
+      await act(async () => {
+        await harness.view.result.current.importProfileJson(
+          asFile({ id: "lab", version: "v2", keys: KEYS }),
+        );
+      });
+      expect((harness.bundle()?.profiles ?? [])[0]?.id).toBe("lab");
+    });
+
+    it("refuses JSON that is not a profile", async () => {
+      const harness = renderAgainst(bundleWith());
+      await act(async () => {
+        await harness.view.result.current.importProfileJson(
+          asFile({ nodes: [], edges: [] }),
+        );
+      });
+      expect(harness.bundle()?.profiles ?? []).toHaveLength(0);
+    });
+
+    it("refuses a profile whose keys are not paths", async () => {
+      const harness = renderAgainst(bundleWith());
+      await act(async () => {
+        await harness.view.result.current.importProfileJson(
+          asFile({ id: "lab", version: "v2", keys: [{ name: "oops" }] }),
+        );
+      });
+      expect(harness.bundle()?.profiles ?? []).toHaveLength(0);
+    });
+  });
+});

--- a/apps/vizij-authoring/src/hooks/useProfiles.ts
+++ b/apps/vizij-authoring/src/hooks/useProfiles.ts
@@ -1,4 +1,5 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { profile, profiles, type ProfileSummary } from "@vizij/runtime";
 import type { VizijBundleExtension, VizijBundleProfile } from "@vizij/render";
 import { downloadJsonFile } from "../utils/fileIO";
 
@@ -65,13 +66,35 @@ function addressToFace(
  * Declaring one writes it into the bundle, so the vocabulary travels with the
  * asset exactly like any other authored input.
  *
- * Profiles arrive as **files**, not from a registry. Vizij ships its own — get
- * one with `vizij-bundle export-profile <id> -o <file>.json` — but so can
- * anyone else, and the app treats them the same. That keeps the import list to
- * things the author chose rather than a menu of options whose effect is not
- * obvious.
+ * Profiles arrive two ways, and the app treats them identically once declared:
+ * from the shipped registry, or from a JSON file (`vizij-bundle export-profile
+ * <id> -o <file>.json` writes one, but so can anyone). Both land in
+ * `bundle.profiles`.
+ *
+ * The registry is compiled into `@vizij/runtime`'s wasm, so it grows by adding
+ * an entry there and publishing — it is not fetched at runtime. `available` is
+ * a plain list either way, so a remote registry would slot in behind it without
+ * the callers changing.
  */
 export function useProfiles({ bundle, updateBundle }: UseProfilesOptions) {
+  const [available, setAvailable] = useState<ProfileSummary[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    profiles()
+      .then((list) => {
+        if (!cancelled) {
+          setAvailable(list);
+        }
+      })
+      .catch((error) => {
+        console.error("profile registry unavailable", error);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   // The face's keys live under `rig/<faceId>/`, and an imported profile is
   // addressed to them.
   const rigPrefix = useMemo(() => {
@@ -100,6 +123,24 @@ export function useProfiles({ bundle, updateBundle }: UseProfilesOptions) {
       });
     },
     [updateBundle],
+  );
+
+  /**
+   * Declare a profile from the shipped registry, addressed to this face.
+   * Resolves to `null` for an unknown id.
+   */
+  const importProfile = useCallback(
+    async (id: string): Promise<VizijBundleProfile | null> => {
+      const fetched = await profile(id, rigPrefix);
+      if (!fetched) {
+        console.error(`profile ${id} unavailable`);
+        return null;
+      }
+      const entry = fetched as unknown as VizijBundleProfile;
+      declare(entry);
+      return entry;
+    },
+    [declare, rigPrefix],
   );
 
   /**
@@ -162,9 +203,12 @@ export function useProfiles({ bundle, updateBundle }: UseProfilesOptions) {
   );
 
   return {
+    /** The profiles the registry offers, for the import picker. */
+    available,
     /** The profiles this face declares. */
     declared,
     declaredIds,
+    importProfile,
     importProfileJson,
     exportProfileJson,
     removeProfile,

--- a/apps/vizij-authoring/src/hooks/useProfiles.ts
+++ b/apps/vizij-authoring/src/hooks/useProfiles.ts
@@ -1,14 +1,6 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { profile, profiles, type ProfileSummary } from "@vizij/runtime";
+import { useCallback, useMemo } from "react";
 import type { VizijBundleExtension, VizijBundleProfile } from "@vizij/render";
 import { downloadJsonFile } from "../utils/fileIO";
-
-/**
- * The registry id of the Vizij face standard — the profile a face adaptation
- * maps from. Named here so the app has one place that knows it, rather than
- * the string appearing wherever an adaptation is created.
- */
-export const FACE_PROFILE_ID = "vizij-face";
 
 interface UseProfilesOptions {
   /** The open document's bundle — `null` while no face is loaded. */
@@ -39,39 +31,49 @@ function isProfile(value: unknown): value is VizijBundleProfile {
 }
 
 /**
+ * Address a profile to one face.
+ *
+ * A profile file is portable — `vizij-bundle export-profile` writes the paths
+ * unprefixed, because the vocabulary is the same for every face. The store is
+ * not: a face's keys live under `rig/<faceId>/`. So an imported path picks up
+ * this face's prefix unless it already carries one, which leaves a file that
+ * was exported from a face alone.
+ */
+function addressToFace(
+  profile: VizijBundleProfile,
+  rigPrefix: string,
+): VizijBundleProfile {
+  if (!rigPrefix) {
+    return profile;
+  }
+  return {
+    ...profile,
+    keys: profile.keys.map((key) =>
+      key.path.startsWith("rig/")
+        ? key
+        : { ...key, path: `${rigPrefix}${key.path}` },
+    ),
+  };
+}
+
+/**
  * The profiles a face declares it speaks — the vocabularies its graphs are
  * authored against.
  *
  * A *profile* is a set of paths and their types; a *mapping* is the graph that
  * carries one profile's values onto another's. This hook owns the first.
- * Importing one writes it into the bundle, so the vocabulary travels with the
- * asset exactly like any other authored input, and returns it so the caller can
- * put its paths in front of the author.
+ * Declaring one writes it into the bundle, so the vocabulary travels with the
+ * asset exactly like any other authored input.
  *
- * The registry comes from `@vizij/runtime`, which serves the same assets the
- * native bundler embeds — no second copy of the vocabulary lives here.
+ * Profiles arrive as **files**, not from a registry. Vizij ships its own — get
+ * one with `vizij-bundle export-profile <id> -o <file>.json` — but so can
+ * anyone else, and the app treats them the same. That keeps the import list to
+ * things the author chose rather than a menu of options whose effect is not
+ * obvious.
  */
 export function useProfiles({ bundle, updateBundle }: UseProfilesOptions) {
-  const [available, setAvailable] = useState<ProfileSummary[]>([]);
-
-  useEffect(() => {
-    let cancelled = false;
-    profiles()
-      .then((list) => {
-        if (!cancelled) {
-          setAvailable(list);
-        }
-      })
-      .catch((error) => {
-        console.error("profile registry unavailable", error);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  // A profile's paths address this face's store, so they take the bundle's rig
-  // prefix — the same prefix the runtime gives the controls a mapping writes.
+  // The face's keys live under `rig/<faceId>/`, and an imported profile is
+  // addressed to them.
   const rigPrefix = useMemo(() => {
     const faceId = bundle?.metadata?.faceId;
     return typeof faceId === "string" && faceId ? `rig/${faceId}/` : "";
@@ -101,18 +103,25 @@ export function useProfiles({ bundle, updateBundle }: UseProfilesOptions) {
   );
 
   /**
-   * Import a shipped profile: fetch it with this face's rig prefix applied,
-   * declare it on the bundle, and hand it back so its paths can be offered to
-   * the author. Resolves to `null` for an unknown id.
+   * Declare a profile from a JSON file, addressed to this face. Resolves to the
+   * declared profile, or `null` when the file is not one.
    */
-  const importProfile = useCallback(
-    async (id: string): Promise<VizijBundleProfile | null> => {
-      const fetched = await profile(id, rigPrefix);
-      if (!fetched) {
-        console.error(`profile ${id} unavailable`);
+  const importProfileJson = useCallback(
+    async (file: File): Promise<VizijBundleProfile | null> => {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(await file.text());
+      } catch (error) {
+        console.error(`profile JSON ${file.name} does not parse`, error);
         return null;
       }
-      const entry = fetched as unknown as VizijBundleProfile;
+      if (!isProfile(parsed)) {
+        console.error(
+          `${file.name} is not a profile — expected { id, version, keys: [{ path }] }`,
+        );
+        return null;
+      }
+      const entry = addressToFace(parsed, rigPrefix);
       declare(entry);
       return entry;
     },
@@ -132,34 +141,7 @@ export function useProfiles({ bundle, updateBundle }: UseProfilesOptions) {
     [updateBundle],
   );
 
-  /**
-   * Declare a profile from a JSON file — a vocabulary that is not in the
-   * shipped registry (a lab's own, or one pinned to a version). Stored
-   * verbatim: a profile is face-specific once its paths carry a rig prefix, so
-   * there is no canonical form to restore.
-   */
-  const importProfileJson = useCallback(
-    async (file: File): Promise<VizijBundleProfile | null> => {
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(await file.text());
-      } catch (error) {
-        console.error(`profile JSON ${file.name} does not parse`, error);
-        return null;
-      }
-      if (!isProfile(parsed)) {
-        console.error(
-          `profile JSON ${file.name} is not a profile ({ id, version, keys })`,
-        );
-        return null;
-      }
-      declare(parsed);
-      return parsed;
-    },
-    [declare],
-  );
-
-  /** Download a declared profile, verbatim. */
+  /** Download a declared profile, verbatim — paths included, so it round-trips. */
   const exportProfileJson = useCallback(
     (id: string) => {
       const entry = declared.find((p) => p.id === id);
@@ -180,12 +162,9 @@ export function useProfiles({ bundle, updateBundle }: UseProfilesOptions) {
   );
 
   return {
-    /** The profiles the registry ships, for the import picker. */
-    available,
     /** The profiles this face declares. */
     declared,
     declaredIds,
-    importProfile,
     importProfileJson,
     exportProfileJson,
     removeProfile,

--- a/apps/vizij-authoring/src/hooks/useProfiles.ts
+++ b/apps/vizij-authoring/src/hooks/useProfiles.ts
@@ -1,0 +1,194 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { profile, profiles, type ProfileSummary } from "@vizij/runtime";
+import type { VizijBundleExtension, VizijBundleProfile } from "@vizij/render";
+import { downloadJsonFile } from "../utils/fileIO";
+
+/**
+ * The registry id of the Vizij face standard — the profile a face adaptation
+ * maps from. Named here so the app has one place that knows it, rather than
+ * the string appearing wherever an adaptation is created.
+ */
+export const FACE_PROFILE_ID = "vizij-face";
+
+interface UseProfilesOptions {
+  /** The open document's bundle — `null` while no face is loaded. */
+  bundle: VizijBundleExtension | null;
+  /** The loader's bundle updater (value or functional form). */
+  updateBundle: (
+    updater:
+      | VizijBundleExtension
+      | null
+      | ((prev: VizijBundleExtension | null) => VizijBundleExtension | null),
+  ) => void;
+}
+
+/** Whether `value` has the shape of a profile, for JSON arriving from disk. */
+function isProfile(value: unknown): value is VizijBundleProfile {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Partial<VizijBundleProfile>;
+  return (
+    typeof candidate.id === "string" &&
+    typeof candidate.version === "string" &&
+    Array.isArray(candidate.keys) &&
+    candidate.keys.every(
+      (key) => key && typeof (key as { path?: unknown }).path === "string",
+    )
+  );
+}
+
+/**
+ * The profiles a face declares it speaks — the vocabularies its graphs are
+ * authored against.
+ *
+ * A *profile* is a set of paths and their types; a *mapping* is the graph that
+ * carries one profile's values onto another's. This hook owns the first.
+ * Importing one writes it into the bundle, so the vocabulary travels with the
+ * asset exactly like any other authored input, and returns it so the caller can
+ * put its paths in front of the author.
+ *
+ * The registry comes from `@vizij/runtime`, which serves the same assets the
+ * native bundler embeds — no second copy of the vocabulary lives here.
+ */
+export function useProfiles({ bundle, updateBundle }: UseProfilesOptions) {
+  const [available, setAvailable] = useState<ProfileSummary[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    profiles()
+      .then((list) => {
+        if (!cancelled) {
+          setAvailable(list);
+        }
+      })
+      .catch((error) => {
+        console.error("profile registry unavailable", error);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // A profile's paths address this face's store, so they take the bundle's rig
+  // prefix — the same prefix the runtime gives the controls a mapping writes.
+  const rigPrefix = useMemo(() => {
+    const faceId = bundle?.metadata?.faceId;
+    return typeof faceId === "string" && faceId ? `rig/${faceId}/` : "";
+  }, [bundle]);
+
+  const declared = useMemo(() => bundle?.profiles ?? [], [bundle]);
+  const declaredIds = useMemo(() => declared.map((p) => p.id), [declared]);
+
+  /** Write `entry` into the bundle, replacing the profile of the same id. */
+  const declare = useCallback(
+    (entry: VizijBundleProfile) => {
+      updateBundle((prev) => {
+        if (!prev) {
+          return prev;
+        }
+        const next = [...(prev.profiles ?? [])];
+        const existing = next.findIndex((p) => p.id === entry.id);
+        if (existing >= 0) {
+          next[existing] = entry;
+        } else {
+          next.push(entry);
+        }
+        return { ...prev, profiles: next };
+      });
+    },
+    [updateBundle],
+  );
+
+  /**
+   * Import a shipped profile: fetch it with this face's rig prefix applied,
+   * declare it on the bundle, and hand it back so its paths can be offered to
+   * the author. Resolves to `null` for an unknown id.
+   */
+  const importProfile = useCallback(
+    async (id: string): Promise<VizijBundleProfile | null> => {
+      const fetched = await profile(id, rigPrefix);
+      if (!fetched) {
+        console.error(`profile ${id} unavailable`);
+        return null;
+      }
+      const entry = fetched as unknown as VizijBundleProfile;
+      declare(entry);
+      return entry;
+    },
+    [declare, rigPrefix],
+  );
+
+  /** Drop a declared profile from the face. Its authored graphs are untouched. */
+  const removeProfile = useCallback(
+    (id: string) => {
+      updateBundle((prev) => {
+        if (!prev?.profiles) {
+          return prev;
+        }
+        return { ...prev, profiles: prev.profiles.filter((p) => p.id !== id) };
+      });
+    },
+    [updateBundle],
+  );
+
+  /**
+   * Declare a profile from a JSON file — a vocabulary that is not in the
+   * shipped registry (a lab's own, or one pinned to a version). Stored
+   * verbatim: a profile is face-specific once its paths carry a rig prefix, so
+   * there is no canonical form to restore.
+   */
+  const importProfileJson = useCallback(
+    async (file: File): Promise<VizijBundleProfile | null> => {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(await file.text());
+      } catch (error) {
+        console.error(`profile JSON ${file.name} does not parse`, error);
+        return null;
+      }
+      if (!isProfile(parsed)) {
+        console.error(
+          `profile JSON ${file.name} is not a profile ({ id, version, keys })`,
+        );
+        return null;
+      }
+      declare(parsed);
+      return parsed;
+    },
+    [declare],
+  );
+
+  /** Download a declared profile, verbatim. */
+  const exportProfileJson = useCallback(
+    (id: string) => {
+      const entry = declared.find((p) => p.id === id);
+      if (!entry) {
+        console.error(`no declared profile ${id} to export`);
+        return;
+      }
+      downloadJsonFile(entry, `${id}.profile.json`);
+    },
+    [declared],
+  );
+
+  /** Every path a declared profile defines, or `[]` when it is not declared. */
+  const profilePaths = useCallback(
+    (id: string): string[] =>
+      declared.find((p) => p.id === id)?.keys.map((key) => key.path) ?? [],
+    [declared],
+  );
+
+  return {
+    /** The profiles the registry ships, for the import picker. */
+    available,
+    /** The profiles this face declares. */
+    declared,
+    declaredIds,
+    importProfile,
+    importProfileJson,
+    exportProfileJson,
+    removeProfile,
+    profilePaths,
+  } as const;
+}

--- a/apps/vizij-authoring/src/hooks/useStandardAdaptation.test.ts
+++ b/apps/vizij-authoring/src/hooks/useStandardAdaptation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { act, renderHook } from "@testing-library/react";
-import type { VizijBundleExtension } from "@vizij/render";
+import type { VizijBundleExtension, VizijBundleProfile } from "@vizij/render";
 import {
   STANDARD_ADAPTATION_KIND,
   adaptationGraphId,
@@ -43,6 +43,17 @@ function renderAgainst(initial: VizijBundleExtension | null) {
   };
 }
 
+/** A three-key profile, standing in for one the runtime would serve. */
+const PROFILE: VizijBundleProfile = {
+  id: "vizij-face",
+  version: "v1",
+  keys: [
+    { path: "rig/quori_latest/standard/vizij/expression/happy" },
+    { path: "rig/quori_latest/standard/vizij/expression/sad" },
+    { path: "rig/quori_latest/standard/vizij/viseme/aa" },
+  ],
+};
+
 describe("useStandardAdaptation", () => {
   it("names the graph after the face, matching the native bundler", () => {
     expect(adaptationGraphId("quori_latest")).toBe(
@@ -50,10 +61,10 @@ describe("useStandardAdaptation", () => {
     );
   });
 
-  it("adds an adaptation declaring every control, wired to nothing", () => {
+  it("adds an adaptation declaring every profile path, wired to nothing", () => {
     const harness = renderAgainst(bundleWith());
     act(() => {
-      harness.view.result.current.toggleAdaptation(true);
+      harness.view.result.current.toggleAdaptation(true, PROFILE);
     });
 
     const graphs = harness.bundle()?.graphs ?? [];
@@ -63,7 +74,7 @@ describe("useStandardAdaptation", () => {
     expect(entry.id).toBe("quori_latest_standard_adaptation");
 
     const spec = entry.spec as { nodes: unknown[]; edges: unknown[] };
-    expect(spec.nodes).toHaveLength(40);
+    expect(spec.nodes).toHaveLength(PROFILE.keys.length);
     expect(spec.edges).toStrictEqual([]);
   });
 
@@ -75,12 +86,14 @@ describe("useStandardAdaptation", () => {
     };
     const harness = renderAgainst(bundleWith([existing]));
     act(() => {
-      harness.view.result.current.toggleAdaptation(true);
+      harness.view.result.current.toggleAdaptation(true, PROFILE);
     });
 
     const graphs = harness.bundle()?.graphs ?? [];
     expect(graphs).toHaveLength(1);
-    expect((graphs[0]!.spec as { nodes: unknown[] }).nodes).toHaveLength(40);
+    expect((graphs[0]!.spec as { nodes: unknown[] }).nodes).toHaveLength(
+      PROFILE.keys.length,
+    );
   });
 
   it("removes the adaptation and leaves the face's other graphs alone", () => {
@@ -119,6 +132,16 @@ describe("useStandardAdaptation", () => {
   it("refuses to embed when the bundle declares no face id", () => {
     const harness = renderAgainst(bundleWith([], {}));
     expect(harness.view.result.current.graphId).toBeNull();
+    act(() => {
+      harness.view.result.current.toggleAdaptation(true, PROFILE);
+    });
+    expect(harness.bundle()?.graphs ?? []).toHaveLength(0);
+  });
+
+  // An adaptation maps *some* profile onto the face; without one there is
+  // nothing to declare, so the toggle refuses rather than writing an empty graph.
+  it("refuses to embed without a profile to map from", () => {
+    const harness = renderAgainst(bundleWith());
     act(() => {
       harness.view.result.current.toggleAdaptation(true);
     });

--- a/apps/vizij-authoring/src/hooks/useStandardAdaptation.test.ts
+++ b/apps/vizij-authoring/src/hooks/useStandardAdaptation.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import type { VizijBundleExtension } from "@vizij/render";
+import {
+  STANDARD_ADAPTATION_KIND,
+  adaptationGraphId,
+  isAdaptationEntry,
+  useStandardAdaptation,
+} from "./useStandardAdaptation";
+
+/**
+ * A minimal bundle, as an imported face would carry. `metadata` is passed
+ * whole so a test can hand over one with no `faceId` at all.
+ */
+function bundleWith(
+  graphs: VizijBundleExtension["graphs"] = [],
+  metadata: Record<string, unknown> = { faceId: "quori_latest" },
+): VizijBundleExtension {
+  return { version: 1, metadata, graphs } as VizijBundleExtension;
+}
+
+/**
+ * Drive the hook against a mutable bundle, the way the loader does — the
+ * updater is functional, so each call sees the previous value.
+ */
+function renderAgainst(initial: VizijBundleExtension | null) {
+  let current = initial;
+  const view = renderHook(() =>
+    useStandardAdaptation({
+      bundle: current,
+      updateBundle: (updater) => {
+        current =
+          typeof updater === "function"
+            ? (updater as (p: typeof current) => typeof current)(current)
+            : updater;
+      },
+    }),
+  );
+  return {
+    view,
+    bundle: () => current,
+    rerender: () => view.rerender(),
+  };
+}
+
+describe("useStandardAdaptation", () => {
+  it("names the graph after the face, matching the native bundler", () => {
+    expect(adaptationGraphId("quori_latest")).toBe(
+      "quori_latest_standard_adaptation",
+    );
+  });
+
+  it("adds an adaptation declaring every control, wired to nothing", () => {
+    const harness = renderAgainst(bundleWith());
+    act(() => {
+      harness.view.result.current.toggleAdaptation(true);
+    });
+
+    const graphs = harness.bundle()?.graphs ?? [];
+    expect(graphs).toHaveLength(1);
+    const entry = graphs[0]!;
+    expect(entry.kind).toBe(STANDARD_ADAPTATION_KIND);
+    expect(entry.id).toBe("quori_latest_standard_adaptation");
+
+    const spec = entry.spec as { nodes: unknown[]; edges: unknown[] };
+    expect(spec.nodes).toHaveLength(40);
+    expect(spec.edges).toStrictEqual([]);
+  });
+
+  it("replaces rather than duplicates when re-enabled", () => {
+    const existing = {
+      id: "quori_latest_standard_adaptation",
+      kind: STANDARD_ADAPTATION_KIND,
+      spec: { nodes: [], edges: [] },
+    };
+    const harness = renderAgainst(bundleWith([existing]));
+    act(() => {
+      harness.view.result.current.toggleAdaptation(true);
+    });
+
+    const graphs = harness.bundle()?.graphs ?? [];
+    expect(graphs).toHaveLength(1);
+    expect((graphs[0]!.spec as { nodes: unknown[] }).nodes).toHaveLength(40);
+  });
+
+  it("removes the adaptation and leaves the face's other graphs alone", () => {
+    const rig = { id: "quori_latest", kind: "rig", spec: { nodes: [] } };
+    const adaptation = {
+      id: "quori_latest_standard_adaptation",
+      kind: STANDARD_ADAPTATION_KIND,
+      spec: { nodes: [], edges: [] },
+    };
+    const harness = renderAgainst(bundleWith([rig, adaptation]));
+    act(() => {
+      harness.view.result.current.toggleAdaptation(false);
+    });
+
+    expect(harness.bundle()?.graphs).toStrictEqual([rig]);
+  });
+
+  it("reports whether the open face carries one", () => {
+    expect(renderAgainst(bundleWith()).view.result.current.embedded).toBe(
+      false,
+    );
+    const withEntry = renderAgainst(
+      bundleWith([
+        {
+          id: "quori_latest_standard_adaptation",
+          kind: STANDARD_ADAPTATION_KIND,
+          spec: { nodes: [], edges: [] },
+        },
+      ]),
+    );
+    expect(withEntry.view.result.current.embedded).toBe(true);
+  });
+
+  // A bundle whose metadata carries no usable face id has no rig prefix and no
+  // stable id, so embedding would write a graph the runtime cannot address.
+  it("refuses to embed when the bundle declares no face id", () => {
+    const harness = renderAgainst(bundleWith([], {}));
+    expect(harness.view.result.current.graphId).toBeNull();
+    act(() => {
+      harness.view.result.current.toggleAdaptation(true);
+    });
+    expect(harness.bundle()?.graphs ?? []).toHaveLength(0);
+  });
+
+  it("ignores a non-string face id rather than stringifying it", () => {
+    const harness = renderAgainst(bundleWith([], { faceId: 42 }));
+    expect(harness.view.result.current.graphId).toBeNull();
+  });
+
+  it("recognises an adaptation entry by kind", () => {
+    expect(
+      isAdaptationEntry({ id: "x", kind: STANDARD_ADAPTATION_KIND, spec: {} }),
+    ).toBe(true);
+    expect(isAdaptationEntry({ id: "x", kind: "rig", spec: {} })).toBe(false);
+  });
+});

--- a/apps/vizij-authoring/src/hooks/useStandardAdaptation.ts
+++ b/apps/vizij-authoring/src/hooks/useStandardAdaptation.ts
@@ -1,0 +1,184 @@
+import { useCallback, useMemo } from "react";
+import type {
+  VizijBundleExtension,
+  VizijBundleGraphEntry,
+} from "@vizij/render";
+import { downloadJsonFile } from "../utils/fileIO";
+import { buildEmptyAdaptationSpec } from "../utils/faceStandard";
+
+/** The bundle graph kind a face's standard adaptation embeds under. */
+export const STANDARD_ADAPTATION_KIND = "standard-adaptation";
+
+/**
+ * The bundle graph id the adaptation embeds under — stable per face, so
+ * re-enabling replaces rather than duplicates. Mirrors the id the native
+ * bundler grafts under (`vizij-bundle add-graph --kind standard-adaptation`).
+ */
+export function adaptationGraphId(faceId: string): string {
+  return `${faceId}_standard_adaptation`;
+}
+
+/** Whether a bundle entry is a face's standard adaptation. */
+export function isAdaptationEntry(entry: VizijBundleGraphEntry): boolean {
+  return entry.kind === STANDARD_ADAPTATION_KIND;
+}
+
+interface UseStandardAdaptationOptions {
+  /** The open document's bundle — `null` while no face is loaded. */
+  bundle: VizijBundleExtension | null;
+  /** The loader's bundle updater (value or functional form). */
+  updateBundle: (
+    updater:
+      | VizijBundleExtension
+      | null
+      | ((prev: VizijBundleExtension | null) => VizijBundleExtension | null),
+  ) => void;
+}
+
+/**
+ * The face's standard adaptation: the graph that turns the Vizij face
+ * standard's `standard/vizij/*` controls into this face's own pose weights.
+ *
+ * It is the last link in the chain a ROS4HRI command travels —
+ * `standard/ros4hri/*` → the profile → `standard/vizij/*` → **here** → the
+ * face's poses. A face without one still receives standard commands and does
+ * nothing with them, which is why an export that omits it looks correct right
+ * up until something tries to drive it.
+ *
+ * Unlike a standard *profile*, an adaptation has no canonical face-independent
+ * form: it writes this face's own pose paths. It is stored and exported
+ * verbatim, matching the shipped reference adaptation
+ * (`fixtures/faces/quori/standard-adaptation.json` in vizij-rs), so an exported
+ * file drops straight into `vizij-bundle add-graph`.
+ */
+export function useStandardAdaptation({
+  bundle,
+  updateBundle,
+}: UseStandardAdaptationOptions) {
+  // Bundle metadata is an open record, so the face id is narrowed here rather
+  // than trusted — a bundle without one has no rig prefix and no stable id to
+  // embed under, and the toggle refuses instead of writing a malformed entry.
+  const faceId = useMemo(() => {
+    const value = bundle?.metadata?.faceId;
+    return typeof value === "string" && value ? value : null;
+  }, [bundle]);
+
+  // The adaptation reads the face's namespaced standard controls, so its input
+  // paths take the bundle's rig prefix — the same prefix the deployed runtime
+  // gives the profile that writes them.
+  const rigPrefix = useMemo(() => (faceId ? `rig/${faceId}/` : ""), [faceId]);
+
+  const graphId = useMemo(
+    () => (faceId ? adaptationGraphId(faceId) : null),
+    [faceId],
+  );
+
+  const entry = useMemo(
+    () => (bundle?.graphs ?? []).find(isAdaptationEntry) ?? null,
+    [bundle],
+  );
+
+  const embedded = entry !== null;
+
+  /** Graft `spec` in under the face's adaptation id — replace or append. */
+  const embedSpec = useCallback(
+    (spec: Record<string, unknown>) => {
+      if (!graphId) {
+        console.error("no faceId on the bundle, so no adaptation id to embed");
+        return;
+      }
+      const next: VizijBundleGraphEntry = {
+        id: graphId,
+        kind: STANDARD_ADAPTATION_KIND,
+        spec,
+      };
+      updateBundle((prev) => {
+        if (!prev) {
+          return prev;
+        }
+        const graphs = [...(prev.graphs ?? [])];
+        const existing = graphs.findIndex(isAdaptationEntry);
+        if (existing >= 0) {
+          graphs[existing] = next;
+        } else {
+          graphs.push(next);
+        }
+        return { ...prev, graphs };
+      });
+    },
+    [graphId, updateBundle],
+  );
+
+  /**
+   * Add the adaptation (every standard control declared, nothing wired — the
+   * author binds them in the graph editor) or remove it.
+   */
+  const toggleAdaptation = useCallback(
+    (enabled: boolean) => {
+      if (!enabled) {
+        updateBundle((prev) => {
+          if (!prev?.graphs) {
+            return prev;
+          }
+          return {
+            ...prev,
+            graphs: prev.graphs.filter((graph) => !isAdaptationEntry(graph)),
+          };
+        });
+        return;
+      }
+      embedSpec(
+        buildEmptyAdaptationSpec(rigPrefix) as unknown as Record<
+          string,
+          unknown
+        >,
+      );
+    },
+    [embedSpec, rigPrefix, updateBundle],
+  );
+
+  /**
+   * Download the embedded adaptation as JSON, verbatim — the form
+   * `vizij-bundle add-graph --kind standard-adaptation` reads back.
+   */
+  const exportAdaptationJson = useCallback(() => {
+    if (!entry?.spec) {
+      console.error("no embedded adaptation to export");
+      return;
+    }
+    downloadJsonFile(entry.spec, `${graphId ?? "standard-adaptation"}.json`);
+  }, [entry, graphId]);
+
+  /** Replace the embedded adaptation from a JSON file, verbatim. */
+  const importAdaptationJson = useCallback(
+    async (file: File) => {
+      let spec: { nodes?: unknown[]; edges?: unknown[] };
+      try {
+        spec = JSON.parse(await file.text());
+      } catch (error) {
+        console.error(`adaptation JSON ${file.name} does not parse`, error);
+        return;
+      }
+      if (!Array.isArray(spec.nodes) || !Array.isArray(spec.edges)) {
+        console.error(`adaptation JSON ${file.name} is not a graph spec`);
+        return;
+      }
+      embedSpec(spec as Record<string, unknown>);
+    },
+    [embedSpec],
+  );
+
+  return {
+    /** Whether this face carries a standard adaptation. */
+    embedded,
+    /** The embedded entry, or `null`. */
+    entry,
+    /** The bundle graph id the adaptation embeds under, or `null`. */
+    graphId,
+    toggleAdaptation,
+    exportAdaptationJson,
+    importAdaptationJson,
+    /** Replace the embedded spec in place (the graph editor's apply-back). */
+    replaceAdaptationSpec: embedSpec,
+  } as const;
+}

--- a/apps/vizij-authoring/src/hooks/useStandardAdaptation.ts
+++ b/apps/vizij-authoring/src/hooks/useStandardAdaptation.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from "react";
 import type {
   VizijBundleExtension,
   VizijBundleGraphEntry,
+  VizijBundleProfile,
 } from "@vizij/render";
 import { downloadJsonFile } from "../utils/fileIO";
 import { buildEmptyAdaptationSpec } from "../utils/faceStandard";
@@ -63,11 +64,6 @@ export function useStandardAdaptation({
     return typeof value === "string" && value ? value : null;
   }, [bundle]);
 
-  // The adaptation reads the face's namespaced standard controls, so its input
-  // paths take the bundle's rig prefix — the same prefix the deployed runtime
-  // gives the profile that writes them.
-  const rigPrefix = useMemo(() => (faceId ? `rig/${faceId}/` : ""), [faceId]);
-
   const graphId = useMemo(
     () => (faceId ? adaptationGraphId(faceId) : null),
     [faceId],
@@ -110,11 +106,16 @@ export function useStandardAdaptation({
   );
 
   /**
-   * Add the adaptation (every standard control declared, nothing wired — the
-   * author binds them in the graph editor) or remove it.
+   * Add an adaptation for `profile` (every path it defines declared as an
+   * input, nothing wired — the author binds them in the graph editor), or
+   * remove the adaptation entirely.
+   *
+   * The profile is passed in rather than assumed: an adaptation maps *some*
+   * profile onto this face, and which one is the author's choice. The profile
+   * arrives already addressed to the face, so no prefixing happens here.
    */
   const toggleAdaptation = useCallback(
-    (enabled: boolean) => {
+    (enabled: boolean, profile?: VizijBundleProfile) => {
       if (!enabled) {
         updateBundle((prev) => {
           if (!prev?.graphs) {
@@ -127,14 +128,15 @@ export function useStandardAdaptation({
         });
         return;
       }
+      if (!profile) {
+        console.error("an adaptation needs a profile to map from");
+        return;
+      }
       embedSpec(
-        buildEmptyAdaptationSpec(rigPrefix) as unknown as Record<
-          string,
-          unknown
-        >,
+        buildEmptyAdaptationSpec(profile) as unknown as Record<string, unknown>,
       );
     },
-    [embedSpec, rigPrefix, updateBundle],
+    [embedSpec, updateBundle],
   );
 
   /**

--- a/apps/vizij-authoring/src/state/DeclaredProfilesContext.test.ts
+++ b/apps/vizij-authoring/src/state/DeclaredProfilesContext.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import type { VizijBundleProfile } from "@vizij/render";
+import { namespaceOfProfile } from "./DeclaredProfilesContext";
+
+const profileOf = (paths: string[]): VizijBundleProfile => ({
+  id: "p",
+  version: "v1",
+  keys: paths.map((path) => ({ path })),
+});
+
+describe("namespaceOfProfile", () => {
+  it("reads the namespace from face-addressed paths", () => {
+    expect(
+      namespaceOfProfile(
+        profileOf([
+          "rig/quori_latest/standard/vizij/expression/happy",
+          "rig/quori_latest/standard/vizij/left_eye/pos/x",
+        ]),
+      ),
+    ).toBe("vizij");
+  });
+
+  it("reads it from portable paths too", () => {
+    expect(namespaceOfProfile(profileOf(["standard/ros4hri/au/26"]))).toBe(
+      "ros4hri",
+    );
+  });
+
+  // Depth must not matter — that was the bug. `expression/happy` and
+  // `left_eye/pos/x` are the same profile at different path lengths.
+  it("is depth-independent", () => {
+    expect(
+      namespaceOfProfile(
+        profileOf([
+          "standard/vizij/face/jaw_open",
+          "standard/vizij/left_eye_top_eyelid/pos/y",
+        ]),
+      ),
+    ).toBe("vizij");
+  });
+
+  // Grouping a profile that spans namespaces under one heading would misfile
+  // most of it, so it claims none.
+  it("claims no namespace when the paths disagree", () => {
+    expect(
+      namespaceOfProfile(
+        profileOf(["standard/vizij/expression/happy", "standard/lab/x/y"]),
+      ),
+    ).toBeNull();
+  });
+
+  it("claims none for a profile with no standard paths", () => {
+    expect(
+      namespaceOfProfile(profileOf(["rig/q/poses/pose_a.weight"])),
+    ).toBeNull();
+    expect(namespaceOfProfile(profileOf([]))).toBeNull();
+  });
+});

--- a/apps/vizij-authoring/src/state/DeclaredProfilesContext.tsx
+++ b/apps/vizij-authoring/src/state/DeclaredProfilesContext.tsx
@@ -1,0 +1,70 @@
+import { createContext, useContext, useMemo, type ReactNode } from "react";
+import type { VizijBundleProfile } from "@vizij/render";
+
+/**
+ * The namespaces the open face's declared profiles occupy, mapped to the name
+ * to show for each.
+ *
+ * A standard path is `/standard/<namespace>/<subgroup…>/<attribute>`, so the
+ * segment after `standard` is the group. The trouble is telling that apart from
+ * a legacy path with no namespace at all (`/standard/left_eye/pos/x`), where
+ * the same segment is a channel. Counting segments guesses, and guesses wrong:
+ * `/standard/vizij/expression/happy` and `/standard/vizij/left_eye/pos/x` are
+ * one profile but different lengths.
+ *
+ * A declared profile settles it. If the face says it speaks `vizij-face` and
+ * that profile's paths live under `standard/vizij/`, then `vizij` is a
+ * namespace — known, not inferred. Paths outside any declared namespace keep
+ * the old behaviour.
+ *
+ * This is what `bundle.profiles` is *for*: the record of which vocabularies a
+ * face declares, used to read its own paths correctly.
+ */
+export type DeclaredNamespaces = ReadonlyMap<string, string>;
+
+const DeclaredProfilesContext = createContext<DeclaredNamespaces>(new Map());
+
+/** The namespace a profile's paths occupy, or `null` when they disagree. */
+export function namespaceOfProfile(profile: VizijBundleProfile): string | null {
+  const namespaces = new Set<string>();
+  for (const key of profile.keys) {
+    // Paths may be face-addressed (`rig/<faceId>/standard/…`) or portable.
+    const match = key.path.match(/(?:^|\/)standard\/([^/]+)\//);
+    if (match?.[1]) {
+      namespaces.add(match[1]);
+    }
+  }
+  // A profile spanning several namespaces names none of them; grouping such a
+  // profile under one heading would misfile most of it.
+  return namespaces.size === 1 ? [...namespaces][0]! : null;
+}
+
+export function DeclaredProfilesProvider({
+  profiles,
+  children,
+}: {
+  profiles: readonly VizijBundleProfile[];
+  children: ReactNode;
+}) {
+  const value = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const profile of profiles) {
+      const namespace = namespaceOfProfile(profile);
+      if (namespace) {
+        map.set(namespace, profile.title ?? profile.id);
+      }
+    }
+    return map;
+  }, [profiles]);
+
+  return (
+    <DeclaredProfilesContext.Provider value={value}>
+      {children}
+    </DeclaredProfilesContext.Provider>
+  );
+}
+
+/** The declared namespaces, empty when no face is open or none are declared. */
+export function useDeclaredNamespaces(): DeclaredNamespaces {
+  return useContext(DeclaredProfilesContext);
+}

--- a/apps/vizij-authoring/src/utils/faceStandard.test.ts
+++ b/apps/vizij-authoring/src/utils/faceStandard.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  EXPRESSION_NAMES,
+  VISEME_SHAPES,
+  buildEmptyAdaptationSpec,
+  expressionPath,
+  visemePath,
+} from "./faceStandard";
+
+const PREFIX = "rig/quori_latest/";
+
+describe("the face standard vocabulary", () => {
+  // These counts are the standard's contract, not an implementation detail:
+  // `vizij-bundle validate` reports coverage as a fraction of exactly these.
+  it("carries the standard's 25 expressions and 15 visemes, each unique", () => {
+    expect(EXPRESSION_NAMES).toHaveLength(25);
+    expect(new Set(EXPRESSION_NAMES).size).toBe(25);
+    expect(VISEME_SHAPES).toHaveLength(15);
+    expect(new Set(VISEME_SHAPES).size).toBe(15);
+    // `sil` is the rest shape the standard names explicitly.
+    expect(VISEME_SHAPES).toContain("sil");
+  });
+
+  it("builds control paths under the standard's namespace", () => {
+    expect(expressionPath("happy")).toBe("standard/vizij/expression/happy");
+    expect(visemePath("aa")).toBe("standard/vizij/viseme/aa");
+  });
+});
+
+describe("the empty adaptation", () => {
+  it("declares every control as a rig-prefixed input and wires nothing", () => {
+    const spec = buildEmptyAdaptationSpec(PREFIX);
+
+    expect(spec.nodes).toHaveLength(40);
+    expect(spec.edges).toStrictEqual([]);
+    expect(spec.nodes.every((node) => node.type === "input")).toBe(true);
+
+    const paths = spec.nodes.map((node) => node.params?.path);
+    expect(paths).toContain(`${PREFIX}standard/vizij/expression/happy`);
+    expect(paths).toContain(`${PREFIX}standard/vizij/viseme/aa`);
+    // Node ids must be unique or the graph cannot round-trip through the editor.
+    expect(new Set(spec.nodes.map((node) => node.id)).size).toBe(40);
+  });
+
+  it("rests every control at zero, so an unwired face holds its neutral", () => {
+    const spec = buildEmptyAdaptationSpec(PREFIX);
+    expect(spec.nodes.every((node) => node.params?.value === 0)).toBe(true);
+  });
+
+  it("omits the prefix for a face with no id, matching the runtime", () => {
+    const spec = buildEmptyAdaptationSpec("");
+    expect(spec.nodes[0]?.params?.path).toBe(
+      "standard/vizij/expression/neutral",
+    );
+  });
+});

--- a/apps/vizij-authoring/src/utils/faceStandard.test.ts
+++ b/apps/vizij-authoring/src/utils/faceStandard.test.ts
@@ -1,56 +1,88 @@
 import { describe, expect, it } from "vitest";
-import {
-  EXPRESSION_NAMES,
-  VISEME_SHAPES,
-  buildEmptyAdaptationSpec,
-  expressionPath,
-  visemePath,
-} from "./faceStandard";
+import type { VizijBundleProfile } from "@vizij/render";
+import { buildEmptyAdaptationSpec } from "./faceStandard";
 
 const PREFIX = "rig/quori_latest/";
 
-describe("the face standard vocabulary", () => {
-  // These counts are the standard's contract, not an implementation detail:
-  // `vizij-bundle validate` reports coverage as a fraction of exactly these.
-  it("carries the standard's 25 expressions and 15 visemes, each unique", () => {
-    expect(EXPRESSION_NAMES).toHaveLength(25);
-    expect(new Set(EXPRESSION_NAMES).size).toBe(25);
-    expect(VISEME_SHAPES).toHaveLength(15);
-    expect(new Set(VISEME_SHAPES).size).toBe(15);
-    // `sil` is the rest shape the standard names explicitly.
-    expect(VISEME_SHAPES).toContain("sil");
-  });
-
-  it("builds control paths under the standard's namespace", () => {
-    expect(expressionPath("happy")).toBe("standard/vizij/expression/happy");
-    expect(visemePath("aa")).toBe("standard/vizij/viseme/aa");
-  });
-});
+/** A profile as `@vizij/runtime` serves it, already rig-prefixed. */
+function profileOf(
+  paths: string[],
+  defaults: Record<string, unknown> = {},
+): VizijBundleProfile {
+  return {
+    id: "vizij-face",
+    version: "v1",
+    keys: paths.map((path) => ({
+      path: `${PREFIX}${path}`,
+      kind: "input",
+      value_type: "f32",
+      default_value: defaults[path],
+    })),
+  };
+}
 
 describe("the empty adaptation", () => {
-  it("declares every control as a rig-prefixed input and wires nothing", () => {
-    const spec = buildEmptyAdaptationSpec(PREFIX);
+  it("declares one input per profile path, wired to nothing", () => {
+    const spec = buildEmptyAdaptationSpec(
+      profileOf([
+        "standard/vizij/expression/happy",
+        "standard/vizij/viseme/aa",
+        "standard/vizij/face/jaw_open",
+      ]),
+    );
 
-    expect(spec.nodes).toHaveLength(40);
+    expect(spec.nodes).toHaveLength(3);
     expect(spec.edges).toStrictEqual([]);
     expect(spec.nodes.every((node) => node.type === "input")).toBe(true);
-
-    const paths = spec.nodes.map((node) => node.params?.path);
-    expect(paths).toContain(`${PREFIX}standard/vizij/expression/happy`);
-    expect(paths).toContain(`${PREFIX}standard/vizij/viseme/aa`);
-    // Node ids must be unique or the graph cannot round-trip through the editor.
-    expect(new Set(spec.nodes.map((node) => node.id)).size).toBe(40);
+    expect(spec.nodes.map((node) => node.params?.path)).toStrictEqual([
+      `${PREFIX}standard/vizij/expression/happy`,
+      `${PREFIX}standard/vizij/viseme/aa`,
+      `${PREFIX}standard/vizij/face/jaw_open`,
+    ]);
   });
 
-  it("rests every control at zero, so an unwired face holds its neutral", () => {
-    const spec = buildEmptyAdaptationSpec(PREFIX);
-    expect(spec.nodes.every((node) => node.params?.value === 0)).toBe(true);
-  });
-
-  it("omits the prefix for a face with no id, matching the runtime", () => {
-    const spec = buildEmptyAdaptationSpec("");
-    expect(spec.nodes[0]?.params?.path).toBe(
-      "standard/vizij/expression/neutral",
+  // Node ids must be unique or the spec cannot round-trip through the editor,
+  // and two namespaces can carry the same leaf name.
+  it("gives every path a unique node id, even across namespaces", () => {
+    const spec = buildEmptyAdaptationSpec(
+      profileOf([
+        "standard/vizij/expression/neutral",
+        "standard/vizij/viseme/neutral",
+      ]),
     );
+    expect(new Set(spec.nodes.map((n) => n.id)).size).toBe(2);
+  });
+
+  it("rests each control at the profile's declared default", () => {
+    const spec = buildEmptyAdaptationSpec(
+      profileOf(
+        ["standard/vizij/left_eye/pos/x", "standard/vizij/viseme/sil"],
+        {
+          "standard/vizij/viseme/sil": { f32: 1 },
+        },
+      ),
+    );
+    const value = (suffix: string) =>
+      spec.nodes.find((n) => n.params?.path?.endsWith(suffix))?.params?.value;
+    expect(value("viseme/sil")).toBe(1);
+    // No declared default means rest at zero, so an unwired face holds neutral.
+    expect(value("left_eye/pos/x")).toBe(0);
+  });
+
+  it("ignores a duplicated path rather than emitting a colliding node", () => {
+    const spec = buildEmptyAdaptationSpec(
+      profileOf([
+        "standard/vizij/expression/happy",
+        "standard/vizij/expression/happy",
+      ]),
+    );
+    expect(spec.nodes).toHaveLength(1);
+  });
+
+  it("is empty for a profile that defines nothing", () => {
+    expect(buildEmptyAdaptationSpec(profileOf([]))).toStrictEqual({
+      nodes: [],
+      edges: [],
+    });
   });
 });

--- a/apps/vizij-authoring/src/utils/faceStandard.test.ts
+++ b/apps/vizij-authoring/src/utils/faceStandard.test.ts
@@ -4,7 +4,7 @@ import { buildEmptyAdaptationSpec } from "./faceStandard";
 
 const PREFIX = "rig/quori_latest/";
 
-/** A profile as `@vizij/runtime` serves it, already rig-prefixed. */
+/** A profile as it is declared on a face, already rig-prefixed. */
 function profileOf(
   paths: string[],
   defaults: Record<string, unknown> = {},

--- a/apps/vizij-authoring/src/utils/faceStandard.ts
+++ b/apps/vizij-authoring/src/utils/faceStandard.ts
@@ -1,0 +1,123 @@
+/**
+ * The Vizij face standard's semantic vocabulary, mirrored for the authoring
+ * app.
+ *
+ * The authoritative source is `vizij-arora-host`'s `standard` module in
+ * vizij-rs (see its `docs/face-standard.md`); `@vizij/runtime` serves the
+ * shipped *profiles* but not the vocabulary itself, so the names live here.
+ * Keep them in step with the Rust constants — `vizij-bundle validate` counts
+ * coverage against that list, so a name that drifts silently stops counting.
+ */
+
+/**
+ * The 25 expression weights, at `standard/vizij/expression/<name>`. The names
+ * are ROS4HRI's `hri_msgs/Expression` vocabulary. The standard prescribes the
+ * name a caller commands, not what the expression looks like — that stays the
+ * face's authored pose.
+ */
+export const EXPRESSION_NAMES = [
+  "neutral",
+  "angry",
+  "sad",
+  "happy",
+  "surprised",
+  "disgusted",
+  "scared",
+  "pleading",
+  "vulnerable",
+  "despaired",
+  "guilty",
+  "disappointed",
+  "embarrassed",
+  "horrified",
+  "skeptical",
+  "annoyed",
+  "furious",
+  "suspicious",
+  "rejected",
+  "bored",
+  "tired",
+  "asleep",
+  "confused",
+  "amazed",
+  "excited",
+] as const;
+
+/**
+ * The 15 viseme weights, at `standard/vizij/viseme/<shape>` — the industry
+ * 15-shape set (Oculus/Meta naming). `sil` is silence, the closed-mouth rest
+ * shape.
+ */
+export const VISEME_SHAPES = [
+  "sil",
+  "PP",
+  "FF",
+  "TH",
+  "DD",
+  "kk",
+  "CH",
+  "SS",
+  "nn",
+  "RR",
+  "aa",
+  "E",
+  "ih",
+  "oh",
+  "ou",
+] as const;
+
+/** The control path of a named expression, unprefixed. */
+export function expressionPath(name: string): string {
+  return `standard/vizij/expression/${name}`;
+}
+
+/** The control path of a viseme shape, unprefixed. */
+export function visemePath(shape: string): string {
+  return `standard/vizij/viseme/${shape}`;
+}
+
+/** A graph spec's node, loosely typed — enough for the shapes built here. */
+interface SpecNode {
+  id: string;
+  type: string;
+  params?: { path?: string; value?: number };
+}
+
+/** The minimal graph-spec shape a bundle entry carries. */
+export interface AdaptationSpec {
+  nodes: SpecNode[];
+  edges: unknown[];
+}
+
+/**
+ * An empty standard-adaptation graph for a face: every semantic control the
+ * standard defines, declared as an `input` node reading this face's
+ * rig-prefixed control path, and nothing wired.
+ *
+ * This is the starting point the author binds — each control gets connected to
+ * the face's own pose weights in the graph editor. Until a control is wired it
+ * reads its path and drives nothing.
+ *
+ * Note that `vizij-bundle validate` measures coverage by the control paths a
+ * face's graphs *listen on*, so an unedited graph already reports the
+ * expression and viseme tiers as fully covered. Coverage says the face speaks
+ * the vocabulary; it does not say the vocabulary moves anything.
+ */
+export function buildEmptyAdaptationSpec(rigPrefix: string): AdaptationSpec {
+  const input = (id: string, path: string): SpecNode => ({
+    id,
+    type: "input",
+    params: { path: `${rigPrefix}${path}`, value: 0 },
+  });
+  return {
+    nodes: [
+      ...EXPRESSION_NAMES.map((name) =>
+        input(`in_expr_${name}`, expressionPath(name)),
+      ),
+      ...VISEME_SHAPES.map((shape) =>
+        input(`in_vis_${shape}`, visemePath(shape)),
+      ),
+    ],
+    edges: [],
+  };
+}

--- a/apps/vizij-authoring/src/utils/faceStandard.ts
+++ b/apps/vizij-authoring/src/utils/faceStandard.ts
@@ -3,9 +3,8 @@
  *
  * A *profile* is a set of paths and their types; an *adaptation* is the mapping
  * that carries a profile's values onto this face's own pose weights. The
- * profile comes from `@vizij/runtime` — the same assets the native bundler
- * embeds — so the vocabulary is never copied into this app. What lives here is
- * only the shape of the graph built from it.
+ * profile is a file the author imported, so the vocabulary is never copied into
+ * this app. What lives here is only the shape of the graph built from it.
  */
 
 import type { VizijBundleProfile } from "@vizij/render";

--- a/apps/vizij-authoring/src/utils/faceStandard.ts
+++ b/apps/vizij-authoring/src/utils/faceStandard.ts
@@ -1,80 +1,14 @@
 /**
- * The Vizij face standard's semantic vocabulary, mirrored for the authoring
- * app.
+ * Building an adaptation from a profile.
  *
- * The authoritative source is `vizij-arora-host`'s `standard` module in
- * vizij-rs (see its `docs/face-standard.md`); `@vizij/runtime` serves the
- * shipped *profiles* but not the vocabulary itself, so the names live here.
- * Keep them in step with the Rust constants — `vizij-bundle validate` counts
- * coverage against that list, so a name that drifts silently stops counting.
+ * A *profile* is a set of paths and their types; an *adaptation* is the mapping
+ * that carries a profile's values onto this face's own pose weights. The
+ * profile comes from `@vizij/runtime` — the same assets the native bundler
+ * embeds — so the vocabulary is never copied into this app. What lives here is
+ * only the shape of the graph built from it.
  */
 
-/**
- * The 25 expression weights, at `standard/vizij/expression/<name>`. The names
- * are ROS4HRI's `hri_msgs/Expression` vocabulary. The standard prescribes the
- * name a caller commands, not what the expression looks like — that stays the
- * face's authored pose.
- */
-export const EXPRESSION_NAMES = [
-  "neutral",
-  "angry",
-  "sad",
-  "happy",
-  "surprised",
-  "disgusted",
-  "scared",
-  "pleading",
-  "vulnerable",
-  "despaired",
-  "guilty",
-  "disappointed",
-  "embarrassed",
-  "horrified",
-  "skeptical",
-  "annoyed",
-  "furious",
-  "suspicious",
-  "rejected",
-  "bored",
-  "tired",
-  "asleep",
-  "confused",
-  "amazed",
-  "excited",
-] as const;
-
-/**
- * The 15 viseme weights, at `standard/vizij/viseme/<shape>` — the industry
- * 15-shape set (Oculus/Meta naming). `sil` is silence, the closed-mouth rest
- * shape.
- */
-export const VISEME_SHAPES = [
-  "sil",
-  "PP",
-  "FF",
-  "TH",
-  "DD",
-  "kk",
-  "CH",
-  "SS",
-  "nn",
-  "RR",
-  "aa",
-  "E",
-  "ih",
-  "oh",
-  "ou",
-] as const;
-
-/** The control path of a named expression, unprefixed. */
-export function expressionPath(name: string): string {
-  return `standard/vizij/expression/${name}`;
-}
-
-/** The control path of a viseme shape, unprefixed. */
-export function visemePath(shape: string): string {
-  return `standard/vizij/viseme/${shape}`;
-}
+import type { VizijBundleProfile } from "@vizij/render";
 
 /** A graph spec's node, loosely typed — enough for the shapes built here. */
 interface SpecNode {
@@ -90,34 +24,58 @@ export interface AdaptationSpec {
 }
 
 /**
- * An empty standard-adaptation graph for a face: every semantic control the
- * standard defines, declared as an `input` node reading this face's
- * rig-prefixed control path, and nothing wired.
+ * A node id derived from a control path, stable and unique per path: the path
+ * with every non-word character folded to `_`. Graph node ids must be unique
+ * or the spec cannot round-trip through the editor, and two profiles can carry
+ * the same leaf name under different namespaces.
+ */
+function nodeIdFor(path: string): string {
+  return `in_${path.replace(/[^\w]+/g, "_").replace(/^_+|_+$/g, "")}`;
+}
+
+/**
+ * An empty adaptation for `profile`: every path the profile defines, declared
+ * as an `input` node, and nothing wired.
  *
  * This is the starting point the author binds — each control gets connected to
  * the face's own pose weights in the graph editor. Until a control is wired it
  * reads its path and drives nothing.
  *
- * Note that `vizij-bundle validate` measures coverage by the control paths a
- * face's graphs *listen on*, so an unedited graph already reports the
- * expression and viseme tiers as fully covered. Coverage says the face speaks
- * the vocabulary; it does not say the vocabulary moves anything.
+ * The profile's paths are used as given, so a profile fetched with this face's
+ * rig prefix produces a graph addressed to this face. Each input rests at the
+ * profile's declared default, falling back to zero, so an unwired face holds
+ * its neutral.
+ *
+ * Note that `vizij-bundle validate` currently measures coverage by the control
+ * paths a face's graphs *listen on*, so an unedited graph already reports its
+ * tiers as covered. Coverage says the face speaks the vocabulary; it does not
+ * say the vocabulary moves anything — the per-profile reachability check is
+ * what closes that gap.
  */
-export function buildEmptyAdaptationSpec(rigPrefix: string): AdaptationSpec {
-  const input = (id: string, path: string): SpecNode => ({
-    id,
-    type: "input",
-    params: { path: `${rigPrefix}${path}`, value: 0 },
-  });
-  return {
-    nodes: [
-      ...EXPRESSION_NAMES.map((name) =>
-        input(`in_expr_${name}`, expressionPath(name)),
-      ),
-      ...VISEME_SHAPES.map((shape) =>
-        input(`in_vis_${shape}`, visemePath(shape)),
-      ),
-    ],
-    edges: [],
-  };
+export function buildEmptyAdaptationSpec(
+  profile: VizijBundleProfile,
+): AdaptationSpec {
+  const seen = new Set<string>();
+  const nodes: SpecNode[] = [];
+  for (const key of profile.keys) {
+    if (seen.has(key.path)) {
+      continue;
+    }
+    seen.add(key.path);
+    // `default_value` is arora's tagged form (`{ f32: 0 }`); take the number
+    // out of whichever tag it carries, and rest at zero when it carries none.
+    const tagged = key.default_value as Record<string, unknown> | undefined;
+    const declared = tagged
+      ? Object.values(tagged).find((v) => typeof v === "number")
+      : undefined;
+    nodes.push({
+      id: nodeIdFor(key.path),
+      type: "input",
+      params: {
+        path: key.path,
+        value: typeof declared === "number" ? declared : 0,
+      },
+    });
+  }
+  return { nodes, edges: [] };
 }

--- a/apps/vizij-authoring/vite.config.ts
+++ b/apps/vizij-authoring/vite.config.ts
@@ -1,4 +1,5 @@
 import { fileURLToPath } from "node:url";
+import fs from "node:fs";
 import path from "node:path";
 import { createRequire } from "node:module";
 import react from "@vitejs/plugin-react-swc";
@@ -11,6 +12,39 @@ const workspaceRoot = path.resolve(__dirname, "..", "..");
 const require = createRequire(import.meta.url);
 const threeEntry = require.resolve("three");
 const threePath = path.resolve(path.dirname(threeEntry), "..");
+/**
+ * Where the linked `@vizij/*` wasm packages actually live on disk.
+ *
+ * `pnpm run wasm:link` symlinks them at a sibling vizij-rs checkout, and the
+ * dev server has to be allowed to serve the `.wasm` behind that symlink or it
+ * answers 403 and the runtime fails to init. The relative allow-entry below
+ * covers a normal clone (`vizij-web/` and `vizij-rs/` side by side) but not a
+ * git worktree, which sits three directories deeper — so resolve the real
+ * paths instead of assuming a layout.
+ */
+const linkedVizijDirs = (() => {
+  const scopeDir = path.resolve(workspaceRoot, "node_modules/@vizij");
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(scopeDir);
+  } catch {
+    return [];
+  }
+  const roots = new Set<string>();
+  for (const entry of entries) {
+    try {
+      const real = fs.realpathSync(path.join(scopeDir, entry));
+      // Only somewhere outside the workspace needs allow-listing.
+      if (!real.startsWith(workspaceRoot)) {
+        roots.add(path.dirname(path.dirname(real)));
+      }
+    } catch {
+      // A broken link is the linker's problem, not the dev server's.
+    }
+  }
+  return [...roots];
+})();
+
 const reactPath = path.resolve(__dirname, "node_modules/react");
 const reactDomPath = path.resolve(__dirname, "node_modules/react-dom");
 export default defineConfig(({ mode }) => {
@@ -61,7 +95,7 @@ export default defineConfig(({ mode }) => {
     },
     server: {
       fs: {
-        allow: ["../../../"],
+        allow: ["../../../", ...linkedVizijDirs],
       },
       watch: {
         ignored: [

--- a/packages/@vizij/render/src/types/vizij-bundle.ts
+++ b/packages/@vizij/render/src/types/vizij-bundle.ts
@@ -20,6 +20,38 @@ export interface VizijBundleGraphMetadata {
   [key: string]: unknown;
 }
 
+/**
+ * One path in a profile, with its type and constraints — arora's `KeyInfo`
+ * shape, so a profile round-trips through the descriptor the runtime already
+ * speaks.
+ */
+export interface VizijProfileKey {
+  path: string;
+  kind?: string;
+  value_type?: string;
+  min?: number;
+  max?: number;
+  default_value?: unknown;
+  /** Standard metadata: the FACS action unit, ARKit blendshape, and tier. */
+  meta?: { au?: number; arkit?: string; tier?: string };
+}
+
+/**
+ * A profile the face declares it speaks: a set of paths and their types — the
+ * vocabulary its graphs are authored against.
+ *
+ * A profile is names and types, not a graph, so it sits beside `graphs` rather
+ * than inside it. Declaring it on the asset is what lets a reader know which
+ * vocabulary to hold the face to.
+ */
+export interface VizijBundleProfile {
+  id: string;
+  version: string;
+  title?: string;
+  description?: string;
+  keys: VizijProfileKey[];
+}
+
 export interface VizijBundleGraphEntry {
   id: VizijGraphId;
   kind: VizijBundleGraphKind;
@@ -126,6 +158,8 @@ export interface VizijBundleExtension {
   version: VizijBundleVersion;
   exportedAt?: string;
   graphs?: VizijBundleGraphEntry[];
+  /** The profiles this face declares it speaks (see {@link VizijBundleProfile}). */
+  profiles?: VizijBundleProfile[];
   poses?: VizijBundlePoseSection | null;
   animations?: VizijBundleAnimationEntry[];
   /**

--- a/scripts/add-standard-adaptation.mjs
+++ b/scripts/add-standard-adaptation.mjs
@@ -1,0 +1,335 @@
+#!/usr/bin/env node
+/**
+ * Graft a `standard-adaptation` graph into a face GLB's `VIZIJ_bundle`.
+ *
+ * A face GLB exported by the authoring app carries a `rig` graph and a
+ * `pose-driver` graph, so it renders and it poses — but nothing in it listens
+ * on the Vizij face standard's `standard/vizij/*` control paths. That last link
+ * is the `standard-adaptation` graph: the asset-side mapping from the standard
+ * vocabulary onto *this* face's own pose weights. Without it a ROS4HRI command
+ * travels as far as `standard/vizij/expression/happy` and stops — the profile
+ * writes the control, and no graph reads it.
+ *
+ * This is the Node peer of `vizij-bundle add-graph --kind standard-adaptation`
+ * (vizij-rs, crates/tools/vizij-bundle). It discovers the face's pose weights
+ * from its pose-driver graph, matches them by name against the canonical
+ * mapping below, and writes the graph back into the GLB.
+ *
+ * The mapping mirrors the shipped reference adaptation,
+ * vizij-rs `fixtures/faces/quori/standard-adaptation.json`: each face pose sums
+ * the standard controls that should drive it, clamped to [0, 1].
+ *
+ *   node scripts/add-standard-adaptation.mjs <face.glb> [-o <out.glb>] [--dry-run]
+ *
+ * Re-running replaces the graph in place (it grafts under a stable id), so an
+ * adapted GLB can be re-adapted after a re-export without accumulating copies.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { basename } from "node:path";
+
+/** Face pose (canonical leaf name) ← the standard controls that drive it. */
+const MAPPING = {
+  // Expressions: `standard/vizij/expression/<name>`, the ROS4HRI vocabulary
+  // of 25 folded onto the seven poses these faces actually author.
+  anger: ["angry", "furious", "annoyed", "disgusted"],
+  sad: [
+    "sad",
+    "despaired",
+    "disappointed",
+    "guilty",
+    "rejected",
+    "vulnerable",
+    "embarrassed",
+    "pleading",
+  ],
+  concerned: ["scared", "horrified", "suspicious", "skeptical", "confused"],
+  surprise: ["surprised", "amazed"],
+  happy: ["happy", "excited"],
+  sleepy: ["bored", "tired", "asleep"],
+  neutral: ["neutral"],
+};
+
+/** Face pose (canonical leaf name) ← the standard viseme shapes. */
+const VISEME_MAPPING = {
+  p: ["PP"],
+  f: ["FF"],
+  t_2: ["TH"],
+  t: ["DD", "nn"],
+  k: ["kk"],
+  s: ["CH", "SS"],
+  r: ["RR"],
+  a: ["aa"],
+  e: ["E"],
+  i: ["ih"],
+  o: ["oh"],
+  u: ["ou"],
+};
+
+const JSON_CHUNK = 0x4e4f534a;
+const GLB_MAGIC = 0x46546c67;
+
+/** Split a GLB into its JSON document and its trailing chunks, verbatim. */
+function parseGlb(buf) {
+  if (buf.readUInt32LE(0) !== GLB_MAGIC) {
+    throw new Error("not a GLB (bad magic)");
+  }
+  const total = buf.readUInt32LE(8);
+  const chunks = [];
+  let json = null;
+  let offset = 12;
+  while (offset < total) {
+    const length = buf.readUInt32LE(offset);
+    const type = buf.readUInt32LE(offset + 4);
+    const data = buf.subarray(offset + 8, offset + 8 + length);
+    if (type === JSON_CHUNK && json === null) {
+      json = JSON.parse(data.toString("utf8"));
+      chunks.push({ type, data: null });
+    } else {
+      chunks.push({ type, data });
+    }
+    offset += 8 + length;
+  }
+  if (json === null) {
+    throw new Error("the GLB carries no JSON chunk");
+  }
+  return { json, chunks };
+}
+
+/** Re-encode a GLB, the JSON chunk rewritten and every other chunk verbatim. */
+function writeGlb(json, chunks) {
+  const encoded = chunks.map((chunk) => {
+    const data =
+      chunk.data === null
+        ? Buffer.from(JSON.stringify(json), "utf8")
+        : chunk.data;
+    // glTF requires 4-byte-aligned chunks: JSON pads with spaces, binary with
+    // zeroes, so a padded chunk stays valid as its own content type.
+    const padding = (4 - (data.length % 4)) % 4;
+    const pad = Buffer.alloc(padding, chunk.type === JSON_CHUNK ? 0x20 : 0x00);
+    const header = Buffer.alloc(8);
+    header.writeUInt32LE(data.length + padding, 0);
+    header.writeUInt32LE(chunk.type, 4);
+    return Buffer.concat([header, data, pad]);
+  });
+  const body = Buffer.concat(encoded);
+  const header = Buffer.alloc(12);
+  header.writeUInt32LE(GLB_MAGIC, 0);
+  header.writeUInt32LE(2, 4);
+  header.writeUInt32LE(12 + body.length, 8);
+  return Buffer.concat([header, body]);
+}
+
+/**
+ * The `VIZIJ_bundle` object: on a node's `extensions`, else the document's —
+ * the same two places `vizij-bundle` looks, in the same order.
+ */
+function findBundle(json) {
+  for (const node of json.nodes ?? []) {
+    const bundle = node.extensions?.VIZIJ_bundle;
+    if (bundle) {
+      return bundle;
+    }
+  }
+  const bundle = json.extensions?.VIZIJ_bundle;
+  if (bundle) {
+    return bundle;
+  }
+  throw new Error("the GLB carries no VIZIJ_bundle");
+}
+
+/**
+ * The canonical leaf name of a pose weight path: the pose's own name, stripped
+ * of the container, the `pose_` prefix, the `.weight` suffix, and the `d_…_d`
+ * wrapping some exporters add. `rig/quori/poses/pose_d_happy_d.weight` → `happy`.
+ */
+function poseLeaf(path) {
+  let leaf = path.split("/").pop() ?? "";
+  leaf = leaf.replace(/\.weight$/, "").replace(/^pose_/, "");
+  leaf = leaf.replace(/^d_/, "").replace(/_d$/, "");
+  // The exporters disagree on the adjective; the pose is the same one.
+  return leaf === "angry" ? "anger" : leaf;
+}
+
+/** Every store path the bundle's pose-driver graphs read. */
+function posePaths(bundle) {
+  const paths = [];
+  for (const graph of bundle.graphs ?? []) {
+    if (graph.kind !== "pose-driver") {
+      continue;
+    }
+    for (const node of graph.spec?.nodes ?? []) {
+      if (node.type === "input" && typeof node.params?.path === "string") {
+        paths.push(node.params.path);
+      }
+    }
+  }
+  return [...new Set(paths)];
+}
+
+/**
+ * Build the adaptation graph: for each of the face's poses that the canonical
+ * mapping covers, sum its standard controls and clamp the total to [0, 1]
+ * (several expressions fold onto one pose, so the sum can exceed 1).
+ */
+function buildSpec(rigPrefix, poses) {
+  const nodes = [
+    { id: "c0", type: "constant", params: { value: 0.0 } },
+    { id: "c1", type: "constant", params: { value: 1.0 } },
+  ];
+  const edges = [];
+  const inputs = new Map();
+  const mapped = [];
+
+  /** One `input` node per standard control, shared across the poses it drives. */
+  const controlNode = (kind, name) => {
+    const key = `${kind}/${name}`;
+    if (!inputs.has(key)) {
+      const id = `in_${kind}_${name}`;
+      nodes.push({
+        id,
+        type: "input",
+        params: {
+          path: `${rigPrefix}standard/vizij/${kind}/${name}`,
+          value: 0.0,
+        },
+      });
+      inputs.set(key, id);
+    }
+    return inputs.get(key);
+  };
+
+  for (const [kind, mapping] of [
+    ["expression", MAPPING],
+    ["viseme", VISEME_MAPPING],
+  ]) {
+    for (const [leaf, controls] of Object.entries(mapping)) {
+      const path = poses.get(leaf);
+      if (!path) {
+        continue;
+      }
+      const sum = `sum_${leaf}`;
+      const clamp = `clamp_${leaf}`;
+      const out = `out_${leaf}`;
+      nodes.push({ id: sum, type: "add", params: {} });
+      nodes.push({ id: clamp, type: "clamp", params: {} });
+      nodes.push({ id: out, type: "output", params: { path } });
+      controls.forEach((control, i) => {
+        edges.push({
+          from: { node_id: controlNode(kind, control) },
+          to: { node_id: sum, input: `operand_${i}` },
+        });
+      });
+      edges.push({
+        from: { node_id: sum },
+        to: { node_id: clamp, input: "in" },
+      });
+      edges.push({
+        from: { node_id: "c0" },
+        to: { node_id: clamp, input: "min" },
+      });
+      edges.push({
+        from: { node_id: "c1" },
+        to: { node_id: clamp, input: "max" },
+      });
+      edges.push({
+        from: { node_id: clamp },
+        to: { node_id: out, input: "in" },
+      });
+      mapped.push({ leaf, kind, path, controls });
+    }
+  }
+
+  // `sil` is silence — the closed-mouth rest shape, which is what the face
+  // already does when no viseme drives it. It gets an input node wired to
+  // nothing: the face listens on the shape (so coverage counts it, and the
+  // viseme tier completes) without a pose to push. The shipped reference
+  // adaptation declares it the same way.
+  if (mapped.some((m) => m.kind === "viseme")) {
+    controlNode("viseme", "sil");
+  }
+
+  return { spec: { nodes, edges }, mapped };
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  let dryRun = false;
+  let input = null;
+  let output = null;
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--dry-run") {
+      dryRun = true;
+    } else if (arg === "-o" || arg === "--out") {
+      i += 1;
+      output = argv[i];
+    } else if (!input) {
+      input = arg;
+    }
+  }
+  if (!input) {
+    console.error(
+      "usage: node scripts/add-standard-adaptation.mjs <face.glb> [-o <out.glb>] [--dry-run]",
+    );
+    process.exit(2);
+  }
+  output = output ?? input;
+
+  const { json, chunks } = parseGlb(readFileSync(input));
+  const bundle = findBundle(json);
+  const faceId = bundle.metadata?.faceId;
+  if (!faceId) {
+    throw new Error(
+      "the bundle declares no metadata.faceId, so it has no rig prefix",
+    );
+  }
+  const rigPrefix = `rig/${faceId}/`;
+
+  const paths = posePaths(bundle);
+  if (paths.length === 0) {
+    throw new Error("the bundle carries no pose-driver graph to adapt onto");
+  }
+  const poses = new Map(paths.map((p) => [poseLeaf(p), p]));
+  const { spec, mapped } = buildSpec(rigPrefix, poses);
+
+  if (mapped.length === 0) {
+    throw new Error(
+      `none of this face's poses match the canonical mapping: ${[...poses.keys()].join(", ")}`,
+    );
+  }
+
+  const id = `${faceId}_standard_adaptation`;
+  const entry = { kind: "standard-adaptation", id, spec };
+  bundle.graphs = bundle.graphs ?? [];
+  const existing = bundle.graphs.findIndex((g) => g.id === id);
+  if (existing === -1) {
+    bundle.graphs.push(entry);
+  } else {
+    bundle.graphs[existing] = entry;
+  }
+
+  const covered = new Set(mapped.map((m) => m.leaf));
+  const unmapped = [...poses.keys()].filter((leaf) => !covered.has(leaf));
+
+  console.log(`${basename(input)} — face ${faceId} (rig prefix ${rigPrefix})`);
+  console.log(`  ${mapped.length} poses adapted, ${spec.nodes.length} nodes:`);
+  for (const m of mapped) {
+    console.log(
+      `    ${m.path.slice(rigPrefix.length).padEnd(44)} <- ${m.kind}/${m.controls.join(", ")}`,
+    );
+  }
+  if (unmapped.length > 0) {
+    console.log(
+      `  ${unmapped.length} poses left unmapped: ${unmapped.join(", ")}`,
+    );
+  }
+  if (dryRun) {
+    console.log("  --dry-run: nothing written");
+    return;
+  }
+  writeFileSync(output, writeGlb(json, chunks));
+  console.log(`  wrote ${output}`);
+}
+
+main();


### PR DESCRIPTION
> **Blocked on [vizij-rs#102](https://github.com/vizij-ai/vizij-rs/pull/102).** The import dialog reads the profile registry from `@vizij/runtime@2.5.0`, which #102's changeset produces. `apps/vizij-authoring/package.json` declares `^2.5.0`, so `pnpm install --frozen-lockfile` fails until that publishes — deliberately, rather than passing on a local link and breaking on a clean install. Draft until then.
>
> To run it now: build the wasm in vizij-rs, then `node scripts/wasm-links.mjs link --pkgs "runtime" --vizij-rs ../vizij-rs`.

## The problem

A face GLB carried a rig graph and a pose-driver graph, so it rendered and it posed — but nothing in it listened on the face standard's `standard/vizij/*` controls. A ROS4HRI command reached `standard/vizij/expression/happy = 1.0` and stopped. No face in this repo had the graph that closes that gap.

Verified against the native device: unadapted, the control reaches 1.0 and **no pose weight moves at all**; adapted, `poses/pose_d_happy_d.weight` and `poses/pose_a.weight` both reach 1.0, and `vizij-bundle validate` goes L0 → L2.

## What this adds

**Import a profile.** A *profile* is a set of paths and their types — the vocabulary a face's graphs are authored against. File → Profiles → *Import Profile…* opens a searchable dialog over the shipped registry (search covers id, title and description, since someone hunting a face vocabulary is as likely to type "viseme" or "ARKit" as the profile's name), with *Import from JSON file…* in the same dialog for a vocabulary outside the registry. The registry is expected to carry tens of entries, so it is a dialog rather than a menu.

**The import creates standard rig inputs.** This is the part that took a few tries to get right. Profiles were first stored only in `bundle.profiles`, a sidecar array no panel reads — so the only way to surface one would have been to teach a panel to go looking for profiles, which is the sign it was in the wrong place. A profile *is* a set of standard inputs, so importing one now creates ordinary ones through the same entry point the "Add Driver" flow uses. They appear in Input Controls and group in Std Feature Spaces because they **are** inputs, not because a panel learned anything.

`bundle.profiles` stays, as what it should always have been: the record of which vocabulary and version the face declares, for the coverage check and for round-tripping the file.

**Grouped by namespace, named for the profile.** Std Feature Spaces decided whether a path had a namespace by counting segments — 4 or more after `standard` meant the first was one. That split a single profile across two groups purely by path depth:

```
/standard/vizij/left_eye/pos/x     -> namespace "vizij"
/standard/vizij/expression/happy   -> namespace ""      (channel "vizij")
```

A declared profile settles it without guessing, and the group is labelled with the profile's name. Paths outside any declared namespace keep the old heuristic, so a legacy face is undisturbed.

**A disconnect marker.** A profile's controls arrive unconnected — that is the point — but an unconnected control was indistinguishable from a working one. `derivedChildren` already lists every input naming this one as its source, so an empty list is precisely "nothing reads this"; those rows now show an amber unplug icon. Not profile-specific: a rig input whose binding was removed lands in the same state and now says so.

**File → Standard Adaptation** builds the mapping from a profile the face declares, and refuses with a pointer to the import when none is. Because `specToEditorState` turns every `input` node into a `customInputPath`, the profile's paths land in the graph editor's input tree — binding a control to a pose is then an ordinary edge between two listed sides.

**`scripts/add-standard-adaptation.mjs`** grafts an adaptation into faces already exported — the Node peer of `vizij-bundle add-graph --kind standard-adaptation`.

## Two fixes that fell out

- **Linked wasm 403'd from a worktree.** `fs.allow: ["../../../"]` assumed `vizij-web/` and `vizij-rs/` were siblings; a git worktree sits three directories deeper, so the path landed inside `.claude/worktrees/`. Now it reads the real path behind each `node_modules/@vizij/*` symlink instead of assuming a layout.
- **The app carried its own copy of the standard's vocabulary.** The 25 expression names, 15 viseme shapes and path helpers are gone; `faceStandard.ts` is now only the shape of the graph built from a profile.

## Verified

- End to end through the native tooling: build an adaptation from a profile's 81 keys (81 unique node ids), write both into a GLB, and `vizij-bundle inspect` reads back `declared profiles: [('vizij-face', 'v1', 81)]` alongside the `standard-adaptation` graph.
- Live in the running app: importing `vizij-face` takes Input Controls from **182 → 257**. Exactly 75 of its 81 paths are new — the rig already listens on the 6 standard gaze controls, and the de-dupe guard skips them. That guard matters: the underlying entry point de-duplicates by *id* and would otherwise mint `happy_2` on a re-import.
- The search dialog filtering, and the dev server booting clean with no hand-patched config.
- 63 tests across 11 files; typecheck and lint clean for the changed files.

**Not verified by eye:** the group label reading "Vizij face standard" rather than "Vizij", and the disconnect icon rendering. Both are covered by unit tests and typecheck, but the face reload cycle kept eating the verification window — worth a look during review.

## Known gap

`vizij-bundle validate` counts the control paths a face *listens on*, so an adaptation with everything declared and nothing wired still reports L2 — this PR can produce exactly that state. The fix is the per-profile reachability check ("is the profile loaded **and** connected downstream?"), which now has both inputs it needs. Not in scope here, but it should land before many faces are authored against the current signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)