### PR TITLE
fix(standalone): ROS 2 inputs are visible and the catalog rebuild is sound

### DIFF
--- a/apps/vizij-standalone/README.md
+++ b/apps/vizij-standalone/README.md
@@ -138,12 +138,38 @@ the standalone joins the ROS graph as a ROS4HRI face renderer:
   reset, priorities, standard error codes) and the device's described task-run
   methods (e.g. `say`) under `/{namespace}/actions/...`
 - **data topics** — every key under `/{namespace}/keys/...`: the device
-  publishes each changed key and subscribes to the input keys (declared up
-  front from the key catalog; a changed catalog rebuilds the run)
+  publishes each changed key and subscribes to the **input** keys the webview
+  advertised (declared up front from the key catalog; a changed catalog
+  rebuilds the run). Advertised keys are `f64`, so their input topics are
+  `std_msgs/msg/Float64` — `ros2 topic info -v <topic>` shows each topic's
+  type and the bridge's subscription; a publisher of another type
+  (e.g. `Float32`) never matches
 - the `reset` / `speak` / `mute` / `transport` app methods stay on the
   WebSocket (and Studio) bridge — they are WS-registry methods, not device
   methods
 - the namespace defaults to `vizij`; the DDS domain defaults to `0`
+- a `ros2-zenoh` build reaches the rmw_zenoh router through the Zenoh session
+  config, e.g. `ZENOH_CONFIG_OVERRIDE='mode="client";connect/endpoints=["tcp/localhost:7447"]'`
+
+### Which keys a remote write actually moves
+
+A key's value is what its **last writer in the step** left there, so pick
+keys nobody else owns:
+
+- keys the device's **ROS4HRI profile** writes every step — the
+  `standard/vizij/*` expressions, gaze, lids, visemes, muscle tier — cannot be
+  driven directly; drive them through the ROS4HRI topics
+  (`/robot_face/expression`, `/robot_face/look_at`, …) that feed the profile;
+- keys the face's **autoplaying program** writes every frame (on the reference
+  Quori face: the `standard/vizij/mouth|*_eye*|*_brow*|*_eyelid*` controls)
+  are the program's outputs; drive its **inputs** instead
+  (`standard/vmotion/idle/*`, `speech/speaking`, `speech/user_speaking`,
+  `speech/thinking`) — `vizij-bundle unpack face.glb` lists every graph's
+  output paths;
+- `propsrig/*` are the rig's computed actuation values, not inputs.
+
+A key nobody drives — a face input control the program leaves alone — takes
+a remote write and holds it.
 
 Relevant files:
 
@@ -523,7 +549,7 @@ WebSocket/manual panel checks:
 - call `reset` from the panel or `wscat`
 - if a bundle contains transport items, verify the Transport tab can list, play, pause, and stop them
 
-ROS2 check (topics and the served actions):
+ROS2 check (topics and the served actions; note the `Float64`):
 
 ```bash
 # with the app running (default `ros2` feature), from src-tauri/:

--- a/apps/vizij-standalone/src-tauri/src/lib.rs
+++ b/apps/vizij-standalone/src-tauri/src/lib.rs
@@ -34,9 +34,13 @@ struct AppState {
     /// registry (advertised keys + methods) is updated live; the serve loop is
     /// started/stopped under `cancel_token`.
     ws_server: Arc<AroraWSServer>,
-    /// Governs the WS serve loop and the WS bridge pump (the start/stop lifecycle).
+    /// Governs the WS serve loop and the device run (the start/stop lifecycle).
     /// `Some` iff the host is running.
     cancel_token: StdMutex<Option<CancellationToken>>,
+    /// The device thread of the running host, joined on stop so the arora —
+    /// with its WS bridge and ROS 2 participant — is fully gone before a
+    /// rebuild binds and joins the graph again.
+    device_thread: StdMutex<Option<std::thread::JoinHandle<()>>>,
     #[cfg(feature = "ros2")]
     ros2_domain_id: u16,
     #[cfg(feature = "ros2")]
@@ -591,11 +595,23 @@ async fn start_host(app: &AppHandle, emit_started: bool) -> Result<(), String> {
     // before the serve loop, which snapshots those handlers once at startup.
     let ws_bridge = WsBridge::new(ws_server.clone()).await;
 
-    let listener = match ws_server.bind().await {
-        Ok(listener) => listener,
-        Err(e) => {
-            *app.state::<AppState>().cancel_token.lock().unwrap() = None;
-            return Err(e);
+    // The previous serve loop releases the port on its next poll after a stop;
+    // a rebuild that follows a stop immediately retries the bind briefly.
+    let listener = {
+        let mut attempt = 0;
+        loop {
+            match ws_server.bind().await {
+                Ok(listener) => break listener,
+                Err(e) if attempt < 20 => {
+                    attempt += 1;
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                    log::debug!("WS bind retry {attempt}: {e}");
+                }
+                Err(e) => {
+                    *app.state::<AppState>().cancel_token.lock().unwrap() = None;
+                    return Err(e);
+                }
+            }
         }
     };
 
@@ -628,7 +644,7 @@ async fn start_host(app: &AppHandle, emit_started: bool) -> Result<(), String> {
             (state.ros2_namespace.clone(), state.ros2_domain_id)
         };
         let device_cancel = cancel.child_token();
-        std::thread::Builder::new()
+        let device_thread = std::thread::Builder::new()
             .name("arora-device".into())
             .spawn(move || {
                 let rt = match tokio::runtime::Builder::new_multi_thread()
@@ -656,13 +672,31 @@ async fn start_host(app: &AppHandle, emit_started: bool) -> Result<(), String> {
                         // against this device's described methods at startup.
                         let mut config = Ros2BridgeConfig::new(namespace, domain_id)
                             .with_profile(ExposureProfile::ros4hri());
+                        let mut declared = 0usize;
                         for key in keys {
                             // Only input keys accept inbound commands (become
                             // subscribed topics); outputs publish on demand.
                             if key.kind.as_deref() == Some("input") {
                                 let value_type = key.value_type.clone().unwrap_or(Type::F64);
                                 config = config.with_input(key.path.clone(), value_type);
+                                declared += 1;
                             }
+                        }
+                        // The webview advertises its keys as f64: the input
+                        // topics subscribe std_msgs/Float64 (`ros2 topic info -v`
+                        // shows each topic's type).
+                        if declared == 0 {
+                            log::warn!(
+                                "ROS 2: no input topics yet — the webview has not advertised \
+                                 its key catalog; the run rebuilds once it does"
+                            );
+                        } else {
+                            log::info!(
+                                "ROS 2: {declared} input keys subscribed under /{}/keys/<path> \
+                                 (f64 keys as std_msgs/Float64), plus the ROS4HRI typed topics \
+                                 and the /skill/look_at action",
+                                config.namespace
+                            );
                         }
                         builder = builder.with_bridge(Box::new(Ros2Bridge::new(config).await));
                     }
@@ -681,6 +715,7 @@ async fn start_host(app: &AppHandle, emit_started: bool) -> Result<(), String> {
                 });
             })
             .map_err(|e| format!("failed to spawn the device thread: {e}"))?;
+        *app.state::<AppState>().device_thread.lock().unwrap() = Some(device_thread);
     }
 
     if emit_started {
@@ -693,15 +728,23 @@ async fn start_host(app: &AppHandle, emit_started: bool) -> Result<(), String> {
 
 /// Stop the bridge host: cancel the WS serve loop + all pumps.
 async fn stop_host(app: &AppHandle) -> Result<(), String> {
-    let state = app.state::<AppState>();
-    let token = state.cancel_token.lock().unwrap().take();
-    if let Some(token) = token {
-        token.cancel();
-        info!("Bridge host stop requested");
-        Ok(())
-    } else {
-        Err("Connection servers are not running".to_string())
+    let (token, device_thread) = {
+        let state = app.state::<AppState>();
+        let token = state.cancel_token.lock().unwrap().take();
+        let device_thread = state.device_thread.lock().unwrap().take();
+        (token, device_thread)
+    };
+    let Some(token) = token else {
+        return Err("Connection servers are not running".to_string());
+    };
+    token.cancel();
+    info!("Bridge host stop requested");
+    // Wait for the device to be gone — its arora, WS bridge, and ROS 2
+    // participant drop with the thread — so a rebuild starts from nothing.
+    if let Some(handle) = device_thread {
+        let _ = tokio::task::spawn_blocking(move || handle.join()).await;
     }
+    Ok(())
 }
 
 // =============================================================================
@@ -1577,6 +1620,7 @@ pub fn run() {
                 store: store.clone(),
                 ws_server,
                 cancel_token: StdMutex::new(None),
+                device_thread: StdMutex::new(None),
                 #[cfg(feature = "ros2")]
                 ros2_domain_id: cli.ros2_domain_id,
                 #[cfg(feature = "ros2")]


### PR DESCRIPTION
**Review of the 'publishing on the keys does nothing' report**, verified with the real `ros2` CLI over **rmw_zenoh** (Jazzy in Docker, `rmw_zenohd` router, the bridge as a zenoh client):

- The bridge's subscriptions ARE visible and typed: `ros2 topic info -v /vizij/keys/…` → `Type: std_msgs/msg/Float64`, `Subscription count: 1`, node `arora_bridge`. The webview advertises every key as `f64`, so the standalone subscribes **Float64**. The colleague published **Float32** → rmw refuses the publisher (`publisher's context is invalid`) and nothing arrives; the same publish as Float64 landed 3/3. That is the failure.
- Even with the right type, two families of keys are rewritten every step and cannot be driven directly: the ones the device's **ROS4HRI profile** outputs (`standard/vizij/*` expressions/gaze/lids/visemes/muscles → drive them through `/robot_face/*`), and the ones the face's **autoplaying program** outputs (on the reference Quori: mouth/eyes/brows/lids standard controls → drive its inputs, `standard/vmotion/idle/*`, `speech/*`). `propsrig/*` are computed rig outputs. arora's step order makes this deterministic (bridge readings apply, then the behavior is the frame's last writer).

**Code**: the device build logs the subscribed inputs + types and warns when the catalog is empty (the setup-time device has no inputs until the webview advertises); the catalog rebuild is made sound — `stop_host` joins the device thread so the arora/WS bridge/ROS participant are gone, and the rebind retries briefly while the previous serve loop releases the port. **Docs**: the ROS 2 section explains the Float64 types, `ros2 topic info -v`, the ownership rules, and the zenoh router env.

Green: default + `ros2` configs, tests, clippy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)